### PR TITLE
Install script: Don't bother using sudo if user is running as root

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Warn with a prompt if we're running as root
+SUDO=sudo
 if [ "$EUID" -eq 0 ]; then
     echo -e "${ORANGE}WARNING: You are running this script as root. It is recommended to run this script as a non-root user.${NC}"
     echo -e "${ORANGE}Do you want to continue? (y/n)${NC}"
@@ -16,6 +17,8 @@ if [ "$EUID" -eq 0 ]; then
         echo -e "${ORANGE}Aborting installation.${NC}"
         exit 1
     fi
+
+    SUDO=
 fi
 
 # CD to project root if we're in the scripts dir
@@ -58,13 +61,13 @@ if [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ "$ID_LIKE" == *"debian"* || "$ID" == *"debian"* ]]; then
         pkg_manager="apt-get"
-        update_cmd="sudo $pkg_manager update"
-        install_cmd="sudo $pkg_manager install -y"
+        update_cmd="$SUDO $pkg_manager update"
+        install_cmd="$SUDO $pkg_manager install -y"
         echo -e "${GREEN}Detected Debian-based system. Using apt-get package manager.${NC}"
     elif [[ "$ID_LIKE" == *"arch"* || "$ID" == *"arch"* ]]; then
         pkg_manager="pacman"
-        update_cmd="sudo $pkg_manager -Sy"
-        install_cmd="sudo $pkg_manager -S --noconfirm"
+        update_cmd="$SUDO $pkg_manager -Sy"
+        install_cmd="$SUDO $pkg_manager -S --noconfirm"
         echo -e "${GREEN}Detected Arch-based system. Using pacman package manager.${NC}"
     else
         echo -e "${ORANGE}Your operating system is not supported. Either try to install manually or reach out to spoolman github for support.${NC}"
@@ -249,14 +252,14 @@ WantedBy=default.target
 
     # Create the systemd service unit file
     service_file="/etc/systemd/system/$service_name.service"
-    echo "$service_unit" | sudo tee "$service_file" > /dev/null
+    echo "$service_unit" | $SUDO tee "$service_file" > /dev/null
 
     # Reload the systemd user service manager
-    sudo systemctl daemon-reload
+    $SUDO systemctl daemon-reload
 
     # Enable and start the service
-    sudo systemctl enable "$service_name"
-    sudo systemctl start "$service_name"
+    $SUDO systemctl enable "$service_name"
+    $SUDO systemctl start "$service_name"
 
     # Load .env file now
     set -o allexport


### PR DESCRIPTION
On some systems, sudo isn't present by default, so allow the user to manually elevate the script bypassing the use of sudo.