### PR TITLE
explicitly disable pagination for useSelect

### DIFF
--- a/client/src/pages/filaments/create.tsx
+++ b/client/src/pages/filaments/create.tsx
@@ -64,6 +64,7 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
   const { selectProps: vendorSelect } = useSelect<IVendor>({
     resource: "vendor",
     optionLabel: "name",
+    pagination: { mode: "off" },
   });
 
   const importFilament = async (filament: ExternalFilament) => {

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -40,6 +40,7 @@ export const FilamentEdit = () => {
   const { selectProps } = useSelect<IVendor>({
     resource: "vendor",
     optionLabel: "name",
+    pagination: { mode: "off" },
   });
 
   // Add the vendor_id field to the form

--- a/client/src/pages/spools/functions.tsx
+++ b/client/src/pages/spools/functions.tsx
@@ -128,6 +128,7 @@ export function useGetFilamentSelectOptions() {
   const t = useTranslate();
   const { query: internalFilaments } = useSelect<IFilament>({
     resource: "filament",
+    pagination: { mode: "off" },
   });
   const externalFilaments = useGetExternalDBFilaments();
 


### PR DESCRIPTION
It seems that v5 of `@refinedev/core` changed the default pagination setting from [off](https://github.com/refinedev/refine/blob/%40refinedev/core%404.58.0/packages/core/src/definitions/helpers/handlePaginationParams/index.ts#L15) to [server](https://github.com/refinedev/refine/blob/%40refinedev/core%405.0.8/packages/core/src/definitions/helpers/handlePaginationParams/index.ts#L10), so with the version bump in spoolman `v0.23.0`, it only fetches the first 10 filaments from the server when adding a spool.

resolves #827