### PR TITLE
Add SPOOLMAN_CORS_ORIGIN variable

### DIFF
--- a/spoolman/env.py
+++ b/spoolman/env.py
@@ -210,6 +210,35 @@ def is_debug_mode() -> bool:
         return True
     raise ValueError(f"Failed to parse SPOOLMAN_DEBUG_MODE variable: Unknown debug mode '{debug_mode}'.")
 
+def is_cors_defined() -> bool:
+    """Get whether CORS is enabled from environment variables.
+
+    Returns False if no environment variable was set for CORS.
+    Returns True otherwise
+
+    Returns:
+        bool: Whether CORS is enabled.
+
+    """
+    cors = os.getenv("SPOOLMAN_CORS_ORIGIN", "FALSE").upper()
+    if cors in {"FALSE", "0"}:
+        return False
+    else:
+        return True
+
+def get_cors_origin() -> Optional[list[str]]:
+    """Get the CORS origin from environment variables.
+
+    Returns None if no environment variable was set for the origin.
+
+    Returns:
+        Optional[str]: The origin.
+
+    """
+    cors = os.getenv("SPOOLMAN_CORS_ORIGIN")
+    if cors is None:
+        return None
+    return cors.split(",")
 
 def is_automatic_backup_enabled() -> bool:
     """Get whether automatic backup is enabled from environment variables.

--- a/spoolman/main.py
+++ b/spoolman/main.py
@@ -101,12 +101,16 @@ window.SPOOLMAN_BASE_PATH = "{base_path}";
 app.mount(base_path, app=SinglePageApplication(directory="client/dist", base_path=env.get_base_path()))
 
 # Allow all origins if in debug mode
-if env.is_debug_mode():
-    logger.warning("Running in debug mode, allowing all origins.")
+if env.is_debug_mode() or env.is_cors_defined():
+    if(env.is_cors_defined()):
+        origins = env.get_cors_origin()
+    else:
+        origins = ["*"]
+        logger.warning("Running in debug mode, allowing all origins.")
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],


### PR DESCRIPTION
Add the ability to have CORS origin set in a variable without having to setup the entire app in debug mode.

I have another app that's accessing Spoolman and needs CORS policy to be setup. I don't think this should need debug mode.