### PR TITLE
Update OctoPrint plugin in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is currently only supported in the Klipper ecosystem, with official support f
   * ✔️ Fluidd
   * ✔️ KlipperScreen
   * ✔️ Mainsail
-* ✖️ Octoprint - A plugin is in progress: [OctoPrint-Spoolman](https://github.com/mdziekon/octoprint-spoolman)
+* ✔️ Octoprint: [OctoPrint-Spoolman](https://github.com/mdziekon/octoprint-spoolman)
 * ✔️ Home Assistant integration: [spoolman-homeassistant](https://github.com/Disane87/spoolman-homeassistant)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It is currently only supported in the Klipper ecosystem, with official support f
   * ✔️ Fluidd
   * ✔️ KlipperScreen
   * ✔️ Mainsail
-* ✖️ Octoprint - A plugin is in progress: [OctoPrint-Spoolman](https://github.com/mkevenaar/OctoPrint-Spoolman)
+* ✖️ Octoprint - A plugin is in progress: [OctoPrint-Spoolman](https://github.com/mdziekon/octoprint-spoolman)
 * ✔️ Home Assistant integration: [spoolman-homeassistant](https://github.com/Disane87/spoolman-homeassistant)
 
 ## Installation


### PR DESCRIPTION
original plugins repo was archived, putting in new link found from Octoprint plugin site

https://plugins.octoprint.org/plugins/Spoolman/