### PR TITLE
Switch tests from "docker-compose" to "docker compose"

### DIFF
--- a/tests_integration/run.py
+++ b/tests_integration/run.py
@@ -35,9 +35,9 @@ if __name__ == "__main__":
 
     for target in targets:
         print(f"Running integration tests against {target}...")
-        os.system(f"docker-compose -f tests_integration/docker-compose-{target}.yml down -v")
+        os.system(f"docker compose -f tests_integration/docker-compose-{target}.yml down -v")
         if (
-            os.system(f"docker-compose -f tests_integration/docker-compose-{target}.yml up --abort-on-container-exit")
+            os.system(f"docker compose -f tests_integration/docker-compose-{target}.yml up --abort-on-container-exit")
             > 0
         ):
             print(f"Integration tests against {target} failed!")


### PR DESCRIPTION
I was running some tests and ran into the error `kwargs_from_env() got an unexpected keyword argument 'ssl_version'`. [The suggestion](https://stackoverflow.com/questions/77641240/getting-docker-compose-typeerror-kwargs-from-env-got-an-unexpected-keyword-ar
) of just switching to the newer `docker compose` command worked great for me (all `pdm run itest` passes).

I'm hoping this should be a drop-in change with no impact.