### PR TITLE
Fix Spool Edit page Empty Weight and Initial Weight bug

### DIFF
--- a/client/src/pages/spools/edit.tsx
+++ b/client/src/pages/spools/edit.tsx
@@ -131,8 +131,8 @@ export const SpoolEdit: React.FC<IResourceComponentsProps> = () => {
   const [usedWeight, setUsedWeight] = useState(0);
 
   useEffect(() => {
-    const newFilamentWeight = selectedFilament?.weight || 0;
-    const newSpoolWeight = selectedFilament?.spool_weight || 0;
+    const newFilamentWeight = getFilamentWeight();
+    const newSpoolWeight = getSpoolWeight();
     if (newFilamentWeight > 0) {
       form.setFieldValue("initial_weight", newFilamentWeight);
     }


### PR DESCRIPTION
This work fixes #477 by defaulting to spool values first.

First foray into TypeScript after a long stretch away from React/JSX so I'm very open to addressing any style/best-practice issues.

After digging in locally, I noticed the issue appeared to be related to the useEffect hook at [edit.tsx#L133](https://github.com/Donkie/Spoolman/blob/8af6013331757b9210ac8e77498ecbcf386086a0/client/src/pages/spools/edit.tsx#L133). Upon loading the page it would initialize the form with the values from the selected filament, without first checking to see if there were already values present.

To resolve the issue I took advantage of the already defined `getSpoolWeight()` and `getFilamentWeight()` functions which already implement the desired behavior by returning the spool values, then filament values when the spool values are undefined, and finally falling back to 0.