### PR TITLE
Add external DB support for prices

### DIFF
--- a/client/src/components/filamentImportModal.tsx
+++ b/client/src/components/filamentImportModal.tsx
@@ -2,6 +2,7 @@ import { useTranslate } from "@refinedev/core";
 import { Form, Modal, Select } from "antd";
 import { Trans } from "react-i18next";
 import { formatFilamentLabel } from "../pages/spools/functions";
+import { useCurrency } from "../utils/settings";
 import { searchMatches } from "../utils/filtering";
 import { ExternalFilament, useGetExternalDBFilaments } from "../utils/queryExternalDB";
 
@@ -13,7 +14,9 @@ export function FilamentImportModal(props: {
   const [form] = Form.useForm();
   const t = useTranslate();
 
-  const externalFilaments = useGetExternalDBFilaments();
+  const currency = useCurrency();
+  
+  const externalFilaments = useGetExternalDBFilaments(currency);
   const filamentOptions =
     externalFilaments.data?.map((item) => {
       return {

--- a/client/src/pages/filaments/create.tsx
+++ b/client/src/pages/filaments/create.tsx
@@ -79,6 +79,7 @@ export const FilamentCreate: React.FC<IResourceComponentsProps & CreateOrClonePr
       name: filament.name,
       vendor_id: vendor.id,
       material: filament.material,
+      price: filament.price,
       density: filament.density,
       diameter: filament.diameter,
       weight: filament.weight,

--- a/client/src/pages/filaments/functions.ts
+++ b/client/src/pages/filaments/functions.ts
@@ -24,6 +24,7 @@ export async function createFilamentFromExternal(externalFilament: ExternalFilam
     name: externalFilament.name,
     material: externalFilament.material,
     vendor_id: vendor.id,
+    price: externalFilament.price,
     density: externalFilament.density,
     diameter: externalFilament.diameter,
     weight: externalFilament.weight,

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -78,7 +78,7 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
     internalSelectOptions,
     externalSelectOptions,
     allExternalFilaments,
-  } = useGetFilamentSelectOptions();
+  } = useGetFilamentSelectOptions(currency);
 
   const selectedFilamentID = Form.useWatch("filament_id", form);
   const selectedFilament = useMemo(() => {
@@ -147,8 +147,12 @@ export const SpoolCreate: React.FC<IResourceComponentsProps & CreateOrCloneProps
   const [usedWeight, setUsedWeight] = useState(0);
 
   useEffect(() => {
+    const newFilamentPrice = selectedFilament?.price || 0;
     const newFilamentWeight = selectedFilament?.weight || 0;
     const newSpoolWeight = selectedFilament?.spool_weight || 0;
+    if (newFilamentPrice > 0) {
+      form.setFieldValue("price", newFilamentPrice);
+    }
     if (newFilamentWeight > 0) {
       form.setFieldValue("initial_weight", newFilamentWeight);
     }

--- a/client/src/pages/spools/edit.tsx
+++ b/client/src/pages/spools/edit.tsx
@@ -76,7 +76,7 @@ export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
     internalSelectOptions,
     externalSelectOptions,
     allExternalFilaments,
-  } = useGetFilamentSelectOptions();
+  } = useGetFilamentSelectOptions(currency);
 
   const selectedFilamentID = Form.useWatch("filament_id", form);
   const selectedFilament = useMemo(() => {

--- a/client/src/pages/spools/functions.tsx
+++ b/client/src/pages/spools/functions.tsx
@@ -98,18 +98,19 @@ export function formatFilamentLabel(
 interface SelectOption {
   label: string;
   value: string | number;
+  price?: number;
   weight?: number;
   spool_weight?: number;
   is_internal: boolean;
 }
 
-export function useGetFilamentSelectOptions() {
+export function useGetFilamentSelectOptions(currency: string) {
   // Setup hooks
   const t = useTranslate();
   const { queryResult: internalFilaments } = useSelect<IFilament>({
     resource: "filament",
   });
-  const externalFilaments = useGetExternalDBFilaments();
+  const externalFilaments = useGetExternalDBFilaments(currency);
 
   // Format and sort internal filament options
   const filamentSelectInternal: SelectOption[] = useMemo(() => {
@@ -148,6 +149,7 @@ export function useGetFilamentSelectOptions() {
           ),
           value: item.id,
           weight: item.weight,
+          price: item.price,
           spool_weight: item.spool_weight || undefined,
           is_internal: false,
         };

--- a/client/src/utils/queryExternalDB.ts
+++ b/client/src/utils/queryExternalDB.ts
@@ -27,6 +27,8 @@ export interface ExternalFilament {
   manufacturer: string;
   name: string;
   material: string;
+  prices: { [key: string]: number}
+  price?: number,
   density: number;
   weight: number;
   spool_weight?: number;
@@ -50,7 +52,7 @@ export interface ExternalMaterial {
   bed_temp: number | null;
 }
 
-export function useGetExternalDBFilaments() {
+export function useGetExternalDBFilaments(currency: string) {
   return useQuery<ExternalFilament[]>({
     queryKey: ["external", "filaments"],
     staleTime: 60,
@@ -58,6 +60,10 @@ export function useGetExternalDBFilaments() {
       const response = await fetch(`${getAPIURL()}/external/filament`);
       return response.json();
     },
+    select: data => data.map(fil => { // Set price to current currency
+      fil.price = fil.prices?.[currency]; 
+      return (fil as ExternalFilament); 
+    })
   });
 }
 

--- a/spoolman/externaldb.py
+++ b/spoolman/externaldb.py
@@ -60,6 +60,7 @@ class ExternalFilament(BaseModel):
     manufacturer: str = Field(description="Filament manufacturer.", examples=["Polymaker"])
     name: str = Field(description="Filament name.", examples=["Polysonic\u2122 Black"])
     material: str = Field(description="Filament material.", examples=["PLA"])
+    prices: Optional[dict[str, float]] = Field(description="Prices.", examples=["PLA"])
     density: float = Field(description="Density in g/cm3.", examples=[1.23])
     weight: float = Field(description="Net weight of a single spool.", examples=[1000])
     spool_weight: Optional[float] = Field(default=None, description="Weight of an empty spool.", examples=[140])


### PR DESCRIPTION
Requires [SpoolmanDB support](https://github.com/Donkie/SpoolmanDB/pull/108) to work, you can temporarily point at my file for testing (https://dave-lang.github.io/SpoolmanDB/) in `spoolman/externaldb.py`

I don't particularly like having to pass around the currency but didn't want to implement a full application state just for this.

I considered implementing it into the API but it would have required changing from using stored files to either:
- Only storing the current currency when caching the DB, it would need to refetch after currency change
- Parsing and filtering the stored JSON at API request time, much slower than the current method.

If this solution is too clunky, I'm open to implementing one of those instead.
