### PR TITLE
Add conditional logic to drop permissions for unprivileged Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked --no-install-project
 
 # Copy and install app
-COPY --chown=app:app migrations /home/app/spoolman/migrations
-COPY --chown=app:app spoolman /home/app/spoolman/spoolman
-COPY --chown=app:app alembic.ini README.md uv.lock pyproject.toml /home/app/spoolman/
+COPY migrations /home/app/spoolman/migrations
+COPY spoolman /home/app/spoolman/spoolman
+COPY alembic.ini README.md uv.lock pyproject.toml /home/app/spoolman/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
@@ -45,7 +45,6 @@ RUN apt-get update && apt-get install -y \
 
 # Add local user so we don't run as root
 RUN useradd -u 1000 -U app \
-    && usermod -G users app \
     && mkdir -p /home/app/.local/share/spoolman \
     && chown -R app:app /home/app/.local/share/spoolman
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Add local user so we don't run as root
-RUN groupmod -g 1000 users \
-    && useradd -u 1000 -U app \
+RUN useradd -u 1000 -U app \
     && usermod -G users app \
     && mkdir -p /home/app/.local/share/spoolman \
     && chown -R app:app /home/app/.local/share/spoolman

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,8 @@ if [ "$(id -g app)" -ne "$PGID" ]; then
 fi
 
 if [ "$(id -u)" -eq 0 ]; then
-    exec gosu "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
-else
-    exec uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
+    exec gosu "app" "$0" "$@"
+    # NOT REACHABLE
 fi
+
+exec uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,23 @@ PGID=${PGID:-1000}
 SPOOLMAN_PORT=${SPOOLMAN_PORT:-8000}
 SPOOLMAN_HOST=${SPOOLMAN_HOST:-0.0.0.0}
 
-groupmod -o -g "$PGID" app
-usermod -o -u "$PUID" app
+fail() {
+    echo "$1" >&2
+    exit 1
+}
 
-echo User UID: $(id -u app)
-echo User GID: $(id -g app)
+if [ "$(id -u app)" -ne "$PUID" ]; then
+    usermod -o -u "$PUID" app ||
+        fail "Failed to update app UID to $PUID"
+fi
 
-echo "Starting uvicorn..."
+if [ "$(id -g app)" -ne "$PGID" ]; then
+    groupmod -o -g "$PGID" app ||
+        fail "Failed to update app GID to $PGID"
+fi
 
-# Execute the uvicorn command with any additional arguments
-exec gosu "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
+if [ "$(id -u)" -eq 0 ]; then
+    exec gosu "app" uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
+else
+    exec uvicorn spoolman.main:app --host $SPOOLMAN_HOST --port $SPOOLMAN_PORT "$@"
+fi


### PR DESCRIPTION
This change enables the container to run in unprivileged mode (without --privileged or additional capabilities) by making permission drops conditional:

- Changed users group GID from 1000 to 1001 to avoid conflicts with the app user's primary group (UID 1000)
- Only modify user/group IDs when PUID/PGID environment variables differ from the default value of 1000, avoiding unnecessary privilege requirements
- Skip su-exec entirely when running as the default user, since changing user context requires additional capabilities that unprivileged containers don't have

This allows the container to work in restricted environments like Kubernetes with security contexts or rootless Docker while maintaining backward compatibility for users who customize PUID/PGID.

Fixes #791