### PR TITLE
Include the incremental weight consumption in the web-socket spool_changed messages

### DIFF
--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -437,7 +437,7 @@ async def find_lot_numbers(
     return [row[0] for row in rows.all() if row[0] is not None]
 
 
-async def spool_changed(spool: models.Spool, typ: EventType, delta: Optional[dict]) -> None:
+async def spool_changed(spool: models.Spool, typ: EventType, delta: Optional[dict] = None) -> None:
     """Notify websocket clients that a spool has changed."""
     try:
         spool = Spool.from_db(spool)


### PR DESCRIPTION
I implemented this additional change to the spool_changed event to have a solution for the following problem. Maybe it is useful for others as well who want to get notified about the actual spool consumption.

## Problem

I need to track the consumption - in weight - of spools in real time and I need to have the deltas without keeping the previous state. 

## Solution

I added the delta in weight (`weight_decrement`) as an extra information (under  `event_extra`) to the data sent by the spool_changed websocket message. 

## Rationale
Placing this data under extra information does not seem to break anything and works for my purpose, although adding the delta in weight to the standard SpoolEvent attributes would be a cleaner and more intuitive solution.