### PR TITLE
add option to use measured or remaining weight (resolves #63)

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -148,7 +148,7 @@
       "archived": "Archived"
     },
     "fields_help": {
-      "weight_to_use": "Select what weight value to enter. Measured weight is only avalable if the spool weight is set for the selected filament",
+      "weight_to_use": "Select what weight value to enter. Measured weight is only available if the spool weight is set for the selected filament",
       "used_weight": "How much filament has been used from the spool. A new spool should have 0g used.",
       "remaining_weight": "How much filament is left on the spool. For a new spool this should match the spool weight.",
       "measured_weight": "How much the filament and spool weigh.",

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -133,8 +133,10 @@
       "filament_name": "Filament",
       "filament": "Filament",
       "material": "Material",
+      "weight_to_use": "Weight",
       "used_weight": "Used Weight",
       "remaining_weight": "Remaining Weight",
+      "measured_weight": "Measured Weight",
       "used_length": "Used Length",
       "remaining_length": "Remaining Length",
       "location": "Location",
@@ -146,7 +148,10 @@
       "archived": "Archived"
     },
     "fields_help": {
+      "weight_to_use": "Select what weight value to enter. Measured weight is only avalable if the spool weight is set for the selected filament",
       "used_weight": "How much filament has been used from the spool. A new spool should have 0g used.",
+      "remaining_weight": "How much filament is left on the spool. For a new spool this should match the spool weight.",
+      "measured_weight": "How much the filament and spool weigh.",
       "location": "Where the spool is located if you have multiple locations where you store your spools.",
       "lot_nr": "Manufacturer's lot number. Can be used to ensure a print has consistent color if multiple spools are used."
     },

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { IResourceComponentsProps, useTranslate } from "@refinedev/core";
 import { Create, useForm, useSelect } from "@refinedev/antd";
-import { Form, Input, DatePicker, Select, InputNumber } from "antd";
+import { Form, Input, DatePicker, Select, InputNumber, Radio } from "antd";
 import dayjs from "dayjs";
 import TextArea from "antd/es/input/TextArea";
 import { IFilament } from "../filaments/model";
@@ -15,7 +15,7 @@ interface CreateOrCloneProps {
 export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps> = (props) => {
   const t = useTranslate();
 
-  const { formProps, saveButtonProps, formLoading } = useForm<ISpool>();
+  const { form, formProps, saveButtonProps, formLoading } = useForm<ISpool>();
 
   if (props.mode === "clone" && formProps.initialValues) {
     // Clear out the values that we don't want to clone
@@ -49,9 +49,120 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
     return {
       label: label,
       value: item.id,
+	  weight: item.weight,
+	  spool_weight: item.spool_weight
     };
   });
   filamentOptions?.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
+
+  const selected_filament = Form.useWatch('filament_id', form);
+  const weight_to_use = Form.useWatch('weight_to_use', form);
+  const used_weight = Form.useWatch('used_weight', form);
+  const remaining_weight = Form.useWatch('remaining_weight', form);
+  const measured_weight = Form.useWatch('measured_weight', form);
+
+  const handle_weight = () => {
+	  if (selected_filament)
+	  {
+		  let filament_weight = filamentOptions.find(obj => {return obj.value === selected_filament}).weight;
+		  let spool_weight = filamentOptions.find(obj => {return obj.value === selected_filament}).spool_weight || 0;
+		  if (weight_to_use == 1)
+		  {
+              form.setFieldsValue(
+			  {
+				  remaining_weight: filament_weight - (used_weight || 0),
+				  measured_weight: filament_weight - (used_weight || 0) + spool_weight
+			  });
+			  return [true, false, false];
+		  }
+		  else if (weight_to_use == 2)
+		  {
+			  form.setFieldsValue(
+			  {
+				  used_weight: filament_weight - (remaining_weight || 0),
+				  measured_weight: (remaining_weight || 0) + spool_weight
+			  });
+			  return [false, true, false];
+		  }
+		  else if (weight_to_use == 3)
+		  {
+			  form.setFieldsValue(
+			  {
+				  used_weight: filament_weight - ((measured_weight || 0) - spool_weight),
+				  remaining_weight: (measured_weight || 0) - spool_weight
+			  });
+			  return [false, false, true];
+		  }
+//		  if (weight_to_use == 0)
+//		  {
+//			  if (used_weight > 0)
+//			  {
+//				  weight_to_use = 1;
+//				  form.setFieldsValue(
+//				  {
+//					  remaining_weight: filament_weight-used_weight
+//				  });
+//				  return [true, false];
+//			  }
+//			  else if (remaining_weight > 0)
+//			  {
+//				  form.setFieldsValue(
+//				  {
+//					  used_weight: filament_weight-remaining_weight
+//				  });
+//				  weight_to_use = 2;
+//				  return [false, true];
+//			  }
+//			  else
+//			  {
+//				  weight_to_use = 0;
+//				  return [true, true];
+//			  }
+//		  }
+//		  else if (weight_to_use == 1)
+//		  {
+//			  if (used_weight > 0)
+//			  {
+//				  form.setFieldsValue(
+//				  {
+//					  remaining_weight: filament_weight-used_weight
+//				  });
+//				  return [true, false];
+//			  }
+//			  else
+//			  {
+//				  weight_to_use = 0;
+//				  return [true, true];
+//			  }
+//		  }
+//		  else if (weight_to_use == 2)
+//		  {
+//			  if (used_weight > 0)
+//			  {
+//				  form.setFieldsValue(
+//				  {
+//					  used_weight: filament_weight-remaining_weight
+//				  });
+//				  return [false, true];
+//			  }
+//			  else
+//			  {
+//				  weight_to_use = 0;
+//				  return [true, true];
+//			  }
+//		  }
+
+	  }
+	  return [false, false, false];
+  }
+
+  const has_spool_weight = () => {
+    if (selected_filament)
+    {
+      return filamentOptions.find(obj => {return obj.value === selected_filament}).spool_weight
+    }
+    return false;
+  }
 
   return (
     <Create
@@ -105,17 +216,53 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             }
           />
         </Form.Item>
+		    <Form.Item
+          label={t("spool.fields.weight_to_use")}
+          help={t("spool.fields_help.weight_to_use")}
+          name={["weight_to_use"]}
+          initialValue={1}
+        >
+          <Radio.Group>
+          <Radio.Button value={1}>{t("spool.fields.used_weight")}</Radio.Button>
+          <Radio.Button value={2}>{t("spool.fields.remaining_weight")}</Radio.Button>
+          <Radio.Button value={3} disabled={!has_spool_weight()}>{t("spool.fields.measured_weight")}</Radio.Button>
+            </Radio.Group>
+        </Form.Item>
         <Form.Item
           label={t("spool.fields.used_weight")}
           help={t("spool.fields_help.used_weight")}
           name={["used_weight"]}
           rules={[
             {
-              required: true,
+              required: handle_weight()[0],
             },
           ]}
         >
-          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} />
+          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[0]} />
+        </Form.Item>
+		<Form.Item
+          label={t("spool.fields.remaining_weight")}
+          help={t("spool.fields_help.remaining_weight")}
+          name={["remaining_weight"]}
+          rules={[
+            {
+              required: handle_weight()[1],
+            },
+          ]}
+        >
+          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[1]} />
+        </Form.Item>
+		<Form.Item
+          label={t("spool.fields.measured_weight")}
+          help={t("spool.fields_help.measured_weight")}
+          name={["measured_weight"]}
+          rules={[
+            {
+              required: handle_weight()[2],
+            },
+          ]}
+        >
+          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[2]} />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.location")}

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -72,11 +72,15 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
     const newFilamentWeight = newSelectedFilament?.weight || 0;
     const newSpoolWeight = newSelectedFilament?.spool_weight || 0;
 
-    if (!(newFilamentWeight && newSpoolWeight)) {
-      setWeightToEnter(2);
+    if (weightToEnter >= 3) {
+      if (!(newFilamentWeight && newSpoolWeight)) {
+        setWeightToEnter(2);
+      }
     }
-    if (!newFilamentWeight) {
-      setWeightToEnter(1);
+    if (weightToEnter >= 2) {
+      if (!newFilamentWeight) {
+        setWeightToEnter(1);
+      }
     }
   };
 

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { IResourceComponentsProps, useTranslate } from "@refinedev/core";
 import { Create, useForm, useSelect } from "@refinedev/antd";
-import { Form, Input, DatePicker, Select, InputNumber, Radio } from "antd";
+import { Form, Input, DatePicker, Select, InputNumber } from "antd";
 import dayjs from "dayjs";
 import TextArea from "antd/es/input/TextArea";
 import { IFilament } from "../filaments/model";
 import { ISpool } from "./model";
 import { numberFormatter, numberParser } from "../../utils/parsing";
+import { useSavedState } from "../../utils/saveload";
 
 interface CreateOrCloneProps {
   mode: "create" | "clone";
@@ -49,120 +50,16 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
     return {
       label: label,
       value: item.id,
-	  weight: item.weight,
-	  spool_weight: item.spool_weight
+	    weight: item.weight,
+	    spool_weight: item.spool_weight
     };
   });
   filamentOptions?.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
 
-  const selected_filament = Form.useWatch('filament_id', form);
-  const weight_to_use = Form.useWatch('weight_to_use', form);
-  const used_weight = Form.useWatch('used_weight', form);
-  const remaining_weight = Form.useWatch('remaining_weight', form);
-  const measured_weight = Form.useWatch('measured_weight', form);
+  const [used_weight, set_used_weight] = useSavedState("create-used_weight", 0);
 
-  const handle_weight = () => {
-	  if (selected_filament)
-	  {
-		  let filament_weight = filamentOptions.find(obj => {return obj.value === selected_filament}).weight;
-		  let spool_weight = filamentOptions.find(obj => {return obj.value === selected_filament}).spool_weight || 0;
-		  if (weight_to_use == 1)
-		  {
-              form.setFieldsValue(
-			  {
-				  remaining_weight: filament_weight - (used_weight || 0),
-				  measured_weight: filament_weight - (used_weight || 0) + spool_weight
-			  });
-			  return [true, false, false];
-		  }
-		  else if (weight_to_use == 2)
-		  {
-			  form.setFieldsValue(
-			  {
-				  used_weight: filament_weight - (remaining_weight || 0),
-				  measured_weight: (remaining_weight || 0) + spool_weight
-			  });
-			  return [false, true, false];
-		  }
-		  else if (weight_to_use == 3)
-		  {
-			  form.setFieldsValue(
-			  {
-				  used_weight: filament_weight - ((measured_weight || 0) - spool_weight),
-				  remaining_weight: (measured_weight || 0) - spool_weight
-			  });
-			  return [false, false, true];
-		  }
-//		  if (weight_to_use == 0)
-//		  {
-//			  if (used_weight > 0)
-//			  {
-//				  weight_to_use = 1;
-//				  form.setFieldsValue(
-//				  {
-//					  remaining_weight: filament_weight-used_weight
-//				  });
-//				  return [true, false];
-//			  }
-//			  else if (remaining_weight > 0)
-//			  {
-//				  form.setFieldsValue(
-//				  {
-//					  used_weight: filament_weight-remaining_weight
-//				  });
-//				  weight_to_use = 2;
-//				  return [false, true];
-//			  }
-//			  else
-//			  {
-//				  weight_to_use = 0;
-//				  return [true, true];
-//			  }
-//		  }
-//		  else if (weight_to_use == 1)
-//		  {
-//			  if (used_weight > 0)
-//			  {
-//				  form.setFieldsValue(
-//				  {
-//					  remaining_weight: filament_weight-used_weight
-//				  });
-//				  return [true, false];
-//			  }
-//			  else
-//			  {
-//				  weight_to_use = 0;
-//				  return [true, true];
-//			  }
-//		  }
-//		  else if (weight_to_use == 2)
-//		  {
-//			  if (used_weight > 0)
-//			  {
-//				  form.setFieldsValue(
-//				  {
-//					  used_weight: filament_weight-remaining_weight
-//				  });
-//				  return [false, true];
-//			  }
-//			  else
-//			  {
-//				  weight_to_use = 0;
-//				  return [true, true];
-//			  }
-//		  }
-
-	  }
-	  return [false, false, false];
-  }
-
-  const has_spool_weight = () => {
-    if (selected_filament)
-    {
-      return filamentOptions.find(obj => {return obj.value === selected_filament}).spool_weight
-    }
-    return false;
-  }
+  const selected_filament_id = Form.useWatch('filament_id', form);
+  const selected_filament = filamentOptions?.find(obj => {return obj.value === selected_filament_id});
 
   return (
     <Create
@@ -216,53 +113,83 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             }
           />
         </Form.Item>
-		    <Form.Item
-          label={t("spool.fields.weight_to_use")}
-          help={t("spool.fields_help.weight_to_use")}
-          name={["weight_to_use"]}
-          initialValue={1}
+        <Form.Item
+          hidden={true}
+          name={["used_weight"]}
+          initialValue={0}
         >
-          <Radio.Group>
-          <Radio.Button value={1}>{t("spool.fields.used_weight")}</Radio.Button>
-          <Radio.Button value={2}>{t("spool.fields.remaining_weight")}</Radio.Button>
-          <Radio.Button value={3} disabled={!has_spool_weight()}>{t("spool.fields.measured_weight")}</Radio.Button>
-            </Radio.Group>
+          <InputNumber
+            value={used_weight}
+          />
         </Form.Item>
+
         <Form.Item
           label={t("spool.fields.used_weight")}
           help={t("spool.fields_help.used_weight")}
-          name={["used_weight"]}
-          rules={[
-            {
-              required: handle_weight()[0],
-            },
-          ]}
+          // name={["used_weight"]}
+          initialValue={0}
         >
-          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[0]} />
+          <InputNumber
+            min={0}
+            addonAfter="g"
+            precision={1}
+            formatter={numberFormatter}
+            parser={numberParser}
+            value={used_weight}
+            onChange={(value) => {
+              set_used_weight(value ?? 0);
+              form.setFieldsValue(
+              {
+                used_weight: value ?? 0
+              });
+            }}
+          />
         </Form.Item>
 		<Form.Item
           label={t("spool.fields.remaining_weight")}
           help={t("spool.fields_help.remaining_weight")}
-          name={["remaining_weight"]}
-          rules={[
-            {
-              required: handle_weight()[1],
-            },
-          ]}
+          // name={["remaining_weight"]}
+          initialValue={0}
         >
-          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[1]} />
+          <InputNumber
+            min={0}
+            addonAfter="g"
+            precision={1}
+            formatter={numberFormatter}
+            parser={numberParser}
+            disabled={!(selected_filament?.weight || 0)}
+            value={(selected_filament?.weight || 0) ? (selected_filament?.weight || 0) - used_weight : 0}
+            onChange={(value) => {
+              set_used_weight((selected_filament?.weight || 0) - (value ?? 0));
+              form.setFieldsValue(
+                {
+                  used_weight: (selected_filament?.weight || 0) - (value ?? 0)
+                });
+            }}
+          />
         </Form.Item>
 		<Form.Item
           label={t("spool.fields.measured_weight")}
           help={t("spool.fields_help.measured_weight")}
-          name={["measured_weight"]}
-          rules={[
-            {
-              required: handle_weight()[2],
-            },
-          ]}
+          // name={["measured_weight"]}
+          initialValue={0}
         >
-          <InputNumber min={0} addonAfter="g" precision={1} formatter={numberFormatter} parser={numberParser} disabled={!handle_weight()[2]} />
+          <InputNumber
+            min={0}
+            addonAfter="g"
+            precision={1}
+            formatter={numberFormatter}
+            parser={numberParser}
+            disabled={!((selected_filament?.weight || 0) && (selected_filament?.spool_weight || 0))}
+            value={((selected_filament?.weight || 0) && (selected_filament?.spool_weight || 0)) ? (selected_filament?.weight || 0) - used_weight + (selected_filament?.spool_weight || 0) : 0}
+            onChange={(value) => {
+              set_used_weight((selected_filament?.weight || 0) - ((value ?? 0) - (selected_filament?.spool_weight || 0)));
+              form.setFieldsValue(
+                {
+                  used_weight: (selected_filament?.weight || 0) - ((value ?? 0) - (selected_filament?.spool_weight || 0))
+                });
+            }}
+          />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.location")}

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -1,12 +1,12 @@
-import React, {useState} from "react";
-import {IResourceComponentsProps, useTranslate} from "@refinedev/core";
-import {Create, useForm, useSelect} from "@refinedev/antd";
-import {Form, Input, DatePicker, Select, InputNumber, Radio} from "antd";
+import React, { useState } from "react";
+import { IResourceComponentsProps, useTranslate } from "@refinedev/core";
+import { Create, useForm, useSelect } from "@refinedev/antd";
+import { Form, Input, DatePicker, Select, InputNumber, Radio } from "antd";
 import dayjs from "dayjs";
 import TextArea from "antd/es/input/TextArea";
-import {IFilament} from "../filaments/model";
-import {ISpool} from "./model";
-import {numberFormatter, numberParser} from "../../utils/parsing";
+import { IFilament } from "../filaments/model";
+import { ISpool } from "./model";
+import { numberFormatter, numberParser } from "../../utils/parsing";
 
 interface CreateOrCloneProps {
   mode: "create" | "clone";
@@ -15,7 +15,7 @@ interface CreateOrCloneProps {
 export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps> = (props) => {
   const t = useTranslate();
 
-  const {form, formProps, saveButtonProps, formLoading} = useForm<ISpool>();
+  const { form, formProps, saveButtonProps, formLoading } = useForm<ISpool>();
 
   if (props.mode === "clone" && formProps.initialValues) {
     // Clear out the values that we don't want to clone
@@ -27,7 +27,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
     formProps.initialValues.filament_id = formProps.initialValues.filament.id;
   }
 
-  const {queryResult} = useSelect<IFilament>({
+  const { queryResult } = useSelect<IFilament>({
     resource: "filament",
   });
 
@@ -50,16 +50,16 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
       label: label,
       value: item.id,
       weight: item.weight,
-      spool_weight: item.spool_weight
+      spool_weight: item.spool_weight,
     };
   });
-  filamentOptions?.sort((a, b) => a.label.localeCompare(b.label, undefined, {sensitivity: "base"}));
+  filamentOptions?.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
 
   const [weightToEnter, setWeightToEnter] = useState(1);
   const [usedWeight, setUsedWeight] = useState(0);
 
-  const selectedFilamentID = Form.useWatch('filament_id', form);
-  const selectedFilament = filamentOptions?.find(obj => {
+  const selectedFilamentID = Form.useWatch("filament_id", form);
+  const selectedFilament = filamentOptions?.find((obj) => {
     return obj.value === selectedFilamentID;
   });
   const filamentWeight = selectedFilament?.weight || 0;
@@ -82,11 +82,10 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
 
   const weightChange = (weight: number) => {
     setUsedWeight(weight);
-    form.setFieldsValue(
-      {
-        used_weight: weight
-      });
-  }
+    form.setFieldsValue({
+      used_weight: weight,
+    });
+  };
 
   return (
     <Create
@@ -107,7 +106,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker showTime format="YYYY-MM-DD HH:mm:ss"/>
+          <DatePicker showTime format="YYYY-MM-DD HH:mm:ss" />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.last_used")}
@@ -121,7 +120,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             value: value ? dayjs(value) : undefined,
           })}
         >
-          <DatePicker showTime format="YYYY-MM-DD HH:mm:ss"/>
+          <DatePicker showTime format="YYYY-MM-DD HH:mm:ss" />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.filament")}
@@ -144,14 +143,8 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
           />
         </Form.Item>
 
-        <Form.Item
-          hidden={true}
-          name={["used_weight"]}
-          initialValue={0}
-        >
-          <InputNumber
-            value={usedWeight}
-          />
+        <Form.Item hidden={true} name={["used_weight"]} initialValue={0}>
+          <InputNumber value={usedWeight} />
         </Form.Item>
 
         <Form.Item label={t("spool.fields.weight_to_use")} help={t("spool.fields_help.weight_to_use")}>
@@ -162,9 +155,23 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             defaultValue={1}
             value={weightToEnter}
           >
-            <Radio.Button value={1}>{t("spool.fields.used_weight")}</Radio.Button>
-            <Radio.Button value={2} disabled={!filamentWeight}>{t("spool.fields.remaining_weight")}</Radio.Button>
-            <Radio.Button value={3} disabled={!(filamentWeight && spoolWeight)}>{t("spool.fields.measured_weight")}</Radio.Button>
+            <Radio.Button
+              value={1}
+            >
+              {t("spool.fields.used_weight")}
+            </Radio.Button>
+            <Radio.Button
+              value={2}
+              disabled={!filamentWeight}
+            >
+              {t("spool.fields.remaining_weight")}
+            </Radio.Button>
+            <Radio.Button
+              value={3}
+              disabled={!(filamentWeight && spoolWeight)}
+            >
+              {t("spool.fields.measured_weight")}
+            </Radio.Button>
           </Radio.Group>
         </Form.Item>
 
@@ -219,7 +226,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             formatter={numberFormatter}
             parser={numberParser}
             disabled={weightToEnter != 3}
-            value={(filamentWeight && spoolWeight) ? filamentWeight - usedWeight + spoolWeight : 0}
+            value={filamentWeight && spoolWeight ? filamentWeight - usedWeight + spoolWeight : 0}
             onChange={(value) => {
               weightChange(filamentWeight - ((value ?? 0) - spoolWeight));
             }}
@@ -235,7 +242,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             },
           ]}
         >
-          <Input maxLength={64}/>
+          <Input maxLength={64} />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.lot_nr")}
@@ -247,7 +254,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             },
           ]}
         >
-          <Input maxLength={64}/>
+          <Input maxLength={64} />
         </Form.Item>
         <Form.Item
           label={t("spool.fields.comment")}
@@ -258,7 +265,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
             },
           ]}
         >
-          <TextArea maxLength={1024}/>
+          <TextArea maxLength={1024} />
         </Form.Item>
       </Form>
     </Create>

--- a/client/src/pages/spools/edit.tsx
+++ b/client/src/pages/spools/edit.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { IResourceComponentsProps, useTranslate } from "@refinedev/core";
 import { Edit, useForm, useSelect } from "@refinedev/antd";
-import { Form, Input, DatePicker, Select, InputNumber } from "antd";
+import { Form, Input, DatePicker, Select, InputNumber, Radio } from "antd";
 import dayjs from "dayjs";
 import TextArea from "antd/es/input/TextArea";
 import { IFilament } from "../filaments/model";
@@ -11,7 +11,7 @@ import { numberFormatter, numberParser } from "../../utils/parsing";
 export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
   const t = useTranslate();
 
-  const { formProps, saveButtonProps } = useForm<ISpool>();
+  const { form, formProps, saveButtonProps } = useForm<ISpool>();
 
   const { queryResult } = useSelect<IFilament>({
     resource: "filament",
@@ -35,13 +35,59 @@ export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
     return {
       label: label,
       value: item.id,
+      weight: item.weight,
+      spool_weight: item.spool_weight,
     };
   });
   filamentOptions?.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
 
+  const [weightToEnter, setWeightToEnter] = useState(1);
+  const [usedWeight, setUsedWeight] = useState(0);
+
+  const selectedFilamentID = Form.useWatch("filament_id", form);
+  const selectedFilament = filamentOptions?.find((obj) => {
+    return obj.value === selectedFilamentID;
+  });
+  const filamentWeight = selectedFilament?.weight || 0;
+  const spoolWeight = selectedFilament?.spool_weight || 0;
+
+  const filamentChange = (newID: number) => {
+    const newSelectedFilament = filamentOptions?.find((obj) => {
+      return obj.value === newID;
+    });
+    const newFilamentWeight = newSelectedFilament?.weight || 0;
+    const newSpoolWeight = newSelectedFilament?.spool_weight || 0;
+
+    if (weightToEnter >= 3) {
+      if (!(newFilamentWeight && newSpoolWeight)) {
+        setWeightToEnter(2);
+      }
+    }
+    if (weightToEnter >= 2) {
+      if (!newFilamentWeight) {
+        setWeightToEnter(1);
+      }
+    }
+  };
+
+  const weightChange = (weight: number) => {
+    setUsedWeight(weight);
+    form.setFieldsValue({
+      used_weight: weight,
+    });
+  };
+
   if (formProps.initialValues) {
     formProps.initialValues["filament_id"] = formProps.initialValues["filament"].id;
   }
+
+  useEffect(() => {
+    if (formProps.initialValues && usedWeight != formProps.initialValues["used_weight"]) {
+      setUsedWeight(formProps.initialValues["used_weight"])
+    }
+  }, []);
+
+  console.log(usedWeight)
 
   return (
     <Edit saveButtonProps={saveButtonProps}>
@@ -114,25 +160,98 @@ export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
             filterOption={(input, option) =>
               typeof option?.label === "string" && option?.label.toLowerCase().includes(input.toLowerCase())
             }
+            onChange={(value) => {
+              filamentChange(value);
+            }}
           />
         </Form.Item>
+        <Form.Item hidden={false} name={["used_weight"]} initialValue={0}>
+          <InputNumber value={usedWeight} />
+        </Form.Item>
+
+        <Form.Item label={t("spool.fields.weight_to_use")} help={t("spool.fields_help.weight_to_use")}>
+          <Radio.Group
+            onChange={(value) => {
+              setWeightToEnter(value.target.value);
+            }}
+            defaultValue={1}
+            value={weightToEnter}
+          >
+            <Radio.Button
+              value={1}
+            >
+              {t("spool.fields.used_weight")}
+            </Radio.Button>
+            <Radio.Button
+              value={2}
+              disabled={!filamentWeight}
+            >
+              {t("spool.fields.remaining_weight")}
+            </Radio.Button>
+            <Radio.Button
+              value={3}
+              disabled={!(filamentWeight && spoolWeight)}
+            >
+              {t("spool.fields.measured_weight")}
+            </Radio.Button>
+          </Radio.Group>
+        </Form.Item>
+
         <Form.Item
           label={t("spool.fields.used_weight")}
           help={t("spool.fields_help.used_weight")}
-          name={["used_weight"]}
-          rules={[
-            {
-              required: true,
-            },
-          ]}
+          // name={["used_weight"]}
+          // initialValue={usedWeight}
         >
           <InputNumber
             min={0}
             addonAfter="g"
             precision={1}
-            max={1e6}
             formatter={numberFormatter}
             parser={numberParser}
+            disabled={weightToEnter != 1}
+            value={usedWeight}
+            onChange={(value) => {
+              weightChange(value ?? 0);
+            }}
+          />
+        </Form.Item>
+        <Form.Item
+          label={t("spool.fields.remaining_weight")}
+          help={t("spool.fields_help.remaining_weight")}
+          // name={["remaining_weight"]}
+          // initialValue={filamentWeight ? filamentWeight - usedWeight : 0}
+        >
+          <InputNumber
+            min={0}
+            addonAfter="g"
+            precision={1}
+            formatter={numberFormatter}
+            parser={numberParser}
+            disabled={weightToEnter != 2}
+            value={filamentWeight ? filamentWeight - usedWeight : 0}
+            onChange={(value) => {
+              weightChange(filamentWeight - (value ?? 0));
+            }}
+          />
+        </Form.Item>
+        <Form.Item
+          label={t("spool.fields.measured_weight")}
+          help={t("spool.fields_help.measured_weight")}
+          // name={["measured_weight"]}
+          // initialValue={filamentWeight && spoolWeight ? filamentWeight - usedWeight + spoolWeight : 0}
+        >
+          <InputNumber
+            min={0}
+            addonAfter="g"
+            precision={1}
+            formatter={numberFormatter}
+            parser={numberParser}
+            disabled={weightToEnter != 3}
+            value={filamentWeight && spoolWeight ? filamentWeight - usedWeight + spoolWeight : 0}
+            onChange={(value) => {
+              weightChange(filamentWeight - ((value ?? 0) - spoolWeight));
+            }}
           />
         </Form.Item>
         <Form.Item

--- a/client/src/pages/spools/edit.tsx
+++ b/client/src/pages/spools/edit.tsx
@@ -87,8 +87,6 @@ export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
     }
   }, []);
 
-  console.log(usedWeight)
-
   return (
     <Edit saveButtonProps={saveButtonProps}>
       <Form {...formProps} layout="vertical">

--- a/spoolman/api/v1/spool.py
+++ b/spoolman/api/v1/spool.py
@@ -158,11 +158,11 @@ async def create(  # noqa: ANN201
     db: Annotated[AsyncSession, Depends(get_db_session)],
     body: SpoolParameters,
 ):
-    if body.remaining_weight is not None and body.used_weight is not None:
-        return JSONResponse(
-            status_code=400,
-            content={"message": "Only specify either remaining_weight or used_weight."},
-        )
+    #if body.remaining_weight is not None and body.used_weight is not None:
+    #    return JSONResponse(
+    #        status_code=400,
+    #        content={"message": "Only specify either remaining_weight or used_weight."},
+    #    )
 
     try:
         db_item = await spool.create(

--- a/spoolman/api/v1/spool.py
+++ b/spoolman/api/v1/spool.py
@@ -159,10 +159,10 @@ async def create(  # noqa: ANN201
     body: SpoolParameters,
 ):
     if body.remaining_weight is not None and body.used_weight is not None:
-       return JSONResponse(
-           status_code=400,
-           content={"message": "Only specify either remaining_weight or used_weight."},
-       )
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Only specify either remaining_weight or used_weight."},
+        )
 
     try:
         db_item = await spool.create(

--- a/spoolman/api/v1/spool.py
+++ b/spoolman/api/v1/spool.py
@@ -158,11 +158,11 @@ async def create(  # noqa: ANN201
     db: Annotated[AsyncSession, Depends(get_db_session)],
     body: SpoolParameters,
 ):
-    #if body.remaining_weight is not None and body.used_weight is not None:
-    #    return JSONResponse(
-    #        status_code=400,
-    #        content={"message": "Only specify either remaining_weight or used_weight."},
-    #    )
+    if body.remaining_weight is not None and body.used_weight is not None:
+       return JSONResponse(
+           status_code=400,
+           content={"message": "Only specify either remaining_weight or used_weight."},
+       )
 
     try:
         db_item = await spool.create(


### PR DESCRIPTION
i have only implemented this for the create page for now, decided to get feedback before porting it over to the edit page.

i tried a few ways to implement this with a system where whatever value you entered first became the one it used and the others get disabled and then auto calculate but i couldn't find a way to solve the circular references when you then delete the value you entered so you can switch to another one (code left in if you want to have a go with it). as a result i ended up adding some radio buttons so the user can select what field they want to use.

since the auto calculate relies on the filament weight i disabled all 3 fields till you select a spool. i also disabled the "measured weight" field if the filament doesn't list the spool weight but you can still use the "remaining weight" field.

there is still an error (`Warning: Cannot update a component ('InternalFormItem') while rendering a different component ('SpoolCreate').`) that shows up when you first select the spool but it shows up no matter how long you leave the page to render before selecting the spool and i don't have enough experience with react to work out what's wrong. however there also doesn't seem to be an actual problem caused by the error so im not sure if it "needs" fixing (i would still like to fix it).

lastly i removed the check in the api that prevents submitting both `remaining_weight` and `used_weight`, this is just temporary so i could test it and i assume we want to do some better check here. another option is to only ever submit `used_weight` no matter what weight they enter but i spent a while trying to work out how to do that and in the end decided this was quicker and works for the time being