### PR TITLE
Helps to identify the icon

### DIFF
--- a/client/src/components/spoolIcon.css
+++ b/client/src/components/spoolIcon.css
@@ -18,6 +18,7 @@
 .spool-icon * {
   flex: 1 1 0px;
   border-radius: 2px;
+  border: #44444430 solid 2px;
 }
 
 .spool-icon.vertical *:first-child {


### PR DESCRIPTION
 When there is low contrast between color and table background

Before:
<img width="217" alt="before" src="https://github.com/user-attachments/assets/0f00485a-4eaf-408a-ac70-b4a9192631df">

After:
<img width="246" alt="after" src="https://github.com/user-attachments/assets/76e1ee00-6ebc-4039-b7f4-2c492ebfd869">

After on dark background:
<img width="225" alt="after_on_dark" src="https://github.com/user-attachments/assets/803b230d-c34d-4a60-a3ed-4f562a49f55d">
