### PR TITLE
Support dynamic ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,3 @@ ENV BUILD_DATE=${BUILD_DATE}
 # Run command
 EXPOSE 8000
 ENTRYPOINT ["/home/app/spoolman/entrypoint.sh"]
-CMD ["--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ If you want to connect with an external database instead, specify the `SPOOLMAN_
 | SPOOLMAN_AUTOMATIC_BACKUP | Automatic nightly DB backups for SQLite databases. Enabled by default, set to `FALSE` to disable.                            |
 | PUID                      | (*docker only*) Set the UID of the user in the docker container. Default is 1000.                                            |
 | PGID                      | (*docker only*) Set the GID of the user in the docker container. Default is 1000.                                            |
+| SPOOLMAN_PORT             | The port Spoolman should run on (default: 8000)                                                                              |
+| SPOOLMAN_HOST             | The hostname/ip Spoolman should bind to (default: 0.0.0.0)                                                                   |
 
 ## Frequently Asked Questions (FAQs)
 ### QR Code Does not work on HTTP / The page is not served over HTTPS

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,8 @@
 
 PUID=${PUID:-1000}
 PGID=${PGID:-1000}
+SPOOLMAN_PORT=${SPOOLMAN_PORT:-8000}
+SPOOLMAN_HOST=${SPOOLMAN_HOST:-0.0.0.0}
 
 groupmod -o -g "$PGID" app
 usermod -o -u "$PUID" app
@@ -12,4 +14,4 @@ echo User GID: $(id -g app)
 echo "Starting uvicorn..."
 
 # Execute the uvicorn command with any additional arguments
-exec su-exec "app" uvicorn spoolman.main:app "$@"
+exec su-exec "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"

--- a/tests_integration/tests/conftest.py
+++ b/tests_integration/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 
 TIMEOUT = 10
 
-URL = "http://spoolman:" + os.environ.get("PORT", "8000")
+URL = "http://spoolman:" + os.environ.get("SPOOLMAN_PORT", "8000")
 
 
 class DbType(StrEnum):

--- a/tests_integration/tests/conftest.py
+++ b/tests_integration/tests/conftest.py
@@ -13,7 +13,7 @@ import pytest
 
 TIMEOUT = 10
 
-URL = "http://spoolman:8000"
+URL = "http://spoolman:" + os.environ.get("PORT", "8000")
 
 
 class DbType(StrEnum):
@@ -43,7 +43,7 @@ def _wait_for_server():  # noqa: ANN202
     start_time = time.time()
     while True:
         try:
-            response = httpx.get("http://spoolman:8000", timeout=1)
+            response = httpx.get(URL, timeout=1)
             response.raise_for_status()
         except httpx.HTTPError:  # noqa: PERF203
             if time.time() - start_time > TIMEOUT:

--- a/tests_integration/tests/fields/test_create.py
+++ b/tests_integration/tests/fields/test_create.py
@@ -6,9 +6,7 @@ from datetime import datetime, timezone
 import httpx
 import pytest
 
-from ..conftest import assert_httpx_success, assert_lists_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_httpx_success, assert_lists_compatible
 
 
 def test_add_text_field():

--- a/tests_integration/tests/fields/test_delete.py
+++ b/tests_integration/tests/fields/test_delete.py
@@ -4,9 +4,7 @@ import json
 
 import httpx
 
-from ..conftest import assert_httpx_success
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_httpx_success
 
 
 def test_delete_field():

--- a/tests_integration/tests/fields/test_get.py
+++ b/tests_integration/tests/fields/test_get.py
@@ -4,9 +4,7 @@ import json
 
 import httpx
 
-from ..conftest import assert_httpx_success, assert_lists_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_httpx_success, assert_lists_compatible
 
 
 def test_get_field():

--- a/tests_integration/tests/fields/test_utilize.py
+++ b/tests_integration/tests/fields/test_utilize.py
@@ -4,9 +4,7 @@ import json
 
 import httpx
 
-from ..conftest import assert_httpx_success
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_httpx_success
 
 
 def test_add_vendor_with_extra_field():

--- a/tests_integration/tests/filament/test_add.py
+++ b/tests_integration/tests/filament/test_add.py
@@ -5,9 +5,7 @@ from typing import Any
 
 import httpx
 
-from ..conftest import assert_dicts_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_dicts_compatible
 
 
 def test_add_filament(random_vendor: dict[str, Any]):

--- a/tests_integration/tests/filament/test_delete.py
+++ b/tests_integration/tests/filament/test_delete.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_delete_filament(random_vendor: dict[str, Any]):

--- a/tests_integration/tests/filament/test_find.py
+++ b/tests_integration/tests/filament/test_find.py
@@ -7,9 +7,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ..conftest import assert_lists_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_lists_compatible
 
 
 @dataclass

--- a/tests_integration/tests/filament/test_get.py
+++ b/tests_integration/tests/filament/test_get.py
@@ -4,9 +4,7 @@ from typing import Any
 
 import httpx
 
-from ..conftest import assert_dicts_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_dicts_compatible
 
 
 def test_get_filament(random_vendor: dict[str, Any]):

--- a/tests_integration/tests/filament/test_update.py
+++ b/tests_integration/tests/filament/test_update.py
@@ -4,9 +4,7 @@ from typing import Any
 
 import httpx
 
-from ..conftest import assert_dicts_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_dicts_compatible
 
 
 def test_update_filament(random_vendor: dict[str, Any]):

--- a/tests_integration/tests/setting/test_get.py
+++ b/tests_integration/tests/setting/test_get.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_get_currency():

--- a/tests_integration/tests/setting/test_set.py
+++ b/tests_integration/tests/setting/test_set.py
@@ -4,7 +4,7 @@ import json
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_set_currency():

--- a/tests_integration/tests/spool/test_add.py
+++ b/tests_integration/tests/spool/test_add.py
@@ -6,9 +6,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ..conftest import assert_dicts_compatible, length_from_weight
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_dicts_compatible, length_from_weight
 
 
 def test_add_spool_remaining_weight(random_filament: dict[str, Any]):

--- a/tests_integration/tests/spool/test_delete.py
+++ b/tests_integration/tests/spool/test_delete.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_delete_spool(random_filament: dict[str, Any]):

--- a/tests_integration/tests/spool/test_find.py
+++ b/tests_integration/tests/spool/test_find.py
@@ -7,9 +7,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ..conftest import assert_lists_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_lists_compatible
 
 
 @dataclass

--- a/tests_integration/tests/spool/test_get.py
+++ b/tests_integration/tests/spool/test_get.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_get_spool(random_filament: dict[str, Any]):

--- a/tests_integration/tests/spool/test_update.py
+++ b/tests_integration/tests/spool/test_update.py
@@ -5,9 +5,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ..conftest import length_from_weight
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, length_from_weight
 
 
 def test_update_spool(random_filament: dict[str, Any]):

--- a/tests_integration/tests/spool/test_use.py
+++ b/tests_integration/tests/spool/test_use.py
@@ -8,7 +8,7 @@ from typing import Any
 import httpx
 import pytest
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 @pytest.mark.parametrize("use_weight", [0, 0.05, -0.05, 1500])  # 1500 is big enough to use all filament

--- a/tests_integration/tests/test_backup.py
+++ b/tests_integration/tests/test_backup.py
@@ -2,9 +2,7 @@
 
 import httpx
 
-from .conftest import DbType, get_db_type
-
-URL = "http://spoolman:8000"
+from .conftest import URL, DbType, get_db_type
 
 
 def test_backup():

--- a/tests_integration/tests/vendor/test_add.py
+++ b/tests_integration/tests/vendor/test_add.py
@@ -4,9 +4,7 @@ from datetime import datetime, timezone
 
 import httpx
 
-from ..conftest import assert_dicts_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_dicts_compatible
 
 
 def test_add_vendor():

--- a/tests_integration/tests/vendor/test_delete.py
+++ b/tests_integration/tests/vendor/test_delete.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_delete_vendor():

--- a/tests_integration/tests/vendor/test_find.py
+++ b/tests_integration/tests/vendor/test_find.py
@@ -7,9 +7,7 @@ from typing import Any
 import httpx
 import pytest
 
-from ..conftest import assert_lists_compatible
-
-URL = "http://spoolman:8000"
+from ..conftest import URL, assert_lists_compatible
 
 
 @dataclass

--- a/tests_integration/tests/vendor/test_get.py
+++ b/tests_integration/tests/vendor/test_get.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_get_vendor():

--- a/tests_integration/tests/vendor/test_update.py
+++ b/tests_integration/tests/vendor/test_update.py
@@ -2,7 +2,7 @@
 
 import httpx
 
-URL = "http://spoolman:8000"
+from ..conftest import URL
 
 
 def test_update_vendor():


### PR DESCRIPTION
This add support for overriding the default port used by Spoolman's docker container. 8000 is still used unless the `SPOOLMAN_PORT` envvar is provided. Also `SPOOLMAN_HOST` can be used to change the address bound to, but defaults to `0.0.0.0`.

Motivation for this change is that not all docker architectures use port mapping (e.g. it's possible each container gets its own routable IP instead). In these cases services need to bind directly to the port number they're expected to be reachable on (e.g. port 80).

Other work done:
 - Updated docs
 - Updated integration tests to handle port overrides
 - Created new integration test specifically for port overrides (using an sqlite backend)
  