### PR TITLE
Bug Fix:  Ensure the QR code favicon.svg honors the base path, when configured.

### DIFF
--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -1,3 +1,4 @@
+import { getBasePath } from "../../utils/url";
 import { useTranslate } from "@refinedev/core";
 import { Col, Form, InputNumber, QRCode, Radio, RadioChangeEvent, Row, Slider, Switch, Typography } from "antd";
 import { QRCodePrintSettings } from "./printing";
@@ -47,7 +48,7 @@ const QRCodePrintingDialog: React.FC<QRCodePrintingDialogProps> = ({
           <div className="print-qrcode-container">
             <QRCode
               className="print-qrcode"
-              icon={showQRCodeMode === "withIcon" ? "/favicon.svg" : undefined}
+              icon={showQRCodeMode === "withIcon" ? getBasePath() + "/favicon.svg" : undefined}
               value={item.value}
               errorLevel={item.errorLevel}
               type="svg"

--- a/client/src/pages/spools/show.tsx
+++ b/client/src/pages/spools/show.tsx
@@ -1,3 +1,4 @@
+import { getBasePath } from "../../utils/url";
 import { InboxOutlined, PrinterOutlined, ToTopOutlined } from "@ant-design/icons";
 import { DateField, NumberField, Show, TextField } from "@refinedev/antd";
 import { IResourceComponentsProps, useInvalidate, useShow, useTranslate } from "@refinedev/core";
@@ -118,7 +119,7 @@ export const SpoolShow: React.FC<IResourceComponentsProps> = () => {
           <Button
             type="primary"
             icon={<PrinterOutlined />}
-            href={"/spool/print?spools=" + record?.id + "&return=" + encodeURIComponent(window.location.pathname)}
+            href={getBasePath() + "/spool/print?spools=" + record?.id + "&return=" + encodeURIComponent(window.location.pathname)}
           >
             {t("printing.qrcode.button")}
           </Button>


### PR DESCRIPTION
I noticed when playing around the with the label feature that there was an empty square in the center of the QR code.  After debugging, I found that the code was referring to favicon.svg without including the base path.  This fixes that.