### PR TITLE
Allow disabling access log with uvicorn's `--no-access-log`

### DIFF
--- a/spoolman/main.py
+++ b/spoolman/main.py
@@ -37,9 +37,11 @@ logging.getLogger("uvicorn").addHandler(console_handler)
 logging.getLogger("uvicorn.error").setLevel(log_level)
 logging.getLogger("uvicorn.error").addHandler(console_handler)
 
-logging.getLogger("uvicorn.access").setLevel(log_level)
-logging.getLogger("uvicorn.access").removeHandler(logging.getLogger("uvicorn.access").handlers[0])
-logging.getLogger("uvicorn.access").addHandler(console_handler)
+access_handlers = logging.getLogger("uvicorn.access").handlers
+if access_handlers:
+    logging.getLogger("uvicorn.access").setLevel(log_level)
+    logging.getLogger("uvicorn.access").removeHandler(access_handlers[0])
+    logging.getLogger("uvicorn.access").addHandler(console_handler)
 
 # Get logger instance for this module
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Trying to disable the access logs with uvicorn's `--no-access-log` results in an exception being raised during startup:

```usermod: no changes
User UID: 1000
User GID: 1000
Starting uvicorn...
Traceback (most recent call last):
  File "/home/app/spoolman/.venv/bin/uvicorn", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/main.py", line 412, in main
    run(
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/main.py", line 579, in run
    server.run()
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/server.py", line 65, in run
    return asyncio.run(self.serve(sockets=sockets))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/server.py", line 69, in serve
    await self._serve(sockets)
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/server.py", line 76, in _serve
    config.load()
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/config.py", line 434, in load
    self.loaded_app = import_from_string(self.app)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/app/spoolman/.venv/lib/python3.11/site-packages/uvicorn/importer.py", line 19, in import_from_string
    module = importlib.import_module(module_str)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1206, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1149, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/app/spoolman/spoolman/main.py", line 41, in <module>
    logging.getLogger("uvicorn.access").removeHandler(logging.getLogger("uvicorn.access").handlers[0])
                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Checking if the access logs are being handled first allows spoolman to still fix the logging when using access logs.