### PR TITLE
Update table scroll and style for responsiveness

### DIFF
--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -126,7 +126,9 @@ const SpoolSelectModal = ({ description, onContinue }: Props) => {
           tableLayout="auto"
           dataSource={dataSource}
           pagination={false}
-          scroll={{ y: 200 }}
+          // Use a viewport-based height so the table scales with the browser window
+          scroll={{ y: "60vh" }}
+          style={{ maxHeight: "70vh" }}
           columns={removeUndefined([
             {
               width: 50,


### PR DESCRIPTION
Changed table scroll height to be viewport-based and set max height. The original behavior shows only 4 rows per page.