### PR TITLE
All caps short QR codes for alphanumerical encoding

### DIFF
--- a/client/src/components/qrCodeScanner.tsx
+++ b/client/src/components/qrCodeScanner.tsx
@@ -13,12 +13,12 @@ const QRCodeScannerModal: React.FC = () => {
 
   const onScan = (result: string) => {
     // Check for the spoolman ID format
-    const match = result.match(/^web\+spoolman:s-(?<id>[0-9]+)$/);
+    const match = result.match(/^web\+spoolman:s-(?<id>[0-9]+)$/i);
     if (match && match.groups) {
       setVisible(false);
       navigate(`/spool/show/${match.groups.id}`);
     }
-    const fullURLmatch = result.match(/^https?:\/\/[^/]+\/spool\/show\/(?<id>[0-9]+)$/);
+    const fullURLmatch = result.match(/^https?:\/\/[^/]+\/spool\/show\/(?<id>[0-9]+)$/i);
     if (fullURLmatch && fullURLmatch.groups) {
       setVisible(false);
       navigate(`/spool/show/${fullURLmatch.groups.id}`);

--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -110,7 +110,7 @@ const QRCodePrintingDialog: React.FC<QRCodePrintingDialogProps> = ({
                 </Radio.Group>
               </Form.Item>
               <Form.Item label={t("printing.qrcode.useHTTPUrl.preview")}>
-                <Text> {useHTTPUrl ? `${baseUrlRoot}/spool/show/{id}` : `web+spoolman:s-{id}`}</Text>
+                <Text> {useHTTPUrl ? `${baseUrlRoot}/spool/show/{id}` : `WEB+SPOOLMAN:S-{id}`}</Text>
               </Form.Item>
             </>
           )}

--- a/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
@@ -300,7 +300,7 @@ Spool Weight: {filament.spool_weight} g
           </>
         }
         items={items.map((spool) => ({
-          value: useHTTPUrl ? `${baseUrlRoot}/spool/show/${spool.id}` : `web+spoolman:s-${spool.id}`,
+          value: useHTTPUrl ? `${baseUrlRoot}/spool/show/${spool.id}` : `WEB+SPOOLMAN:S-${spool.id}`,
           label: (
             <p
               style={{


### PR DESCRIPTION
Related to Donkie/Spoolman#769

The current short form QR codes generates unnecessarily many data modules reducing printability on low resolution label printers. Replacing the `web+spoolman:s-` prefix with `WEB+SPOOLMAN:S-` automatically lets the QR code be encodes as Alphanumerical reducing the module count. 

The change also makes the QR code scanner match case insensitive to work with new uppercase and old lowercase QR codes as well as the long format with the full URL, so the change is backwards compatible. To further improve printability the error correction level needs to be either configurable or left at "H" for QR codes with icon and reduced to "Q" for QR codes without icons.
