### PR TITLE
Reduce Docker container size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,30 +34,15 @@ COPY --chown=app:app README.md /home/app/spoolman/
 
 FROM python:3.12-slim-bookworm AS python-runner
 
-RUN apt-get update && apt-get install -y \
-    curl uvicorn \
-    && apt-get clean
-
 LABEL org.opencontainers.image.source=https://github.com/Donkie/Spoolman
 LABEL org.opencontainers.image.description="Keep track of your inventory of 3D-printer filament spools."
 LABEL org.opencontainers.image.licenses=MIT
 
-# Install latest su-exec
-RUN set -ex; \
-    \
-    curl -o /usr/local/bin/su-exec.c https://raw.githubusercontent.com/ncopa/su-exec/master/su-exec.c; \
-    \
-    fetch_deps='gcc libc-dev'; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends $fetch_deps; \
-    rm -rf /var/lib/apt/lists/*; \
-    gcc -Wall \
-    /usr/local/bin/su-exec.c -o/usr/local/bin/su-exec; \
-    chown root:root /usr/local/bin/su-exec; \
-    chmod 0755 /usr/local/bin/su-exec; \
-    rm /usr/local/bin/su-exec.c; \
-    \
-    apt-get purge -y --auto-remove $fetch_deps
+# Install gosu for privilege dropping
+RUN apt-get update && apt-get install -y \
+    gosu \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Add local user so we don't run as root
 RUN groupmod -g 1000 users \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,4 +14,4 @@ echo User GID: $(id -g app)
 echo "Starting uvicorn..."
 
 # Execute the uvicorn command with any additional arguments
-exec su-exec "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
+exec gosu "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:4bd60f905c3a76c3818c8d812784be141f10cedb41534379bb2ea40723ee9469"
+content_hash = "sha256:6f14f971b1a5dd3a5a1c02b64c467d1ab5060c7614aef64807f5ce5ee8415fd5"
 
 [[metadata.targets]]
 requires_python = ">=3.9,<=3.12"
@@ -1177,7 +1177,7 @@ version = "0.21.0"
 requires_python = ">=3.8.0"
 summary = "Fast implementation of asyncio event loop on top of libuv"
 groups = ["default"]
-marker = "platform_machine != \"armv7l\" and (sys_platform != \"win32\" and sys_platform != \"cygwin\") and platform_python_implementation != \"PyPy\""
+marker = "(sys_platform != \"win32\" and sys_platform != \"cygwin\") and platform_machine != \"armv7l\" and platform_python_implementation != \"PyPy\""
 files = [
     {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ec7e6b09a6fdded42403182ab6b832b71f4edaf7f37a9a0e371a01db5f0cb45f"},
     {file = "uvloop-0.21.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:196274f2adb9689a289ad7d65700d37df0c0930fd8e4e743fa4834e850d7719d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "httpx~=0.28",
     "hishel~=0.1",
 ]
-requires-python = ">=3.9,<=3.12"
+requires-python = ">=3.9,<3.13"
 
 [project.license]
 text = "MIT"


### PR DESCRIPTION
These changes optimize  the size of the docker container based on #745

Before with `python:3.12-bookwom`: ~1.09 GB

After the changes: ~276 MB

### How I've tested it:
1. Installed client npm dependencies and built client in project with production api environment
2. Created a `docker-compose.yml` in project root folder to build/test the local spoolman image
3. Tested Dockerfile changes via `docker-compose build`
4. Started container via `docker-compose up -d` and made some user tests within the web client

#### My local docker-compose.yml as reference
```
version: '3.8'
services:
  spoolman:
    image: spoolman
    container_name: spoolman
    restart: unless-stopped
    volumes:
      # Mount the host machine's ./data directory into the container's /home/app/.local/share/spoolman directory
      - ./data:/home/app/.local/share/spoolman
    ports:
      # Map the host machine's port 7912 to the container's port 8000
      - "7912:8000"
    environment:
      - TZ=Europe/Stockholm # Optional, defaults to UTC
    build:
      context: .
      target: python-runner
``