### PR TITLE
Docker: set permissions for config directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ LABEL org.opencontainers.image.licenses=MIT
 RUN apk add --no-cache libstdc++
 
 # Add local user so we don't run as root
-RUN adduser -D app
+RUN adduser -D app \
+ && mkdir -p /home/app/.local/share/spoolman \
+ && chown -R app:app /home/app/.local/share/spoolman
+
 USER app
 
 # Copy built client
@@ -58,5 +61,6 @@ ENV PYTHONPATH="/home/app/spoolman:${PYTHONPATH}"
 
 # Run command
 EXPOSE 8000
+VOLUME ["/home/app/.local/share/spoolman"]
 ENTRYPOINT ["uvicorn", "spoolman.main:app"]
 CMD ["--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Hi there, 

while adding spoolman to [prind](https://github.com/mkuf/prind), I noticed that when using a named volume to store the spoolman-db, permissions for `/home/app/.local/share/spoolman` are set to `root:root` which causes the server to fail as the `app` user lacks permissions to write to it. 

Example: 
```yaml
services:
  spoolman:
    image: ghcr.io/donkie/spoolman:edge
    restart: unless-stopped
    volumes:
      - spoolman-db:/home/app/.local/share/spoolman

volumes:
  spoolman-db:
```

This PR creates the database directory and sets `app:app` as owner at image build time.
Furthermore, to follow [Best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#volume) adds the `VOLUME` directive to the dockerfile for the database directory.

Looking forward to your response.
-Markus