### PR TITLE
Add Color Code Display for Single Color Filaments

### DIFF
--- a/client/src/components/spoolIcon.css
+++ b/client/src/components/spoolIcon.css
@@ -3,6 +3,7 @@
   width: 1.5em;
   height: 2.5em;
   gap: 2px;
+  margin: 0 0.5em;
 }
 
 .spool-icon.vertical {
@@ -12,6 +13,10 @@
 .spool-icon.large {
   width: 4em;
   height: 4em;
+}
+
+.spool-icon.no-margin {
+  margin: 0;
 }
 
 .spool-icon * {

--- a/client/src/components/spoolIcon.css
+++ b/client/src/components/spoolIcon.css
@@ -3,7 +3,6 @@
   width: 1.5em;
   height: 2.5em;
   gap: 2px;
-  margin: 0 0.5em;
 }
 
 .spool-icon.vertical {

--- a/client/src/components/spoolIcon.tsx
+++ b/client/src/components/spoolIcon.tsx
@@ -3,13 +3,15 @@ import "./spoolIcon.css";
 interface Props {
   color: string | { colors: string[]; vertical: boolean };
   size?: "small" | "large";
+  no_margin? : boolean
 }
 
-export default function SpoolIcon(props: Props) {
+export default function SpoolIcon(props: Readonly<Props>) {
   let dirClass = "vertical";
   let cols = [];
   let size = props.size ? props.size : "small";
-
+  let no_margin = props.no_margin ? "no-margin" : "";
+  
   if (typeof props.color === "string") {
     cols = [props.color];
   } else {
@@ -18,7 +20,7 @@ export default function SpoolIcon(props: Props) {
   }
 
   return (
-    <div className={"spool-icon " + dirClass + " " + size}>
+    <div className={"spool-icon " + dirClass + " " + size + " " + no_margin}>
       {cols.map((col) => (
         <div
           key={col}

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -89,6 +89,7 @@ export const FilamentShow: React.FC<IResourceComponentsProps> = () => {
       <TextField value={record?.name} />
       <Title level={5}>{t("filament.fields.color_hex")}</Title>
       {colorObj && <SpoolIcon color={colorObj} size="large" />}
+      {record?.color_hex && <TextField value={`#${record?.color_hex}`} />}
       <Title level={5}>{t("filament.fields.material")}</Title>
       <TextField value={record?.material} />
       <Title level={5}>{t("filament.fields.price")}</Title>

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -88,7 +88,7 @@ export const FilamentShow: React.FC<IResourceComponentsProps> = () => {
       <Title level={5}>{t("filament.fields.name")}</Title>
       <TextField value={record?.name} />
       <Title level={5}>{t("filament.fields.color_hex")}</Title>
-      {colorObj && <SpoolIcon color={colorObj} size="large" />}
+      {colorObj && <SpoolIcon color={colorObj} size="large" no_margin />}
       {record?.color_hex && <TextField value={`#${record?.color_hex}`} />}
       <Title level={5}>{t("filament.fields.material")}</Title>
       <TextField value={record?.material} />

--- a/client/src/pages/spools/show.tsx
+++ b/client/src/pages/spools/show.tsx
@@ -146,7 +146,8 @@ export const SpoolShow: React.FC<IResourceComponentsProps> = () => {
       <Title level={5}>{t("spool.fields.id")}</Title>
       <NumberField value={record?.id ?? ""} />
       <Title level={5}>{t("spool.fields.filament")}</Title>
-      {colorObj && <SpoolIcon color={colorObj} />} <TextField value={record ? filamentURL(record?.filament) : ""} />
+      {colorObj && <SpoolIcon color={colorObj} size="large" no_margin />}
+      <TextField value={record ? filamentURL(record?.filament) : ""} />
       <Title level={5}>{t("spool.fields.price")}</Title>
       <NumberField
         value={record ? spoolPrice(record) : ""}


### PR DESCRIPTION
Hello!

This PR enhances the user experience for tools like HueForge by displaying color codes directly beneath the color icon for single-color filaments. This addition makes it easier for users to access and utilize color information without additional steps.

Thanks for considering this improvement!