### PR TITLE
Reset multi-color when single color is selected

### DIFF
--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -63,6 +63,9 @@ export const FilamentEdit: React.FC<IResourceComponentsProps> = () => {
   const originalOnFinish = formProps.onFinish;
   formProps.onFinish = (allValues: IFilamentParsedExtras) => {
     if (allValues !== undefined && allValues !== null) {
+      if (colorType == "single") {
+        allValues.multi_color_hexes = '';
+      }
       // Lot of stupidity here to make types work
       const stringifiedAllValues = StringifiedExtras<IFilamentParsedExtras>(allValues);
       originalOnFinish?.({


### PR DESCRIPTION
Ensures that when saving changes to a Filament, we reset the `multi_color_hexes` if the user had set `colorType === "single"`.

Fixes #648 