### PR TITLE
Update gitattributes to preserve LF line endings on the `.env.example` file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 
 # Never modify line endings of our bash scripts
 *.sh -crlf
+.env.example text eol=lf


### PR DESCRIPTION
The `.env.example` file in the repository which the as-installed `.env` configuration file is copied/created from has Windows CRLF line terminations instead of Unix/Linux LF line terminations, this creates the reported errors in https://github.com/Donkie/Spoolman/issues/493 causing broken installed `.env` configuration files which causes the Spoolman service to enter into a non-functional state.

This `.gitattribute` change should fix this going forward for subsequent releases by ensuring the repo always maintains/converts the `.env.example` file to LF line endings.
   
For any users with a non-functional install of the v0.20.0 release resulting in Spoolman throwing out the following `.env` file errors and failing to initiate properly when checked with `systemctl status Spoolman`:
```log
klipper bash[45831]: .env: line 29: $'\r': command not found
klipper bash[45832]: .env: line 33: $'\r': command not found
klipper bash[45833]: .env: line 37: $'\r': command not found
klipper bash[45834]: .env: line 41: $'\r': command not found
klipper bash[45835]: .env: line 45: $'\r': command not found
klipper bash[45836]: .env: line 51: $'\r': command not found
klipper bash[45837]: .env: line 55: $'\r': command not found
klipper bash[45838]: .env: line 63: $'\r': command not found
klipper bash[45839]: .env: line 69: $'\r': command not found
```

Those users can manually fix their `.env` file's line endings by either installing and running `dos2unix` on the `.env` & `.env.example` files or you can run them through `sed` inside the `./Spoolman/` install directory by using the following to strip off the additional `\r` from the CRLF Windows/DOS line endings which is creating this issue and returning them to have Linux LF line endings:

```bash
sed -i 's/\r$//' .env .env.example \
file .env && file .env.example
```
By using the `file` utility users can validate that those files no longer have CRLF line endings.

After correcting the `.env` file line endings simply restart the Spoolman service with `sudo systemctl restart Spoolman` and the service will start normally and in a functional state.