### PR TITLE
Add support for sharing table views via link

### DIFF
--- a/client/src/utils/saveload.ts
+++ b/client/src/utils/saveload.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import { CrudFilter, CrudSort } from "@refinedev/core";
 import { isLocalStorageAvailable } from "./support";
-
 interface Pagination {
   current: number;
   pageSize: number;
@@ -16,10 +15,10 @@ export interface TableState {
 
 export function useInitialTableState(tableId: string): TableState {
   const [initialState] = React.useState(() => {
-    const savedSorters = isLocalStorageAvailable ? localStorage.getItem(`${tableId}-sorters`) : null;
-    const savedFilters = isLocalStorageAvailable ? localStorage.getItem(`${tableId}-filters`) : null;
-    const savedPagination = isLocalStorageAvailable ? localStorage.getItem(`${tableId}-pagination`) : null;
-    const savedShowColumns = isLocalStorageAvailable ? localStorage.getItem(`${tableId}-showColumns`) : null;
+    const savedSorters = hasHashProperty(`${tableId}-sorters`) ? getHashProperty(`${tableId}-sorters`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-sorters`) : null;
+    const savedFilters = hasHashProperty(`${tableId}-filters`) ? getHashProperty(`${tableId}-filters`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-filters`) : null;
+    const savedPagination = hasHashProperty(`${tableId}-pagination`) ? getHashProperty(`${tableId}-pagination`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-pagination`) : null;
+    const savedShowColumns = hasHashProperty(`${tableId}-showColumns`) ? getHashProperty(`${tableId}-showColumns`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-showColumns`) : null;
 
     const sorters = savedSorters ? JSON.parse(savedSorters) : [{ field: "id", order: "asc" }];
     const filters = savedFilters ? JSON.parse(savedFilters) : [];
@@ -35,11 +34,17 @@ export function useStoreInitialState(tableId: string, state: TableState) {
     if (isLocalStorageAvailable) {
       localStorage.setItem(`${tableId}-sorters`, JSON.stringify(state.sorters));
     }
+    if (JSON.stringify(state.sorters) != JSON.stringify([{ field: "id", order: "asc" }])) {
+      updateURLHash(`${tableId}-sorters`, JSON.stringify(state.sorters));
+    }
   }, [tableId, state.sorters]);
 
   React.useEffect(() => {
     if (isLocalStorageAvailable) {
       localStorage.setItem(`${tableId}-filters`, JSON.stringify(state.filters));
+    }
+    if (JSON.stringify(state.filters) != JSON.stringify([])) {
+      updateURLHash(`${tableId}-filters`, JSON.stringify(state.filters));
     }
   }, [tableId, state.filters]);
 
@@ -47,16 +52,26 @@ export function useStoreInitialState(tableId: string, state: TableState) {
     if (isLocalStorageAvailable) {
       localStorage.setItem(`${tableId}-pagination`, JSON.stringify(state.pagination));
     }
+    if (JSON.stringify(state.pagination) != JSON.stringify({ current: 1, pageSize: 20 })) {
+      updateURLHash(`${tableId}-pagination`, JSON.stringify(state.pagination));
+    }
+
   }, [tableId, state.pagination]);
 
   React.useEffect(() => {
     if (isLocalStorageAvailable) {
       if (state.showColumns === undefined) {
         localStorage.removeItem(`${tableId}-showColumns`);
+        const params = new URLSearchParams(window.location.hash.substring(1));
+        if (params.has(`${tableId}-showColumns`)) {
+          params.delete(`${tableId}-showColumns`)
+        }
+        window.location.hash = params.toString();
       } else {
         localStorage.setItem(`${tableId}-showColumns`, JSON.stringify(state.showColumns));
       }
     }
+
   }, [tableId, state.showColumns]);
 }
 
@@ -73,4 +88,23 @@ export function useSavedState<T>(id: string, defaultValue: T) {
   }, [id, state]);
 
   return [state, setState] as const;
+}
+
+export function updateURLHash(Id: string, value: string) {
+  const params = new URLSearchParams(window.location.hash.substring(1));
+  if (!params.has(Id)) {
+    params.append(Id, value)
+  }
+  params.set(Id, value);
+  window.location.hash = params.toString();
+}
+
+function getHashProperty(Id: string) {
+  const hash = new URLSearchParams(window.location.hash.substring(1));
+  return hash.get(Id);
+}
+
+function hasHashProperty(property: string): boolean {
+  const hash = new URLSearchParams(window.location.hash.substring(1));
+  return hash.has(property);
 }

--- a/client/src/utils/saveload.ts
+++ b/client/src/utils/saveload.ts
@@ -15,10 +15,10 @@ export interface TableState {
 
 export function useInitialTableState(tableId: string): TableState {
   const [initialState] = React.useState(() => {
-    const savedSorters = hasHashProperty(`${tableId}-sorters`) ? getHashProperty(`${tableId}-sorters`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-sorters`) : null;
-    const savedFilters = hasHashProperty(`${tableId}-filters`) ? getHashProperty(`${tableId}-filters`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-filters`) : null;
-    const savedPagination = hasHashProperty(`${tableId}-pagination`) ? getHashProperty(`${tableId}-pagination`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-pagination`) : null;
-    const savedShowColumns = hasHashProperty(`${tableId}-showColumns`) ? getHashProperty(`${tableId}-showColumns`) : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-showColumns`) : null;
+    const savedSorters = hasHashProperty('sorters') ? getHashProperty('sorters') : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-sorters`) : null;
+    const savedFilters = hasHashProperty('filters') ? getHashProperty('filters') : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-filters`) : null;
+    const savedPagination = hasHashProperty('pagination') ? getHashProperty('pagination') : isLocalStorageAvailable ? localStorage.getItem(`${tableId}-pagination`) : null;
+    const savedShowColumns = isLocalStorageAvailable ? localStorage.getItem(`${tableId}-showColumns`) : null;
 
     const sorters = savedSorters ? JSON.parse(savedSorters) : [{ field: "id", order: "asc" }];
     const filters = savedFilters ? JSON.parse(savedFilters) : [];
@@ -31,29 +31,39 @@ export function useInitialTableState(tableId: string): TableState {
 
 export function useStoreInitialState(tableId: string, state: TableState) {
   React.useEffect(() => {
-    if (isLocalStorageAvailable) {
-      localStorage.setItem(`${tableId}-sorters`, JSON.stringify(state.sorters));
-    }
-    if (JSON.stringify(state.sorters) != JSON.stringify([{ field: "id", order: "asc" }])) {
-      updateURLHash(`${tableId}-sorters`, JSON.stringify(state.sorters));
+    if (state.sorters.length > 0 && JSON.stringify(state.sorters) != JSON.stringify([{ field: "id", order: "asc" }])) {
+      if (isLocalStorageAvailable) {
+        localStorage.setItem(`${tableId}-sorters`, JSON.stringify(state.sorters));
+      }
+      setURLHash(`sorters`, JSON.stringify(state.sorters));
+    } else {
+      localStorage.removeItem(`${tableId}-sorters`)
+      removeURLHash('sorters');
     }
   }, [tableId, state.sorters]);
 
   React.useEffect(() => {
-    if (isLocalStorageAvailable) {
-      localStorage.setItem(`${tableId}-filters`, JSON.stringify(state.filters));
-    }
-    if (JSON.stringify(state.filters) != JSON.stringify([])) {
-      updateURLHash(`${tableId}-filters`, JSON.stringify(state.filters));
+    let filters = state.filters.filter(f => f.value.length != 0);
+    if (filters.length > 0) {
+      if (isLocalStorageAvailable) {
+        localStorage.setItem(`${tableId}-filters`, JSON.stringify(filters));
+        setURLHash('filters', JSON.stringify(state.filters));
+      }
+    } else {
+      localStorage.removeItem(`${tableId}-filters`)
+      removeURLHash(`filters`);
     }
   }, [tableId, state.filters]);
 
   React.useEffect(() => {
-    if (isLocalStorageAvailable) {
-      localStorage.setItem(`${tableId}-pagination`, JSON.stringify(state.pagination));
-    }
     if (JSON.stringify(state.pagination) != JSON.stringify({ current: 1, pageSize: 20 })) {
-      updateURLHash(`${tableId}-pagination`, JSON.stringify(state.pagination));
+      if (isLocalStorageAvailable) {
+        localStorage.setItem(`${tableId}-pagination`, JSON.stringify(state.pagination));
+      }
+      setURLHash(`pagination`, JSON.stringify(state.pagination));
+    } else {
+      localStorage.removeItem(`${tableId}-pagination`)
+      removeURLHash(`pagination`);
     }
 
   }, [tableId, state.pagination]);
@@ -62,11 +72,6 @@ export function useStoreInitialState(tableId: string, state: TableState) {
     if (isLocalStorageAvailable) {
       if (state.showColumns === undefined) {
         localStorage.removeItem(`${tableId}-showColumns`);
-        const params = new URLSearchParams(window.location.hash.substring(1));
-        if (params.has(`${tableId}-showColumns`)) {
-          params.delete(`${tableId}-showColumns`)
-        }
-        window.location.hash = params.toString();
       } else {
         localStorage.setItem(`${tableId}-showColumns`, JSON.stringify(state.showColumns));
       }
@@ -90,12 +95,19 @@ export function useSavedState<T>(id: string, defaultValue: T) {
   return [state, setState] as const;
 }
 
-export function updateURLHash(Id: string, value: string) {
+function setURLHash(Id: string, value: string) {
   const params = new URLSearchParams(window.location.hash.substring(1));
   if (!params.has(Id)) {
     params.append(Id, value)
   }
   params.set(Id, value);
+  window.location.hash = params.toString();
+}
+function removeURLHash(Id: string) {
+  const params = new URLSearchParams(window.location.hash.substring(1));
+  if (params.has(Id)) {
+    params.delete(Id)
+  }
   window.location.hash = params.toString();
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,10 @@
 [project]
 name = "spoolman"
-version = "0.12.2"
+version = "0.13.0"
 description = "A web service that keeps track of 3D printing spools."
-authors = [{ name = "Donkie", email = "daniel.cf.hultgren@gmail.com" }]
+authors = [
+    { name = "Donkie", email = "daniel.cf.hultgren@gmail.com" },
+]
 dependencies = [
     "uvicorn~=0.22.0",
     "httptools>=0.5.0; platform_machine != \"armv7l\"",
@@ -47,7 +49,9 @@ cmd = "uvicorn spoolman.main:app"
 cmd = "python tests_integration/run.py"
 
 [tool.ruff]
-select = ["ALL"]
+select = [
+    "ALL",
+]
 ignore = [
     "ANN101",
     "A003",
@@ -74,13 +78,24 @@ line-length = 120
 target-version = "py39"
 
 [tool.ruff.per-file-ignores]
-"tests*/*" = ["ANN201", "S101", "PLR2004", "D103"]
-"migrations/versions/*" = ["N999"]
+"tests*/*" = [
+    "ANN201",
+    "S101",
+    "PLR2004",
+    "D103",
+]
+"migrations/versions/*" = [
+    "N999",
+]
 
 [tool.black]
 line-length = 120
-target-version = ["py39"]
+target-version = [
+    "py39",
+]
 
 [build-system]
-requires = ["pdm-backend"]
+requires = [
+    "pdm-backend",
+]
 build-backend = "pdm.backend"


### PR DESCRIPTION
Updated PR changing UX to follow discussion in #164 
What does this do?
* Automatically sets table sorts, filters, pagination, and columns on load when visiting Spoolman with full share link
* Updates URL hash fragment to reflect current state of table 
* ~~Adds share button~~ 
* Uses ~~share API or~~ current URL to provide sharable link ~~when clicking share~~

What is the use case for this feature?
* Enables sharing of views in multi-user environments via simple link
* Adds support for simple and quick location and/or material based inventory counts - in my case writing the link for the shelf or drybox location filter to NFC tags and QR codes attached to the shelf.

What is missing?
* ~~Possible translation issues. I'm not a linguist but did my best to add translations for the share button where applicable~~
* Testing, I spent about an hour testing different scenarios but it would be nice to have more than one pair of eyes
* QR code generation could possibly be added using this type of link for shelf ID labels
* In the future Refine's syncWithLocation could potentially support customization (I could not find a good way to do this) so that state is reflected in URL without this extra logic

Please let me know if you see problems or things you'd like changed to get this merged. This is my first open-source contribution and I'm not a React developer (Vue+.NET is my wheelhouse). Thanks for the work you've done on this great tool!