### PR TITLE
Do not ignore empty lists in database selects

### DIFF
--- a/spoolman/database/utils.py
+++ b/spoolman/database/utils.py
@@ -126,6 +126,6 @@ def add_where_clause_int_in(
     value: Optional[Sequence[T]],
 ) -> Select:
     """Add a where clause to a select statement for a field."""
-    if value is not None and len(value) > 0:
+    if value is not None:
         stmt = stmt.where(field.in_(value))
     return stmt


### PR DESCRIPTION
This change resolves issue #590 .

If a where clause checks whether a value is in an empty list, it should not be ignored because it means no results should be returned.