### PR TITLE
feat(printing): filament label printing foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Add filament label printing with separate presets, QR codes, and filament QR scanning support.

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -107,6 +107,7 @@
             "title": "Label Printing",
             "template": "Label Template",
             "templateHelp": "Use {} to insert values of the spool object as text. For example, {id} will be replaced with the spool id, or {filament.material} will be replaced with the material of the spool. if a value is missing it will be replaced with \"?\". A second set of {} can be used to remove this. In addition, any text between the sets of {} will be removed if the value is missing. For example, {Lot Nr: {lot_nr}} will only show the label if the spool has a lot number. Enclose text with double asterix ** to make it bold. Click the button to view a list of all available tags.",
+            "templateHelpFilament": "Use {} to insert values of the filament object as text. For example, {id} will be replaced with the filament id, or {vendor.name} will be replaced with the vendor name. If a value is missing it will be replaced with \"?\". A second set of {} can be used to remove this. In addition, any text between the sets of {} will be removed if the value is missing. For example, {Article: {article_number}} will only show the label if a filament has an article number. Enclose text with double asterix ** to make it bold. Click the button to view a list of all available tags.",
             "textSize": "Label Text Size",
             "showContent": "Print Label",
             "useHTTPUrl": {
@@ -133,6 +134,14 @@
             "selectAll": "Select/Unselect All",
             "selectedTotal_one": "{{count}} spool selected",
             "selectedTotal_other": "{{count}} spools selected"
+        },
+        "filamentSelect": {
+            "title": "Select Filaments",
+            "description": "Select filaments to print labels for.",
+            "noFilamentsSelected": "You have not selected any filaments.",
+            "selectAll": "Select/Unselect All",
+            "selectedTotal_one": "{{count}} filament selected",
+            "selectedTotal_other": "{{count}} filaments selected"
         }
     },
     "scanner": {

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -104,6 +104,8 @@
         },
         "qrcode": {
             "button": "Print Labels",
+            "printFilamentTitle": "Print Filament Labels",
+            "printSpoolTitle": "Print Spool Labels",
             "title": "Label Printing",
             "template": "Label Template",
             "templateHelp": "Use {} to insert values of the spool object as text. For example, {id} will be replaced with the spool id, or {filament.material} will be replaced with the material of the spool. if a value is missing it will be replaced with \"?\". A second set of {} can be used to remove this. In addition, any text between the sets of {} will be removed if the value is missing. For example, {Lot Nr: {lot_nr}} will only show the label if the spool has a lot number. Enclose text with double asterix ** to make it bold. Click the button to view a list of all available tags.",

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -104,6 +104,7 @@
         },
         "qrcode": {
             "button": "Print Labels",
+            "exportButton": "Export Labels",
             "printFilamentTitle": "Print Filament Labels",
             "printSpoolTitle": "Print Spool Labels",
             "title": "Label Printing",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -208,6 +208,7 @@ function App() {
                     />
                     <Route path="edit/:id" element={<LoadableResourcePage resource="filaments" page="edit" />} />
                     <Route path="show/:id" element={<LoadableResourcePage resource="filaments" page="show" />} />
+                    <Route path="print" element={<LoadablePage name="filamentPrinting" />} />
                   </Route>
                   <Route path="/vendor">
                     <Route index element={<LoadableResourcePage resource="vendors" page="list" />} />

--- a/client/src/components/qrCodeScanner.tsx
+++ b/client/src/components/qrCodeScanner.tsx
@@ -18,15 +18,28 @@ const QRCodeScannerModal = () => {
     const result = detectedCodes[0].rawValue;
 
     // Check for the spoolman ID format
-    const match = result.match(/^web\+spoolman:s-(?<id>[0-9]+)$/i);
-    if (match && match.groups) {
+    const spoolMatch = result.match(/^web\+spoolman:s-(?<id>[0-9]+)$/i);
+    if (spoolMatch && spoolMatch.groups) {
       setVisible(false);
-      navigate(`/spool/show/${match.groups.id}`);
+      navigate(`/spool/show/${spoolMatch.groups.id}`);
+      return;
     }
-    const fullURLmatch = result.match(/^https?:\/\/[^/]+\/spool\/show\/(?<id>[0-9]+)$/i);
-    if (fullURLmatch && fullURLmatch.groups) {
+    const filamentMatch = result.match(/^web\+spoolman:f-(?<id>[0-9]+)$/i);
+    if (filamentMatch && filamentMatch.groups) {
       setVisible(false);
-      navigate(`/spool/show/${fullURLmatch.groups.id}`);
+      navigate(`/filament/show/${filamentMatch.groups.id}`);
+      return;
+    }
+    const spoolURLmatch = result.match(/^https?:\/\/[^/]+(?:\/[^/]+)*\/spool\/show\/(?<id>[0-9]+)$/i);
+    if (spoolURLmatch && spoolURLmatch.groups) {
+      setVisible(false);
+      navigate(`/spool/show/${spoolURLmatch.groups.id}`);
+      return;
+    }
+    const filamentURLmatch = result.match(/^https?:\/\/[^/]+(?:\/[^/]+)*\/filament\/show\/(?<id>[0-9]+)$/i);
+    if (filamentURLmatch && filamentURLmatch.groups) {
+      setVisible(false);
+      navigate(`/filament/show/${filamentURLmatch.groups.id}`);
     }
   };
 

--- a/client/src/pages/filamentPrinting/index.tsx
+++ b/client/src/pages/filamentPrinting/index.tsx
@@ -1,0 +1,71 @@
+import { PageHeader } from "@refinedev/antd";
+import { useTranslate } from "@refinedev/core";
+import { theme } from "antd";
+import { Content } from "antd/es/layout/layout";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { useNavigate, useSearchParams } from "react-router";
+import FilamentQRCodePrintingDialog from "../printing/filamentQrCodePrintingDialog";
+import FilamentSelectModal from "../printing/filamentSelectModal";
+
+dayjs.extend(utc);
+
+const { useToken } = theme;
+
+export const FilamentPrinting = () => {
+  const { token } = useToken();
+  const t = useTranslate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const filamentIds = searchParams.getAll("filaments").map(Number);
+  const step = filamentIds.length > 0 ? 1 : 0;
+
+  return (
+    <>
+      <PageHeader
+        title={t("printing.qrcode.button")}
+        onBack={() => {
+          const returnUrl = searchParams.get("return");
+          if (returnUrl) {
+            navigate(returnUrl, { relative: "path" });
+          } else {
+            navigate("/filament");
+          }
+        }}
+      >
+        <Content
+          style={{
+            padding: 20,
+            minHeight: 280,
+            margin: "0 auto",
+            backgroundColor: token.colorBgContainer,
+            borderRadius: token.borderRadiusLG,
+            color: token.colorText,
+            fontFamily: token.fontFamily,
+            fontSize: token.fontSizeLG,
+            lineHeight: 1.5,
+          }}
+        >
+          {step === 0 && (
+            <FilamentSelectModal
+              description={t("printing.filamentSelect.description")}
+              onContinue={(filaments) => {
+                setSearchParams((prev) => {
+                  const newParams = new URLSearchParams(prev);
+                  newParams.delete("filaments");
+                  filaments.forEach((filament) => newParams.append("filaments", filament.id.toString()));
+                  newParams.set("return", "/filament/print");
+                  return newParams;
+                });
+              }}
+            />
+          )}
+          {step === 1 && <FilamentQRCodePrintingDialog filamentIds={filamentIds} />}
+        </Content>
+      </PageHeader>
+    </>
+  );
+};
+
+export default FilamentPrinting;

--- a/client/src/pages/filamentPrinting/index.tsx
+++ b/client/src/pages/filamentPrinting/index.tsx
@@ -50,7 +50,7 @@ export const FilamentPrinting = () => {
           {step === 0 && (
             <FilamentSelectModal
               description={t("printing.filamentSelect.description")}
-              onContinue={(selectedFilamentIds) => {
+              onPrint={(selectedFilamentIds: number[]) => {
                 setSearchParams((prev) => {
                   const newParams = new URLSearchParams(prev);
                   newParams.delete("filaments");

--- a/client/src/pages/filamentPrinting/index.tsx
+++ b/client/src/pages/filamentPrinting/index.tsx
@@ -24,7 +24,7 @@ export const FilamentPrinting = () => {
   return (
     <>
       <PageHeader
-        title={t("printing.qrcode.button")}
+        title={`${t("printing.qrcode.button")} (${t("filament.filament")})`}
         onBack={() => {
           const returnUrl = searchParams.get("return");
           if (returnUrl) {
@@ -50,11 +50,11 @@ export const FilamentPrinting = () => {
           {step === 0 && (
             <FilamentSelectModal
               description={t("printing.filamentSelect.description")}
-              onContinue={(filaments) => {
+              onContinue={(selectedFilamentIds) => {
                 setSearchParams((prev) => {
                   const newParams = new URLSearchParams(prev);
                   newParams.delete("filaments");
-                  filaments.forEach((filament) => newParams.append("filaments", filament.id.toString()));
+                  selectedFilamentIds.forEach((id) => newParams.append("filaments", id.toString()));
                   newParams.set("return", "/filament/print");
                   return newParams;
                 });

--- a/client/src/pages/filamentPrinting/index.tsx
+++ b/client/src/pages/filamentPrinting/index.tsx
@@ -24,7 +24,7 @@ export const FilamentPrinting = () => {
   return (
     <>
       <PageHeader
-        title={`${t("printing.qrcode.button")} (${t("filament.filament")})`}
+        title={t("printing.qrcode.printFilamentTitle")}
         onBack={() => {
           const returnUrl = searchParams.get("return");
           if (returnUrl) {

--- a/client/src/pages/filaments/functions.ts
+++ b/client/src/pages/filaments/functions.ts
@@ -1,3 +1,4 @@
+import { useQueries } from "@tanstack/react-query";
 import { ExternalFilament } from "../../utils/queryExternalDB";
 import { getAPIURL } from "../../utils/url";
 import { getOrCreateVendorFromExternal } from "../vendors/functions";
@@ -47,4 +48,25 @@ export async function createFilamentFromExternal(externalFilament: ExternalFilam
     throw new Error("Network response was not ok");
   }
   return response.json();
+}
+
+/**
+ * Returns an array of queries using the useQueries hook from @tanstack/react-query.
+ * Each query fetches a filament by its ID from the server.
+ *
+ * @param {number[]} ids - An array of filament IDs to fetch.
+ * @return An array of query results, each containing the fetched filament data.
+ */
+export function useGetFilamentsByIds(ids: number[]) {
+  return useQueries({
+    queries: ids.map((id) => {
+      return {
+        queryKey: ["filament", id],
+        queryFn: async () => {
+          const res = await fetch(getAPIURL() + "/filament/" + id);
+          return (await res.json()) as IFilament;
+        },
+      };
+    }),
+  });
 }

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -1,4 +1,11 @@
-import { EditOutlined, EyeOutlined, FileOutlined, FilterOutlined, PlusSquareOutlined } from "@ant-design/icons";
+import {
+  EditOutlined,
+  EyeOutlined,
+  FileOutlined,
+  FilterOutlined,
+  PlusSquareOutlined,
+  PrinterOutlined,
+} from "@ant-design/icons";
 import { List, useTable } from "@refinedev/antd";
 import { useInvalidate, useNavigation, useTranslate } from "@refinedev/core";
 import { Button, Dropdown, Table } from "antd";
@@ -169,6 +176,15 @@ export const FilamentList = () => {
     <List
       headerButtons={({ defaultButtons }) => (
         <>
+          <Button
+            type="primary"
+            icon={<PrinterOutlined />}
+            onClick={() => {
+              navigate("print");
+            }}
+          >
+            {t("printing.qrcode.button")}
+          </Button>
           <Button
             type="primary"
             icon={<FilterOutlined />}

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -1,5 +1,6 @@
 import { DateField, NumberField, Show, TextField } from "@refinedev/antd";
 import { useShow, useTranslate } from "@refinedev/core";
+import { PrinterOutlined } from "@ant-design/icons";
 import { Button, Typography } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -10,6 +11,7 @@ import SpoolIcon from "../../components/spoolIcon";
 import { enrichText } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { useCurrencyFormatter } from "../../utils/settings";
+import { getBasePath } from "../../utils/url";
 import { IFilament } from "./model";
 dayjs.extend(utc);
 
@@ -64,6 +66,19 @@ export const FilamentShow = () => {
         <>
           <Button type="primary" onClick={gotoSpools}>
             {t("filament.fields.spools")}
+          </Button>
+          <Button
+            type="primary"
+            icon={<PrinterOutlined />}
+            href={
+              getBasePath() +
+              "/filament/print?filaments=" +
+              record?.id +
+              "&return=" +
+              encodeURIComponent(window.location.pathname)
+            }
+          >
+            {t("printing.qrcode.button")}
           </Button>
           {defaultButtons}
         </>

--- a/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
@@ -5,7 +5,7 @@ import TextArea from "antd/es/input/TextArea";
 import { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { EntityType, useGetFields } from "../../utils/queryFields";
-import { useGetSetting } from "../../utils/querySettings";
+import { parseStringSettingValue, useGetSetting } from "../../utils/querySettings";
 import { useSavedState } from "../../utils/saveload";
 import { useGetFilamentsByIds } from "../filaments/functions";
 import { IFilament } from "../filaments/model";
@@ -26,10 +26,8 @@ interface FilamentQRCodePrintingDialogProps {
 const FilamentQRCodePrintingDialog = ({ filamentIds }: FilamentQRCodePrintingDialogProps) => {
   const t = useTranslate();
   const baseUrlSetting = useGetSetting("base_url");
-  const baseUrlRoot =
-    baseUrlSetting.data?.value !== undefined && JSON.parse(baseUrlSetting.data?.value) !== ""
-      ? JSON.parse(baseUrlSetting.data?.value)
-      : window.location.origin;
+  const baseUrl = parseStringSettingValue(baseUrlSetting.data?.value);
+  const baseUrlRoot = baseUrl !== "" ? baseUrl : window.location.origin;
   const [messageApi, contextHolder] = message.useMessage();
   const [useHTTPUrl, setUseHTTPUrl] = useSavedState("print-useHTTPUrl-filament", false);
 

--- a/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
@@ -203,8 +203,7 @@ const FilamentQRCodePrintingDialog = ({ filamentIds }: FilamentQRCodePrintingDia
       <QRCodePrintingDialog
         printSettings={curPreset.labelSettings}
         setPrintSettings={(newSettings) => {
-          curPreset.labelSettings = newSettings;
-          updateCurrentPreset(curPreset);
+          updateCurrentPreset({ ...curPreset, labelSettings: newSettings });
         }}
         baseUrlRoot={baseUrlRoot}
         useHTTPUrl={useHTTPUrl}
@@ -264,8 +263,15 @@ const FilamentQRCodePrintingDialog = ({ filamentIds }: FilamentQRCodePrintingDia
               <Input
                 value={curPreset.labelSettings.printSettings?.name}
                 onChange={(e) => {
-                  curPreset.labelSettings.printSettings.name = e.target.value;
-                  updateCurrentPreset(curPreset);
+                  // Triple-spread: name is 3 levels deep; each level must be copied to
+                  // avoid mutating the preset array element referenced by curPreset.
+                  updateCurrentPreset({
+                    ...curPreset,
+                    labelSettings: {
+                      ...curPreset.labelSettings,
+                      printSettings: { ...curPreset.labelSettings.printSettings, name: e.target.value },
+                    },
+                  });
                 }}
               />
             </Form.Item>
@@ -293,8 +299,7 @@ const FilamentQRCodePrintingDialog = ({ filamentIds }: FilamentQRCodePrintingDia
                 value={template}
                 rows={8}
                 onChange={(newValue) => {
-                  curPreset.template = newValue.target.value;
-                  updateCurrentPreset(curPreset);
+                  updateCurrentPreset({ ...curPreset, template: newValue.target.value });
                 }}
               />
             </Form.Item>

--- a/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/filamentQrCodePrintingDialog.tsx
@@ -7,8 +7,8 @@ import { v4 as uuidv4 } from "uuid";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { useGetSetting } from "../../utils/querySettings";
 import { useSavedState } from "../../utils/saveload";
-import { useGetSpoolsByIds } from "../spools/functions";
-import { ISpool } from "../spools/model";
+import { useGetFilamentsByIds } from "../filaments/functions";
+import { IFilament } from "../filaments/model";
 import {
   SpoolQRCodePrintSettings,
   renderLabelContents,
@@ -19,11 +19,11 @@ import QRCodePrintingDialog from "./qrCodePrintingDialog";
 
 const { Text } = Typography;
 
-interface SpoolQRCodePrintingDialog {
-  spoolIds: number[];
+interface FilamentQRCodePrintingDialogProps {
+  filamentIds: number[];
 }
 
-const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
+const FilamentQRCodePrintingDialog = ({ filamentIds }: FilamentQRCodePrintingDialogProps) => {
   const t = useTranslate();
   const baseUrlSetting = useGetSetting("base_url");
   const baseUrlRoot =
@@ -31,23 +31,23 @@ const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
       ? JSON.parse(baseUrlSetting.data?.value)
       : window.location.origin;
   const [messageApi, contextHolder] = message.useMessage();
-  const [useHTTPUrl, setUseHTTPUrl] = useSavedState("print-useHTTPUrl", false);
+  const [useHTTPUrl, setUseHTTPUrl] = useSavedState("print-useHTTPUrl-filament", false);
 
-  const itemQueries = useGetSpoolsByIds(spoolIds);
+  const itemQueries = useGetFilamentsByIds(filamentIds);
   const items = itemQueries
     .map((itemQuery) => {
       return itemQuery.data ?? null;
     })
-    .filter((item) => item !== null) as ISpool[];
+    .filter((item) => item !== null) as IFilament[];
 
-  // Selected preset state
-  const [selectedPresetState, setSelectedPresetState] = useSavedState<string | undefined>("selectedPreset", undefined);
+  const [selectedPresetState, setSelectedPresetState] = useSavedState<string | undefined>(
+    "selectedPresetFilament",
+    undefined,
+  );
 
-  // Keep a local copy of the settings which is what's actually displayed. Use the remote state only for saving.
-  // This decouples the debounce stuff from the UI
   const [localPresets, setLocalPresets] = useState<SpoolQRCodePrintSettings[] | undefined>();
-  const remotePresets = useGetPrintPresets();
-  const setRemotePresets = useSetPrintPresets();
+  const remotePresets = useGetPrintPresets("print_presets_filament");
+  const setRemotePresets = useSetPrintPresets("print_presets_filament");
 
   const localOrRemotePresets = localPresets ?? remotePresets;
 
@@ -56,7 +56,6 @@ const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
     setRemotePresets(localPresets);
   };
 
-  // Functions to update settings
   const addNewPreset = () => {
     if (!localOrRemotePresets) return;
     const newId = uuidv4();
@@ -98,10 +97,8 @@ const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
     setSelectedPresetState(undefined);
   };
 
-  // Initialize presets
   let curPreset: SpoolQRCodePrintSettings;
   if (localOrRemotePresets === undefined) {
-    // DB not loaded yet, use a temporary one
     curPreset = {
       labelSettings: {
         printSettings: {
@@ -111,33 +108,25 @@ const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
       },
     };
   } else {
-    // DB is loaded, find the selected setting
     if (localOrRemotePresets.length === 0) {
-      // DB loaded, but no settings found, add a new one and select it
       const newSetting = addNewPreset();
       if (!newSetting) {
         console.error("Error adding new setting, this should never happen");
         return;
       }
-
-      // Mutate the allPrintSettings list so that the rest of the UI will work fine
       localOrRemotePresets.push(newSetting);
       curPreset = newSetting;
     } else {
-      // DB loaded and at least 1 setting exists
       if (!selectedPresetState) {
-        // No setting has been selected, select the first one
         curPreset = localOrRemotePresets[0];
         setSelectedPresetState(localOrRemotePresets[0].labelSettings.printSettings.id);
       } else {
-        // A setting has been selected, find it
         const foundSetting = localOrRemotePresets.find(
           (settings) => settings.labelSettings.printSettings.id === selectedPresetState,
         );
         if (foundSetting) {
           curPreset = foundSetting;
         } else {
-          // Selected setting not found, select a temp one
           curPreset = {
             labelSettings: {
               printSettings: {
@@ -154,80 +143,59 @@ const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
   const [templateHelpOpen, setTemplateHelpOpen] = useState(false);
   const template =
     curPreset.template ??
-    `**{filament.vendor.name} - {filament.name}
-#{id} - {filament.material}**
-Spool Weight: {filament.spool_weight} g
-{ET: {filament.settings_extruder_temp} °C}
-{BT: {filament.settings_bed_temp} °C}
-{Lot Nr: {lot_nr}}
+    `**{vendor.name} - {name}
+#{id} - {material}**
+{Diameter: {diameter} mm}
+{Weight: {weight} g}
+{Spool Weight: {spool_weight} g}
+{ET: {settings_extruder_temp} °C}
+{BT: {settings_bed_temp} °C}
+{Article: {article_number}}
 {{comment}}
-{filament.comment}
-{filament.vendor.comment}`;
+{comment}
+{vendor.comment}`;
 
-  const spoolTags = [
+  const filamentTags = [
     { tag: "id" },
     { tag: "registered" },
-    { tag: "first_used" },
-    { tag: "last_used" },
+    { tag: "name" },
+    { tag: "material" },
     { tag: "price" },
-    { tag: "initial_weight" },
+    { tag: "density" },
+    { tag: "diameter" },
+    { tag: "weight" },
     { tag: "spool_weight" },
-    { tag: "remaining_weight" },
-    { tag: "used_weight" },
-    { tag: "remaining_length" },
-    { tag: "used_length" },
-    { tag: "location" },
-    { tag: "lot_nr" },
+    { tag: "article_number" },
     { tag: "comment" },
-    { tag: "archived" },
-  ];
-  const spoolFields = useGetFields(EntityType.spool);
-  if (spoolFields.data !== undefined) {
-    spoolFields.data.forEach((field) => {
-      spoolTags.push({ tag: `extra.${field.key}` });
-    });
-  }
-  const filamentTags = [
-    { tag: "filament.id" },
-    { tag: "filament.registered" },
-    { tag: "filament.name" },
-    { tag: "filament.material" },
-    { tag: "filament.price" },
-    { tag: "filament.density" },
-    { tag: "filament.diameter" },
-    { tag: "filament.weight" },
-    { tag: "filament.spool_weight" },
-    { tag: "filament.article_number" },
-    { tag: "filament.comment" },
-    { tag: "filament.settings_extruder_temp" },
-    { tag: "filament.settings_bed_temp" },
-    { tag: "filament.color_hex" },
-    { tag: "filament.multi_color_hexes" },
-    { tag: "filament.multi_color_direction" },
-    { tag: "filament.external_id" },
+    { tag: "settings_extruder_temp" },
+    { tag: "settings_bed_temp" },
+    { tag: "color_hex" },
+    { tag: "multi_color_hexes" },
+    { tag: "multi_color_direction" },
+    { tag: "external_id" },
   ];
   const filamentFields = useGetFields(EntityType.filament);
   if (filamentFields.data !== undefined) {
     filamentFields.data.forEach((field) => {
-      filamentTags.push({ tag: `filament.extra.${field.key}` });
+      filamentTags.push({ tag: `extra.${field.key}` });
     });
   }
   const vendorTags = [
-    { tag: "filament.vendor.id" },
-    { tag: "filament.vendor.registered" },
-    { tag: "filament.vendor.name" },
-    { tag: "filament.vendor.comment" },
-    { tag: "filament.vendor.empty_spool_weight" },
-    { tag: "filament.vendor.external_id" },
+    { tag: "vendor.id" },
+    { tag: "vendor.registered" },
+    { tag: "vendor.name" },
+    { tag: "vendor.comment" },
+    { tag: "vendor.empty_spool_weight" },
+    { tag: "vendor.external_id" },
   ];
   const vendorFields = useGetFields(EntityType.vendor);
   if (vendorFields.data !== undefined) {
     vendorFields.data.forEach((field) => {
-      vendorTags.push({ tag: `filament.vendor.extra.${field.key}` });
+      vendorTags.push({ tag: `vendor.extra.${field.key}` });
     });
   }
 
-  const templateTags = [...spoolTags, ...filamentTags, ...vendorTags];
+  const templateTags = [...filamentTags, ...vendorTags];
 
   return (
     <>
@@ -242,8 +210,8 @@ Spool Weight: {filament.spool_weight} g
         useHTTPUrl={useHTTPUrl}
         setUseHTTPUrl={setUseHTTPUrl}
         previewValues={{
-          default: "WEB+SPOOLMAN:S-{id}",
-          url: `${baseUrlRoot}/spool/show/{id}`,
+          default: "WEB+SPOOLMAN:F-{id}",
+          url: `${baseUrlRoot}/filament/show/{id}`,
         }}
         extraSettingsStart={
           <>
@@ -303,8 +271,8 @@ Spool Weight: {filament.spool_weight} g
             </Form.Item>
           </>
         }
-        items={items.map((spool) => ({
-          value: useHTTPUrl ? `${baseUrlRoot}/spool/show/${spool.id}` : `WEB+SPOOLMAN:S-${spool.id}`,
+        items={items.map((filament) => ({
+          value: useHTTPUrl ? `${baseUrlRoot}/filament/show/${filament.id}` : `WEB+SPOOLMAN:F-${filament.id}`,
           label: (
             <p
               style={{
@@ -313,7 +281,7 @@ Spool Weight: {filament.spool_weight} g
                 whiteSpace: "pre-wrap",
               }}
             >
-              {renderLabelContents(template, spool)}
+              {renderLabelContents(template, filament)}
             </p>
           ),
           errorLevel: "H",
@@ -341,7 +309,7 @@ Spool Weight: {filament.spool_weight} g
               />
             </Modal>
             <Text type="secondary">
-              {t("printing.qrcode.templateHelp")}{" "}
+              {t("printing.qrcode.templateHelpFilament")}{" "}
               <Button size="small" onClick={() => setTemplateHelpOpen(true)}>
                 {t("actions.show")}
               </Button>
@@ -368,4 +336,4 @@ Spool Weight: {filament.spool_weight} g
   );
 };
 
-export default SpoolQRCodePrintingDialog;
+export default FilamentQRCodePrintingDialog;

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -1,0 +1,187 @@
+import { RightOutlined } from "@ant-design/icons";
+import { useTable } from "@refinedev/antd";
+import { Button, Checkbox, Col, message, Row, Space, Table } from "antd";
+import { t } from "i18next";
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router";
+import { FilteredQueryColumn, SortedColumn, SpoolIconColumn } from "../../components/column";
+import { useSpoolmanFilamentNames, useSpoolmanMaterials, useSpoolmanVendors } from "../../components/otherModels";
+import { removeUndefined } from "../../utils/filtering";
+import { TableState } from "../../utils/saveload";
+import { IFilament } from "../filaments/model";
+
+interface Props {
+  description?: string;
+  onContinue: (selectedFilaments: IFilament[]) => void;
+}
+
+interface IFilamentCollapsed extends IFilament {
+  "vendor.name": string | null;
+}
+
+function collapseFilament(element: IFilament): IFilamentCollapsed {
+  return { ...element, "vendor.name": element.vendor?.name ?? null };
+}
+
+const FilamentSelectModal = ({ description, onContinue }: Props) => {
+  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [messageApi, contextHolder] = message.useMessage();
+  const navigate = useNavigate();
+
+  const { tableProps, sorters, filters, currentPage, pageSize } = useTable<IFilamentCollapsed>({
+    resource: "filament",
+    syncWithLocation: false,
+    pagination: {
+      mode: "off",
+      currentPage: 1,
+      pageSize: 10,
+    },
+    sorters: {
+      mode: "server",
+    },
+    filters: {
+      mode: "server",
+    },
+    queryOptions: {
+      select(data) {
+        return {
+          total: data.total,
+          data: data.data.map(collapseFilament),
+        };
+      },
+    },
+  });
+
+  const tableState: TableState = {
+    sorters,
+    filters,
+    pagination: { currentPage: currentPage, pageSize },
+  };
+
+  const dataSource: IFilamentCollapsed[] = useMemo(
+    () => (tableProps.dataSource || []).map((record) => ({ ...record })),
+    [tableProps.dataSource],
+  );
+
+  const selectUnselectFiltered = (select: boolean) => {
+    setSelectedItems((prevSelected) => {
+      const filtered = dataSource.map((filament) => filament.id).filter((id) => !prevSelected.includes(id));
+      return select ? [...prevSelected, ...filtered] : filtered;
+    });
+  };
+
+  const handleSelectItem = (item: number) => {
+    setSelectedItems((prevSelected) =>
+      prevSelected.includes(item) ? prevSelected.filter((selected) => selected !== item) : [...prevSelected, item],
+    );
+  };
+
+  const isAllFilteredSelected = dataSource.every((filament) => selectedItems.includes(filament.id));
+  const isSomeButNotAllFilteredSelected =
+    dataSource.some((filament) => selectedItems.includes(filament.id)) && !isAllFilteredSelected;
+
+  const commonProps = {
+    t,
+    navigate,
+    actions: () => [],
+    dataSource,
+    tableState,
+    sorter: true,
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Space direction="vertical" style={{ width: "100%" }}>
+        {description && <div>{description}</div>}
+        <Table
+          {...tableProps}
+          rowKey="id"
+          tableLayout="auto"
+          dataSource={dataSource}
+          pagination={false}
+          scroll={{ y: 200 }}
+          columns={removeUndefined([
+            {
+              width: 50,
+              render: (_, item: IFilament) => (
+                <Checkbox checked={selectedItems.includes(item.id)} onChange={() => handleSelectItem(item.id)} />
+              ),
+            },
+            SortedColumn({
+              ...commonProps,
+              id: "id",
+              i18ncat: "filament",
+              width: 80,
+            }),
+            FilteredQueryColumn({
+              ...commonProps,
+              id: "vendor.name",
+              i18nkey: "filament.fields.vendor_name",
+              filterValueQuery: useSpoolmanVendors(),
+              width: 130,
+            }),
+            SpoolIconColumn({
+              ...commonProps,
+              id: "name",
+              i18ncat: "filament",
+              color: (record: IFilamentCollapsed) =>
+                record.multi_color_hexes
+                  ? { colors: record.multi_color_hexes.split(","), vertical: record.multi_color_direction === "longitudinal" }
+                  : record.color_hex,
+              filterValueQuery: useSpoolmanFilamentNames(),
+            }),
+            FilteredQueryColumn({
+              ...commonProps,
+              id: "material",
+              i18ncat: "filament",
+              filterValueQuery: useSpoolmanMaterials(),
+              width: 120,
+            }),
+          ])}
+        />
+        <Row gutter={[10, 10]}>
+          <Col span={12}>
+            <Checkbox
+              checked={isAllFilteredSelected}
+              indeterminate={isSomeButNotAllFilteredSelected}
+              onChange={(e) => {
+                selectUnselectFiltered(e.target.checked);
+              }}
+            >
+              {t("printing.filamentSelect.selectAll")}
+            </Checkbox>
+          </Col>
+          <Col span={12}>
+            <div style={{ float: "right" }}>
+              {t("printing.filamentSelect.selectedTotal", {
+                count: selectedItems.length,
+              })}
+            </div>
+          </Col>
+          <Col span={24}>
+            <Button
+              type="primary"
+              icon={<RightOutlined />}
+              iconPosition="end"
+              onClick={() => {
+                if (selectedItems.length === 0) {
+                  messageApi.open({
+                    type: "error",
+                    content: t("printing.filamentSelect.noFilamentsSelected"),
+                  });
+                  return;
+                }
+                onContinue(dataSource.filter((filament) => selectedItems.includes(filament.id)));
+              }}
+            >
+              {t("buttons.continue")}
+            </Button>
+          </Col>
+        </Row>
+      </Space>
+    </>
+  );
+};
+
+export default FilamentSelectModal;

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -12,7 +12,7 @@ import { IFilament } from "../filaments/model";
 
 interface Props {
   description?: string;
-  onContinue: (selectedFilaments: IFilament[]) => void;
+  onContinue: (selectedFilamentIds: number[]) => void;
 }
 
 interface IFilamentCollapsed extends IFilament {
@@ -32,9 +32,9 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
     resource: "filament",
     syncWithLocation: false,
     pagination: {
-      mode: "off",
+      mode: "server",
       currentPage: 1,
-      pageSize: 10,
+      pageSize: 50,
     },
     sorters: {
       mode: "server",
@@ -62,11 +62,24 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
     () => (tableProps.dataSource || []).map((record) => ({ ...record })),
     [tableProps.dataSource],
   );
+  const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
+
+  if (tableProps.pagination) {
+    tableProps.pagination.showSizeChanger = true;
+    tableProps.pagination.pageSizeOptions = ["25", "50", "100", "200"];
+  }
 
   const selectUnselectFiltered = (select: boolean) => {
     setSelectedItems((prevSelected) => {
-      const filtered = dataSource.map((filament) => filament.id).filter((id) => !prevSelected.includes(id));
-      return select ? [...prevSelected, ...filtered] : filtered;
+      const nextSelected = new Set(prevSelected);
+      dataSource.forEach((filament) => {
+        if (select) {
+          nextSelected.add(filament.id);
+        } else {
+          nextSelected.delete(filament.id);
+        }
+      });
+      return Array.from(nextSelected);
     });
   };
 
@@ -76,9 +89,9 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
     );
   };
 
-  const isAllFilteredSelected = dataSource.every((filament) => selectedItems.includes(filament.id));
+  const isAllFilteredSelected = dataSource.every((filament) => selectedSet.has(filament.id));
   const isSomeButNotAllFilteredSelected =
-    dataSource.some((filament) => selectedItems.includes(filament.id)) && !isAllFilteredSelected;
+    dataSource.some((filament) => selectedSet.has(filament.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -99,13 +112,12 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
           rowKey="id"
           tableLayout="auto"
           dataSource={dataSource}
-          pagination={false}
           scroll={{ y: 200 }}
           columns={removeUndefined([
             {
               width: 50,
               render: (_, item: IFilament) => (
-                <Checkbox checked={selectedItems.includes(item.id)} onChange={() => handleSelectItem(item.id)} />
+                <Checkbox checked={selectedSet.has(item.id)} onChange={() => handleSelectItem(item.id)} />
               ),
             },
             SortedColumn({
@@ -172,7 +184,7 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
                   });
                   return;
                 }
-                onContinue(dataSource.filter((filament) => selectedItems.includes(filament.id)));
+                onContinue(selectedItems);
               }}
             >
               {t("buttons.continue")}

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -1,5 +1,5 @@
 import { useTable } from "@refinedev/antd";
-import { Button, Checkbox, Col, Input, message, Pagination, Row, Table } from "antd";
+import { Button, Checkbox, Col, Input, message, Pagination, Row, Space, Table } from "antd";
 import { t } from "i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
@@ -11,7 +11,9 @@ import { IFilament } from "../filaments/model";
 
 interface Props {
   description?: string;
-  onPrint: (selectedFilamentIds: number[]) => void;
+  onPrint?: (selectedFilamentIds: number[]) => void;
+  onExport?: (selectedFilamentIds: number[]) => void;
+  initialSelectedIds?: number[];
   searchPlaceholder?: string;
 }
 
@@ -28,8 +30,8 @@ const MIN_TABLE_SCROLL_Y = 180;
 const TABLE_BOTTOM_GAP = 16;
 
 // Combine server-side paging with lightweight local selection so the print flow can stay inside one dialog.
-const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props) => {
-  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+const FilamentSelectModal = ({ description, onPrint, onExport, initialSelectedIds, searchPlaceholder }: Props) => {
+  const [selectedItems, setSelectedItems] = useState<number[]>(initialSelectedIds ?? []);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
   const [tableScrollY, setTableScrollY] = useState<number>(300);
@@ -259,21 +261,42 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
                   count: selectedItems.length,
                 })}
               </div>
-              <Button
-                type="primary"
-                onClick={() => {
-                  if (selectedItems.length === 0) {
-                    messageApi.open({
-                      type: "error",
-                      content: t("printing.filamentSelect.noFilamentsSelected"),
-                    });
-                    return;
-                  }
-                  onPrint(selectedItems);
-                }}
-              >
-                {t("printing.qrcode.button")}
-              </Button>
+              <Space>
+                {onPrint && (
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      if (selectedItems.length === 0) {
+                        messageApi.open({
+                          type: "error",
+                          content: t("printing.filamentSelect.noFilamentsSelected"),
+                        });
+                        return;
+                      }
+                      onPrint(selectedItems);
+                    }}
+                  >
+                    {t("printing.qrcode.button")}
+                  </Button>
+                )}
+                {onExport && (
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      if (selectedItems.length === 0) {
+                        messageApi.open({
+                          type: "error",
+                          content: t("printing.filamentSelect.noFilamentsSelected"),
+                        });
+                        return;
+                      }
+                      onExport(selectedItems);
+                    }}
+                  >
+                    {t("printing.qrcode.exportButton")}
+                  </Button>
+                )}
+              </Space>
             </div>
           </Col>
         </Row>

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -24,17 +24,6 @@ function collapseFilament(element: IFilament): IFilamentCollapsed {
   return { ...element, "vendor.name": element.vendor?.name ?? null };
 }
 
-// Keep the quick search local to the currently loaded page instead of changing the server-side query contract.
-function matchesSearch(filament: IFilamentCollapsed, searchTerm: string): boolean {
-  const needle = searchTerm.trim().toLowerCase();
-  if (needle.length === 0) {
-    return true;
-  }
-
-  const haystacks = [String(filament.id), filament["vendor.name"] ?? "", filament.name ?? "", filament.material ?? ""];
-  return haystacks.some((value) => value.toLowerCase().includes(needle));
-}
-
 const MIN_TABLE_SCROLL_Y = 180;
 const TABLE_BOTTOM_GAP = 16;
 
@@ -43,9 +32,9 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
-  const [searchValue, setSearchValue] = useState("");
-  const [serverSearchValue, setServerSearchValue] = useState("");
   const [tableScrollY, setTableScrollY] = useState<number>(300);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const rootRef = useRef<HTMLDivElement | null>(null);
   const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
@@ -54,7 +43,7 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
       resource: "filament",
       meta: {
         queryParams: {
-          ...(serverSearchValue.trim().length > 0 ? { search: serverSearchValue.trim() } : {}),
+          ...(debouncedSearch.length > 0 ? { search: debouncedSearch } : {}),
         },
       },
       syncWithLocation: false,
@@ -85,16 +74,9 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
     pagination: { currentPage, pageSize },
   };
 
-  const dataSource: IFilamentCollapsed[] = useMemo(
-    () => (tableProps.dataSource || []).map((record) => ({ ...record })),
-    [tableProps.dataSource],
-  );
-  // Keep typing responsive by narrowing the current page immediately even while the backend query is in flight.
-  const visibleDataSource = useMemo(
-    () => dataSource.filter((filament) => matchesSearch(filament, searchValue)),
-    [dataSource, searchValue],
-  );
+  const dataSource = [...(tableProps.dataSource ?? [])];
   const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
+  const paginationTotal = tableProps.pagination ? (tableProps.pagination.total ?? 0) : 0;
 
   useEffect(() => {
     const computeScrollHeight = () => {
@@ -130,8 +112,6 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
       resizeObserver?.disconnect();
     };
   }, []);
-
-  const paginationTotal = tableProps.pagination ? (tableProps.pagination.total ?? 0) : 0;
   const handlePageChange = useCallback(
     (page: number, nextPageSize?: number) => {
       if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
@@ -145,17 +125,22 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
     setPageSize(size);
     setCurrentPage(1);
   }, []);
-  const applySearchFilter = useCallback((nextSearch: string) => {
-    setServerSearchValue(nextSearch.trim());
-    setCurrentPage(1);
-  }, []);
 
-  // Bulk toggles only touch the rows currently visible after search and paging.
+  // Debounce search input to avoid excessive API calls while typing
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchTerm.trim());
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm, setCurrentPage]);
+
+  // Bulk toggles only touch the rows currently visible after paging and server-side filtering.
   const selectUnselectFiltered = useCallback(
     (select: boolean) => {
       setSelectedItems((prevSelected) => {
         const nextSelected = new Set(prevSelected);
-        visibleDataSource.forEach((filament) => {
+        dataSource.forEach((filament) => {
           if (select) {
             nextSelected.add(filament.id);
           } else {
@@ -165,7 +150,7 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
         return Array.from(nextSelected);
       });
     },
-    [visibleDataSource],
+    [dataSource],
   );
 
   const handleSelectItem = useCallback((item: number) => {
@@ -174,10 +159,9 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
     );
   }, []);
 
-  const isAllFilteredSelected =
-    visibleDataSource.length > 0 && visibleDataSource.every((filament) => selectedSet.has(filament.id));
+  const isAllFilteredSelected = dataSource.length > 0 && dataSource.every((filament) => selectedSet.has(filament.id));
   const isSomeButNotAllFilteredSelected =
-    visibleDataSource.some((filament) => selectedSet.has(filament.id)) && !isAllFilteredSelected;
+    dataSource.some((filament) => selectedSet.has(filament.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -227,17 +211,14 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
           <Col xs={24} md={12}>
             <Input.Search
               placeholder={resolvedSearchPlaceholder}
-              value={searchValue}
+              value={searchTerm}
               allowClear
               enterButton
               onChange={(event) => {
-                const value = event.target.value;
-                setSearchValue(value);
-                applySearchFilter(value);
+                setSearchTerm(event.target.value);
               }}
               onSearch={(value) => {
-                setSearchValue(value);
-                applySearchFilter(value);
+                setSearchTerm(value);
               }}
             />
           </Col>
@@ -246,8 +227,7 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
           <Col flex="none">
             <Button
               onClick={() => {
-                setSearchValue("");
-                setServerSearchValue("");
+                setSearchTerm("");
                 setFilters([], "replace");
                 setCurrentPage(1);
               }}
@@ -303,7 +283,7 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
             rowKey="id"
             tableLayout="fixed"
             pagination={false}
-            dataSource={visibleDataSource}
+            dataSource={dataSource}
             scroll={{ y: tableScrollY, x: "max-content" }}
             columns={removeUndefined([
               {

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -1,8 +1,7 @@
-import { RightOutlined } from "@ant-design/icons";
 import { useTable } from "@refinedev/antd";
-import { Button, Checkbox, Col, message, Row, Space, Table } from "antd";
+import { Button, Checkbox, Col, Input, message, Pagination, Row, Table } from "antd";
 import { t } from "i18next";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { FilteredQueryColumn, SortedColumn, SpoolIconColumn } from "../../components/column";
 import { useSpoolmanFilamentNames, useSpoolmanMaterials, useSpoolmanVendors } from "../../components/otherModels";
@@ -12,67 +11,147 @@ import { IFilament } from "../filaments/model";
 
 interface Props {
   description?: string;
-  onContinue: (selectedFilamentIds: number[]) => void;
+  onPrint: (selectedFilamentIds: number[]) => void;
+  searchPlaceholder?: string;
 }
 
 interface IFilamentCollapsed extends IFilament {
   "vendor.name": string | null;
 }
 
+// Flatten vendor name into each row so shared table helpers can sort and filter it like a top-level field.
 function collapseFilament(element: IFilament): IFilamentCollapsed {
   return { ...element, "vendor.name": element.vendor?.name ?? null };
 }
 
-const FilamentSelectModal = ({ description, onContinue }: Props) => {
+// Keep the quick search local to the currently loaded page instead of changing the server-side query contract.
+function matchesSearch(filament: IFilamentCollapsed, searchTerm: string): boolean {
+  const needle = searchTerm.trim().toLowerCase();
+  if (needle.length === 0) {
+    return true;
+  }
+
+  const haystacks = [String(filament.id), filament["vendor.name"] ?? "", filament.name ?? "", filament.material ?? ""];
+  return haystacks.some((value) => value.toLowerCase().includes(needle));
+}
+
+const MIN_TABLE_SCROLL_Y = 180;
+const TABLE_BOTTOM_GAP = 16;
+
+// Combine server-side paging with lightweight local selection so the print flow can stay inside one dialog.
+const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props) => {
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState("");
+  const [serverSearchValue, setServerSearchValue] = useState("");
+  const [tableScrollY, setTableScrollY] = useState<number>(300);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const { tableProps, sorters, filters, currentPage, pageSize } = useTable<IFilamentCollapsed>({
-    resource: "filament",
-    syncWithLocation: false,
-    pagination: {
-      mode: "server",
-      currentPage: 1,
-      pageSize: 50,
-    },
-    sorters: {
-      mode: "server",
-    },
-    filters: {
-      mode: "server",
-    },
-    queryOptions: {
-      select(data) {
-        return {
-          total: data.total,
-          data: data.data.map(collapseFilament),
-        };
+  const { tableProps, sorters, filters, setFilters, currentPage, pageSize, setCurrentPage, setPageSize } =
+    useTable<IFilamentCollapsed>({
+      resource: "filament",
+      meta: {
+        queryParams: {
+          ...(serverSearchValue.trim().length > 0 ? { search: serverSearchValue.trim() } : {}),
+        },
       },
-    },
-  });
+      syncWithLocation: false,
+      pagination: {
+        mode: "server",
+        currentPage: 1,
+        pageSize: 50,
+      },
+      sorters: {
+        mode: "server",
+      },
+      filters: {
+        mode: "server",
+      },
+      queryOptions: {
+        select(data) {
+          return {
+            total: data.total,
+            data: data.data.map(collapseFilament),
+          };
+        },
+      },
+    });
 
   const tableState: TableState = {
     sorters,
     filters,
-    pagination: { currentPage: currentPage, pageSize },
+    pagination: { currentPage, pageSize },
   };
 
   const dataSource: IFilamentCollapsed[] = useMemo(
     () => (tableProps.dataSource || []).map((record) => ({ ...record })),
     [tableProps.dataSource],
   );
+  // Keep typing responsive by narrowing the current page immediately even while the backend query is in flight.
+  const visibleDataSource = useMemo(
+    () => dataSource.filter((filament) => matchesSearch(filament, searchValue)),
+    [dataSource, searchValue],
+  );
   const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
 
-  if (tableProps.pagination) {
-    tableProps.pagination.showSizeChanger = true;
-    tableProps.pagination.pageSizeOptions = ["25", "50", "100", "200"];
-  }
+  useEffect(() => {
+    const computeScrollHeight = () => {
+      if (!tableContainerRef.current) {
+        return;
+      }
+      // Recompute against the current viewport so the table can fill the dialog without introducing a second pager row.
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const tableTop = tableContainerRef.current.getBoundingClientRect().top;
+      const availableHeight = Math.floor(viewportHeight - tableTop - TABLE_BOTTOM_GAP);
+      setTableScrollY(Math.max(MIN_TABLE_SCROLL_Y, availableHeight));
+    };
 
+    computeScrollHeight();
+
+    const onViewportResize = () => computeScrollHeight();
+    window.addEventListener("resize", onViewportResize);
+    window.addEventListener("orientationchange", onViewportResize);
+    window.visualViewport?.addEventListener("resize", onViewportResize);
+    window.visualViewport?.addEventListener("scroll", onViewportResize);
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => computeScrollHeight()) : undefined;
+    if (resizeObserver && rootRef.current) {
+      resizeObserver.observe(rootRef.current);
+    }
+
+    return () => {
+      window.removeEventListener("resize", onViewportResize);
+      window.removeEventListener("orientationchange", onViewportResize);
+      window.visualViewport?.removeEventListener("resize", onViewportResize);
+      window.visualViewport?.removeEventListener("scroll", onViewportResize);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  const paginationTotal = tableProps.pagination ? (tableProps.pagination.total ?? 0) : 0;
+  const handlePageChange = (page: number, nextPageSize?: number) => {
+    if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
+      setPageSize(nextPageSize);
+    }
+    setCurrentPage(page);
+  };
+  const handlePageSizeChange = (_current: number, size: number) => {
+    setPageSize(size);
+    setCurrentPage(1);
+  };
+  const applySearchFilter = (nextSearch: string) => {
+    setServerSearchValue(nextSearch.trim());
+    setCurrentPage(1);
+  };
+
+  // Bulk toggles only touch the rows currently visible after search and paging.
   const selectUnselectFiltered = (select: boolean) => {
     setSelectedItems((prevSelected) => {
       const nextSelected = new Set(prevSelected);
-      dataSource.forEach((filament) => {
+      visibleDataSource.forEach((filament) => {
         if (select) {
           nextSelected.add(filament.id);
         } else {
@@ -89,9 +168,10 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
     );
   };
 
-  const isAllFilteredSelected = dataSource.every((filament) => selectedSet.has(filament.id));
+  const isAllFilteredSelected =
+    visibleDataSource.length > 0 && visibleDataSource.every((filament) => selectedSet.has(filament.id));
   const isSomeButNotAllFilteredSelected =
-    dataSource.some((filament) => selectedSet.has(filament.id)) && !isAllFilteredSelected;
+    visibleDataSource.some((filament) => selectedSet.has(filament.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -102,96 +182,168 @@ const FilamentSelectModal = ({ description, onContinue }: Props) => {
     sorter: true,
   };
 
+  const resolvedDescription =
+    description ??
+    t("printing.filamentSelect.description", {
+      defaultValue: "Search for and select filament labels to print:",
+    });
+  const resolvedSearchPlaceholder =
+    searchPlaceholder ??
+    t("printing.filamentSelect.searchPlaceholder", {
+      defaultValue: "Search by filament ID, vendor, name, or material",
+    });
+
   return (
     <>
       {contextHolder}
-      <Space direction="vertical" style={{ width: "100%" }}>
-        {description && <div>{description}</div>}
-        <Table
-          {...tableProps}
-          rowKey="id"
-          tableLayout="auto"
-          dataSource={dataSource}
-          scroll={{ y: 200 }}
-          columns={removeUndefined([
-            {
-              width: 50,
-              render: (_, item: IFilament) => (
-                <Checkbox checked={selectedSet.has(item.id)} onChange={() => handleSelectItem(item.id)} />
-              ),
-            },
-            SortedColumn({
-              ...commonProps,
-              id: "id",
-              i18ncat: "filament",
-              width: 80,
-            }),
-            FilteredQueryColumn({
-              ...commonProps,
-              id: "vendor.name",
-              i18nkey: "filament.fields.vendor_name",
-              filterValueQuery: useSpoolmanVendors(),
-              width: 130,
-            }),
-            SpoolIconColumn({
-              ...commonProps,
-              id: "name",
-              i18ncat: "filament",
-              color: (record: IFilamentCollapsed) =>
-                record.multi_color_hexes
-                  ? { colors: record.multi_color_hexes.split(","), vertical: record.multi_color_direction === "longitudinal" }
-                  : record.color_hex,
-              filterValueQuery: useSpoolmanFilamentNames(),
-            }),
-            FilteredQueryColumn({
-              ...commonProps,
-              id: "material",
-              i18ncat: "filament",
-              filterValueQuery: useSpoolmanMaterials(),
-              width: 120,
-            }),
-          ])}
-        />
-        <Row gutter={[10, 10]}>
-          <Col span={12}>
-            <Checkbox
-              checked={isAllFilteredSelected}
-              indeterminate={isSomeButNotAllFilteredSelected}
-              onChange={(e) => {
-                selectUnselectFiltered(e.target.checked);
+      <div ref={rootRef} style={{ width: "100%", display: "flex", flexDirection: "column", height: "100%" }}>
+        {(resolvedDescription || tableProps.pagination) && (
+          <Row gutter={[12, 8]} align="middle" style={{ marginBottom: 8 }}>
+            <Col flex="auto">{resolvedDescription && <div style={{ margin: 0 }}>{resolvedDescription}</div>}</Col>
+            {tableProps.pagination && (
+              <Col flex="none">
+                <Pagination
+                  size="small"
+                  current={currentPage}
+                  pageSize={pageSize}
+                  total={paginationTotal}
+                  showSizeChanger
+                  pageSizeOptions={["10", "20", "50", "100"]}
+                  showQuickJumper
+                  onChange={handlePageChange}
+                  onShowSizeChange={handlePageSizeChange}
+                />
+              </Col>
+            )}
+          </Row>
+        )}
+        <Row gutter={[12, 8]} style={{ marginBottom: 8 }}>
+          <Col xs={24} md={12}>
+            <Input.Search
+              placeholder={resolvedSearchPlaceholder}
+              value={searchValue}
+              allowClear
+              enterButton
+              onChange={(event) => {
+                const value = event.target.value;
+                setSearchValue(value);
+                applySearchFilter(value);
               }}
-            >
-              {t("printing.filamentSelect.selectAll")}
-            </Checkbox>
-          </Col>
-          <Col span={12}>
-            <div style={{ float: "right" }}>
-              {t("printing.filamentSelect.selectedTotal", {
-                count: selectedItems.length,
-              })}
-            </div>
-          </Col>
-          <Col span={24}>
-            <Button
-              type="primary"
-              icon={<RightOutlined />}
-              iconPosition="end"
-              onClick={() => {
-                if (selectedItems.length === 0) {
-                  messageApi.open({
-                    type: "error",
-                    content: t("printing.filamentSelect.noFilamentsSelected"),
-                  });
-                  return;
-                }
-                onContinue(selectedItems);
+              onSearch={(value) => {
+                setSearchValue(value);
+                applySearchFilter(value);
               }}
-            >
-              {t("buttons.continue")}
-            </Button>
+            />
           </Col>
         </Row>
-      </Space>
+        <Row gutter={[12, 12]} align="middle" style={{ marginBottom: 8 }}>
+          <Col flex="none">
+            <Button
+              onClick={() => {
+                setSearchValue("");
+                setServerSearchValue("");
+                setFilters([], "replace");
+                setCurrentPage(1);
+              }}
+            >
+              {t("buttons.clearFilters")}
+            </Button>
+          </Col>
+          <Col flex="auto">
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                gap: 12,
+                flexWrap: "wrap",
+              }}
+            >
+              <Checkbox
+                checked={isAllFilteredSelected}
+                indeterminate={isSomeButNotAllFilteredSelected}
+                onChange={(e) => {
+                  selectUnselectFiltered(e.target.checked);
+                }}
+              >
+                {t("printing.filamentSelect.selectAll")}
+              </Checkbox>
+              <div style={{ minWidth: 140, textAlign: "right" }}>
+                {t("printing.filamentSelect.selectedTotal", {
+                  count: selectedItems.length,
+                })}
+              </div>
+              <Button
+                type="primary"
+                onClick={() => {
+                  if (selectedItems.length === 0) {
+                    messageApi.open({
+                      type: "error",
+                      content: t("printing.filamentSelect.noFilamentsSelected"),
+                    });
+                    return;
+                  }
+                  onPrint(selectedItems);
+                }}
+              >
+                {t("printing.qrcode.button")}
+              </Button>
+            </div>
+          </Col>
+        </Row>
+        <div ref={tableContainerRef} style={{ flex: 1, minHeight: 0 }}>
+          <Table
+            {...tableProps}
+            rowKey="id"
+            tableLayout="fixed"
+            pagination={false}
+            dataSource={visibleDataSource}
+            scroll={{ y: tableScrollY, x: "max-content" }}
+            columns={removeUndefined([
+              {
+                width: 48,
+                render: (_, item: IFilament) => (
+                  <Checkbox checked={selectedSet.has(item.id)} onChange={() => handleSelectItem(item.id)} />
+                ),
+              },
+              SortedColumn({
+                ...commonProps,
+                id: "id",
+                i18ncat: "filament",
+                width: 70,
+              }),
+              FilteredQueryColumn({
+                ...commonProps,
+                id: "vendor.name",
+                i18nkey: "filament.fields.vendor_name",
+                filterValueQuery: useSpoolmanVendors(),
+                width: 180,
+              }),
+              SpoolIconColumn({
+                ...commonProps,
+                id: "name",
+                i18ncat: "filament",
+                width: 320,
+                color: (record: IFilamentCollapsed) =>
+                  record.multi_color_hexes
+                    ? {
+                        colors: record.multi_color_hexes.split(","),
+                        vertical: record.multi_color_direction === "longitudinal",
+                      }
+                    : record.color_hex,
+                filterValueQuery: useSpoolmanFilamentNames(),
+              }),
+              FilteredQueryColumn({
+                ...commonProps,
+                id: "material",
+                i18ncat: "filament",
+                filterValueQuery: useSpoolmanMaterials(),
+                width: 140,
+              }),
+            ])}
+          />
+        </div>
+      </div>
     </>
   );
 };

--- a/client/src/pages/printing/filamentSelectModal.tsx
+++ b/client/src/pages/printing/filamentSelectModal.tsx
@@ -1,7 +1,7 @@
 import { useTable } from "@refinedev/antd";
 import { Button, Checkbox, Col, Input, message, Pagination, Row, Table } from "antd";
 import { t } from "i18next";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { FilteredQueryColumn, SortedColumn, SpoolIconColumn } from "../../components/column";
 import { useSpoolmanFilamentNames, useSpoolmanMaterials, useSpoolmanVendors } from "../../components/otherModels";
@@ -132,41 +132,47 @@ const FilamentSelectModal = ({ description, onPrint, searchPlaceholder }: Props)
   }, []);
 
   const paginationTotal = tableProps.pagination ? (tableProps.pagination.total ?? 0) : 0;
-  const handlePageChange = (page: number, nextPageSize?: number) => {
-    if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
-      setPageSize(nextPageSize);
-    }
-    setCurrentPage(page);
-  };
-  const handlePageSizeChange = (_current: number, size: number) => {
+  const handlePageChange = useCallback(
+    (page: number, nextPageSize?: number) => {
+      if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
+        setPageSize(nextPageSize);
+      }
+      setCurrentPage(page);
+    },
+    [pageSize],
+  );
+  const handlePageSizeChange = useCallback((_current: number, size: number) => {
     setPageSize(size);
     setCurrentPage(1);
-  };
-  const applySearchFilter = (nextSearch: string) => {
+  }, []);
+  const applySearchFilter = useCallback((nextSearch: string) => {
     setServerSearchValue(nextSearch.trim());
     setCurrentPage(1);
-  };
+  }, []);
 
   // Bulk toggles only touch the rows currently visible after search and paging.
-  const selectUnselectFiltered = (select: boolean) => {
-    setSelectedItems((prevSelected) => {
-      const nextSelected = new Set(prevSelected);
-      visibleDataSource.forEach((filament) => {
-        if (select) {
-          nextSelected.add(filament.id);
-        } else {
-          nextSelected.delete(filament.id);
-        }
+  const selectUnselectFiltered = useCallback(
+    (select: boolean) => {
+      setSelectedItems((prevSelected) => {
+        const nextSelected = new Set(prevSelected);
+        visibleDataSource.forEach((filament) => {
+          if (select) {
+            nextSelected.add(filament.id);
+          } else {
+            nextSelected.delete(filament.id);
+          }
+        });
+        return Array.from(nextSelected);
       });
-      return Array.from(nextSelected);
-    });
-  };
+    },
+    [visibleDataSource],
+  );
 
-  const handleSelectItem = (item: number) => {
+  const handleSelectItem = useCallback((item: number) => {
     setSelectedItems((prevSelected) =>
       prevSelected.includes(item) ? prevSelected.filter((selected) => selected !== item) : [...prevSelected, item],
     );
-  };
+  }, []);
 
   const isAllFilteredSelected =
     visibleDataSource.length > 0 && visibleDataSource.every((filament) => selectedSet.has(filament.id));

--- a/client/src/pages/printing/index.tsx
+++ b/client/src/pages/printing/index.tsx
@@ -24,7 +24,7 @@ export const Printing = () => {
   return (
     <>
       <PageHeader
-        title={`${t("printing.qrcode.button")} (${t("spool.spool")})`}
+        title={t("printing.qrcode.printSpoolTitle")}
         onBack={() => {
           const returnUrl = searchParams.get("return");
           if (returnUrl) {

--- a/client/src/pages/printing/index.tsx
+++ b/client/src/pages/printing/index.tsx
@@ -24,7 +24,7 @@ export const Printing = () => {
   return (
     <>
       <PageHeader
-        title={t("printing.qrcode.button")}
+        title={`${t("printing.qrcode.button")} (${t("spool.spool")})`}
         onBack={() => {
           const returnUrl = searchParams.get("return");
           if (returnUrl) {

--- a/client/src/pages/printing/printing.tsx
+++ b/client/src/pages/printing/printing.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { useGetSetting, useSetSetting } from "../../utils/querySettings";
-import { ISpool } from "../spools/model";
 
 export interface PrintSettings {
   id: string;
@@ -30,8 +29,8 @@ export interface SpoolQRCodePrintSettings {
   labelSettings: QRCodePrintSettings;
 }
 
-export function useGetPrintSettings(): SpoolQRCodePrintSettings[] | undefined {
-  const { data } = useGetSetting("print_presets");
+export function useGetPrintSettings(settingKey = "print_presets"): SpoolQRCodePrintSettings[] | undefined {
+  const { data } = useGetSetting(settingKey);
   if (!data) return;
   const parsed: SpoolQRCodePrintSettings[] =
     data && data.value ? JSON.parse(data.value) : ([] as SpoolQRCodePrintSettings[]);
@@ -44,8 +43,10 @@ export function useGetPrintSettings(): SpoolQRCodePrintSettings[] | undefined {
   });
 }
 
-export function useSetPrintSettings(): (spoolQRCodePrintSettings: SpoolQRCodePrintSettings[]) => void {
-  const mut = useSetSetting("print_presets");
+export function useSetPrintSettings(
+  settingKey = "print_presets",
+): (spoolQRCodePrintSettings: SpoolQRCodePrintSettings[]) => void {
+  const mut = useSetSetting(settingKey);
 
   return (spoolQRCodePrintSettings: SpoolQRCodePrintSettings[]) => {
     mut.mutate(spoolQRCodePrintSettings);
@@ -99,20 +100,20 @@ function applyTextFormatting(text: string): ReactElement[] {
   return elements;
 }
 
-export function renderLabelContents(template: string, spool: ISpool): ReactElement {
+export function renderLabelContents(template: string, obj: GenericObject): ReactElement {
   // Find all {tags} in the template string and loop over them
   const matches = [...template.matchAll(/{(?:[^}{]|{[^}{]*})*}/gs)];
   let label_text = template;
   matches.forEach((match) => {
     if ((match[0].match(/{/g) || []).length == 1) {
       const tag = match[0].replace(/[{}]/g, "");
-      const tagValue = getTagValue(tag, spool);
+      const tagValue = getTagValue(tag, obj);
       label_text = label_text.replace(match[0], tagValue);
     } else if ((match[0].match(/{/g) || []).length == 2) {
       const structure = match[0].match(/{(.*?){(.*?)}(.*?)}/);
       if (structure != null) {
         const tag = structure[2];
-        const tagValue = getTagValue(tag, spool);
+        const tagValue = getTagValue(tag, obj);
         if (tagValue == "?") {
           label_text = label_text.replace(match[0], "");
         } else {

--- a/client/src/pages/printing/printingDialog.tsx
+++ b/client/src/pages/printing/printingDialog.tsx
@@ -183,7 +183,6 @@ const PrintingDialog = ({
     return Array.from(root.getElementsByClassName("print-qrcode-item"));
   };
 
-
   const saveAsImage = async () => {
     const hasPrinted: Element[] = [];
     const items = getPrintItems();
@@ -215,7 +214,6 @@ const PrintingDialog = ({
       link.click();
     }
   };
-
 
   return (
     <>

--- a/client/src/pages/printing/printingDialog.tsx
+++ b/client/src/pages/printing/printingDialog.tsx
@@ -178,13 +178,27 @@ const PrintingDialog = ({
     );
   });
 
-  const saveAsImage = () => {
-    const hasPrinted: Element[] = [];
+  const getPrintItems = () => {
+    const root = contentRef.current ?? document;
+    return Array.from(root.getElementsByClassName("print-qrcode-item"));
+  };
 
-    Array.from(document.getElementsByClassName("print-qrcode-item")).forEach(async (item) => {
+
+  const saveAsImage = async () => {
+    const hasPrinted: Element[] = [];
+    const items = getPrintItems();
+
+    for (const item of items) {
       // Prevent printing copies
+      let isDuplicate = false;
       for (let i = 0; i < hasPrinted.length; i += 1) {
-        if (item.isEqualNode(hasPrinted[i])) return;
+        if (item.isEqualNode(hasPrinted[i])) {
+          isDuplicate = true;
+          break;
+        }
+      }
+      if (isDuplicate) {
+        continue;
       }
       hasPrinted.push(item);
 
@@ -199,8 +213,9 @@ const PrintingDialog = ({
       link.href = url;
       link.download = "spoolmanlabel.png";
       link.click();
-    });
+    }
   };
+
 
   return (
     <>

--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -23,6 +23,7 @@ interface QRCodePrintingDialogProps {
   baseUrlRoot: string;
   useHTTPUrl: boolean;
   setUseHTTPUrl: (value: boolean) => void;
+  previewValues?: { default: string; url: string };
 }
 
 const QRCodePrintingDialog = ({
@@ -35,12 +36,15 @@ const QRCodePrintingDialog = ({
   baseUrlRoot,
   useHTTPUrl,
   setUseHTTPUrl,
+  previewValues,
 }: QRCodePrintingDialogProps) => {
   const t = useTranslate();
 
   const showContent = printSettings?.showContent === undefined ? true : printSettings?.showContent;
   const showQRCodeMode = printSettings?.showQRCodeMode || "withIcon";
   const textSize = printSettings?.textSize || 3;
+  const preview =
+    previewValues ?? ({ default: `WEB+SPOOLMAN:S-{id}`, url: `${baseUrlRoot}/spool/show/{id}` } as const);
 
   const elements = items.map((item, idx) => {
     return (
@@ -110,7 +114,7 @@ const QRCodePrintingDialog = ({
                 </Radio.Group>
               </Form.Item>
               <Form.Item label={t("printing.qrcode.useHTTPUrl.preview")}>
-                <Text> {useHTTPUrl ? `${baseUrlRoot}/spool/show/{id}` : `WEB+SPOOLMAN:S-{id}`}</Text>
+                <Text> {useHTTPUrl ? preview.url : preview.default}</Text>
               </Form.Item>
             </>
           )}

--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -26,6 +26,7 @@ interface QRCodePrintingDialogProps {
   previewValues?: { default: string; url: string };
 }
 
+// Layer QR-specific controls on top of the shared sheet-printing dialog used by spool and filament labels.
 const QRCodePrintingDialog = ({
   items,
   printSettings,
@@ -43,9 +44,9 @@ const QRCodePrintingDialog = ({
   const showContent = printSettings?.showContent === undefined ? true : printSettings?.showContent;
   const showQRCodeMode = printSettings?.showQRCodeMode || "withIcon";
   const textSize = printSettings?.textSize || 3;
-  const preview =
-    previewValues ?? ({ default: `WEB+SPOOLMAN:S-{id}`, url: `${baseUrlRoot}/spool/show/{id}` } as const);
+  const preview = previewValues ?? ({ default: `WEB+SPOOLMAN:S-{id}`, url: `${baseUrlRoot}/spool/show/{id}` } as const);
 
+  // Build the printable QR blocks here; the underlying dialog handles page layout and export mechanics.
   const elements = items.map((item, idx) => {
     return (
       <div className="print-qrcode-item" key={idx}>
@@ -114,6 +115,7 @@ const QRCodePrintingDialog = ({
                 </Radio.Group>
               </Form.Item>
               <Form.Item label={t("printing.qrcode.useHTTPUrl.preview")}>
+                {/* Mirror the encoded payload so users can confirm which QR format the preset will emit. */}
                 <Text> {useHTTPUrl ? preview.url : preview.default}</Text>
               </Form.Item>
             </>

--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -76,8 +76,8 @@ const QRCodePrintingDialog = ({
       items={elements}
       printSettings={printSettings.printSettings}
       setPrintSettings={(newSettings) => {
-        printSettings.printSettings = newSettings;
-        setPrintSettings(printSettings);
+        // Spread to preserve immutability — printSettings.printSettings is a nested object
+        setPrintSettings({ ...printSettings, printSettings: newSettings });
       }}
       extraButtons={extraButtons}
       extraSettingsStart={extraSettingsStart}
@@ -94,8 +94,7 @@ const QRCodePrintingDialog = ({
                 { label: t("printing.qrcode.showQRCodeMode.withIcon"), value: "withIcon" },
               ]}
               onChange={(e: RadioChangeEvent) => {
-                printSettings.showQRCodeMode = e.target.value;
-                setPrintSettings(printSettings);
+                setPrintSettings({ ...printSettings, showQRCodeMode: e.target.value });
               }}
               value={showQRCodeMode}
               optionType="button"
@@ -124,8 +123,7 @@ const QRCodePrintingDialog = ({
             <Switch
               checked={showContent}
               onChange={(checked) => {
-                printSettings.showContent = checked;
-                setPrintSettings(printSettings);
+                setPrintSettings({ ...printSettings, showContent: checked });
               }}
             />
           </Form.Item>
@@ -140,8 +138,7 @@ const QRCodePrintingDialog = ({
                   value={textSize}
                   step={0.1}
                   onChange={(value) => {
-                    printSettings.textSize = value;
-                    setPrintSettings(printSettings);
+                    setPrintSettings({ ...printSettings, textSize: value });
                   }}
                 />
               </Col>
@@ -154,8 +151,7 @@ const QRCodePrintingDialog = ({
                   value={textSize}
                   addonAfter="mm"
                   onChange={(value) => {
-                    printSettings.textSize = value ?? 5;
-                    setPrintSettings(printSettings);
+                    setPrintSettings({ ...printSettings, textSize: value ?? 5 });
                   }}
                 />
               </Col>

--- a/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
@@ -235,8 +235,7 @@ Spool Weight: {filament.spool_weight} g
       <QRCodePrintingDialog
         printSettings={curPreset.labelSettings}
         setPrintSettings={(newSettings) => {
-          curPreset.labelSettings = newSettings;
-          updateCurrentPreset(curPreset);
+          updateCurrentPreset({ ...curPreset, labelSettings: newSettings });
         }}
         baseUrlRoot={baseUrlRoot}
         useHTTPUrl={useHTTPUrl}
@@ -296,8 +295,15 @@ Spool Weight: {filament.spool_weight} g
               <Input
                 value={curPreset.labelSettings.printSettings?.name}
                 onChange={(e) => {
-                  curPreset.labelSettings.printSettings.name = e.target.value;
-                  updateCurrentPreset(curPreset);
+                  // Triple-spread: name is 3 levels deep; each level must be copied to
+                  // avoid mutating the preset array element referenced by curPreset.
+                  updateCurrentPreset({
+                    ...curPreset,
+                    labelSettings: {
+                      ...curPreset.labelSettings,
+                      printSettings: { ...curPreset.labelSettings.printSettings, name: e.target.value },
+                    },
+                  });
                 }}
               />
             </Form.Item>
@@ -325,8 +331,7 @@ Spool Weight: {filament.spool_weight} g
                 value={template}
                 rows={8}
                 onChange={(newValue) => {
-                  curPreset.template = newValue.target.value;
-                  updateCurrentPreset(curPreset);
+                  updateCurrentPreset({ ...curPreset, template: newValue.target.value });
                 }}
               />
             </Form.Item>

--- a/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/spoolQrCodePrintingDialog.tsx
@@ -5,7 +5,7 @@ import TextArea from "antd/es/input/TextArea";
 import { useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { EntityType, useGetFields } from "../../utils/queryFields";
-import { useGetSetting } from "../../utils/querySettings";
+import { parseStringSettingValue, useGetSetting } from "../../utils/querySettings";
 import { useSavedState } from "../../utils/saveload";
 import { useGetSpoolsByIds } from "../spools/functions";
 import { ISpool } from "../spools/model";
@@ -26,10 +26,8 @@ interface SpoolQRCodePrintingDialog {
 const SpoolQRCodePrintingDialog = ({ spoolIds }: SpoolQRCodePrintingDialog) => {
   const t = useTranslate();
   const baseUrlSetting = useGetSetting("base_url");
-  const baseUrlRoot =
-    baseUrlSetting.data?.value !== undefined && JSON.parse(baseUrlSetting.data?.value) !== ""
-      ? JSON.parse(baseUrlSetting.data?.value)
-      : window.location.origin;
+  const baseUrl = parseStringSettingValue(baseUrlSetting.data?.value);
+  const baseUrlRoot = baseUrl !== "" ? baseUrl : window.location.origin;
   const [messageApi, contextHolder] = message.useMessage();
   const [useHTTPUrl, setUseHTTPUrl] = useSavedState("print-useHTTPUrl", false);
 

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -100,9 +100,12 @@ const SpoolSelectModal = ({ description, onContinue }: Props) => {
   };
 
   // State for the select/unselect all checkbox
-  const isAllFilteredSelected = dataSource.every((spool) => selectedItems.includes(spool.id));
+  // Memoised Set for O(1) membership checks — avoids O(n²) when dataSource and
+  // selectedItems are both large (many loaded spools, many already selected).
+  const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
+  const isAllFilteredSelected = dataSource.length > 0 && dataSource.every((spool) => selectedSet.has(spool.id));
   const isSomeButNotAllFilteredSelected =
-    dataSource.some((spool) => selectedItems.includes(spool.id)) && !isAllFilteredSelected;
+    dataSource.some((spool) => selectedSet.has(spool.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -131,7 +134,7 @@ const SpoolSelectModal = ({ description, onContinue }: Props) => {
             {
               width: 50,
               render: (_, item: ISpool) => (
-                <Checkbox checked={selectedItems.includes(item.id)} onChange={() => handleSelectItem(item.id)} />
+                <Checkbox checked={selectedSet.has(item.id)} onChange={() => handleSelectItem(item.id)} />
               ),
             },
             SortedColumn({

--- a/client/src/pages/settings/generalSettings.tsx
+++ b/client/src/pages/settings/generalSettings.tsx
@@ -1,7 +1,7 @@
 import { useTranslate } from "@refinedev/core";
 import { Button, Checkbox, Form, Input, message } from "antd";
 import { useEffect } from "react";
-import { useGetSettings, useSetSetting } from "../../utils/querySettings";
+import { parseStringSettingValue, useGetSettings, useSetSetting } from "../../utils/querySettings";
 
 export function GeneralSettings() {
   const settings = useGetSettings();
@@ -17,7 +17,7 @@ export function GeneralSettings() {
     if (settings.data) {
       form.setFieldsValue({
         currency: JSON.parse(settings.data.currency.value),
-        base_url: JSON.parse(settings.data.base_url.value),
+        base_url: parseStringSettingValue(settings.data.base_url.value),
         round_prices: JSON.parse(settings.data.round_prices.value),
       });
     }

--- a/client/src/utils/querySettings.ts
+++ b/client/src/utils/querySettings.ts
@@ -11,6 +11,17 @@ interface SettingsResponse {
   [key: string]: SettingResponseValue;
 }
 
+export function parseStringSettingValue(value: string | undefined, fallback = ""): string {
+  if (value === undefined) return fallback;
+
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed === "string" ? parsed : fallback;
+  } catch {
+    return value;
+  }
+}
+
 export function useGetSettings() {
   return useQuery<SettingsResponse>({
     queryKey: ["settings"],

--- a/spoolman/api/v1/filament.py
+++ b/spoolman/api/v1/filament.py
@@ -202,6 +202,17 @@ class FilamentUpdateParameters(FilamentParameters):
 async def find(
     *,
     db: Annotated[AsyncSession, Depends(get_db_session)],
+    search: Annotated[
+        str | None,
+        Query(
+            title="Search",
+            description=(
+                "Partial case-insensitive search term applied across filament ID, vendor name, name, material, and "
+                "article number. Separate multiple terms with a comma. Surround a term with quotes to search for "
+                "the exact term."
+            ),
+        ),
+    ] = None,
     vendor_name_old: Annotated[
         str | None,
         Query(alias="vendor_name", title="Vendor Name", description="See vendor.name.", deprecated=True),
@@ -345,6 +356,7 @@ async def find(
     db_items, total_count = await filament.find(
         db=db,
         ids=filter_by_ids,
+        search=search,
         vendor_name=vendor_name if vendor_name is not None else vendor_name_old,
         vendor_id=vendor_ids,
         name=name,

--- a/spoolman/api/v1/filament.py
+++ b/spoolman/api/v1/filament.py
@@ -433,8 +433,9 @@ async def create(  # noqa: ANN201
     db: Annotated[AsyncSession, Depends(get_db_session)],
     body: FilamentParameters,
 ):
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.filament)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.filament) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:
@@ -485,8 +486,9 @@ async def update(  # noqa: ANN201
 ):
     patch_data = body.model_dump(exclude_unset=True)
 
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.filament)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.filament) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:

--- a/spoolman/api/v1/spool.py
+++ b/spoolman/api/v1/spool.py
@@ -389,8 +389,9 @@ async def create(  # noqa: ANN201
             content={"message": "Only specify either remaining_weight or used_weight."},
         )
 
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.spool)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.spool) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:
@@ -451,8 +452,9 @@ async def update(  # noqa: ANN201
             content={"message": "Only specify either remaining_weight or used_weight."},
         )
 
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.spool)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.spool) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:

--- a/spoolman/api/v1/vendor.py
+++ b/spoolman/api/v1/vendor.py
@@ -209,8 +209,9 @@ async def create(  # noqa: ANN201
     db: Annotated[AsyncSession, Depends(get_db_session)],
     body: VendorParameters,
 ):
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.vendor)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.vendor) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:
@@ -249,8 +250,9 @@ async def update(  # noqa: ANN201
 ):
     patch_data = body.model_dump(exclude_unset=True)
 
-    if body.extra:
-        all_fields = await get_extra_fields(db, EntityType.vendor)
+    # Fetch extra field definitions once at endpoint entry
+    all_fields = await get_extra_fields(db, EntityType.vendor) if body.extra else None
+    if body.extra and all_fields:
         try:
             validate_extra_field_dict(all_fields, body.extra)
         except ValueError as e:

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -92,10 +92,56 @@ async def get_by_id(db: AsyncSession, filament_id: int) -> models.Filament:
     return filament
 
 
+def _build_search_filters(search: str) -> list:
+    """Build search filter conditions for filament search.
+
+    Supports comma-separated terms, exact matching (quoted strings), fuzzy matching,
+    and numeric ID matching.
+
+    Args:
+        search: Comma-separated search query with optional quoted exact-match terms.
+
+    Returns:
+        List of SQLAlchemy filter conditions to be combined with OR.
+
+    """
+    search_conditions = []
+    for value_part in search.split(","):
+        if len(value_part) == 0:
+            continue
+
+        if value_part[0] == '"' and value_part[-1] == '"':
+            exact_value = value_part[1:-1]
+            search_conditions.extend(
+                [
+                    models.Vendor.name == exact_value,
+                    models.Filament.name == exact_value,
+                    models.Filament.material == exact_value,
+                    models.Filament.article_number == exact_value,
+                ],
+            )
+            if exact_value.lstrip("-").isdigit():
+                search_conditions.append(models.Filament.id == int(exact_value))
+        else:
+            fuzzy_value = f"%{value_part}%"
+            search_conditions.extend(
+                [
+                    models.Vendor.name.ilike(fuzzy_value),
+                    models.Filament.name.ilike(fuzzy_value),
+                    models.Filament.material.ilike(fuzzy_value),
+                    models.Filament.article_number.ilike(fuzzy_value),
+                    sqlalchemy.cast(models.Filament.id, sqlalchemy.String).ilike(fuzzy_value),
+                ],
+            )
+
+    return search_conditions
+
+
 async def find(
     *,
     db: AsyncSession,
     ids: list[int] | None = None,
+    search: str | None = None,
     vendor_name: str | None = None,
     vendor_id: int | Sequence[int] | None = None,
     name: str | None = None,
@@ -126,6 +172,10 @@ async def find(
     stmt = add_where_clause_str_opt(stmt, models.Filament.material, material)
     stmt = add_where_clause_str_opt(stmt, models.Filament.article_number, article_number)
     stmt = add_where_clause_str_opt(stmt, models.Filament.external_id, external_id)
+    if search is not None:
+        search_conditions = _build_search_filters(search)
+        if search_conditions:
+            stmt = stmt.where(sqlalchemy.or_(*search_conditions))
 
     total_count = None
 

--- a/spoolman/settings.py
+++ b/spoolman/settings.py
@@ -64,6 +64,7 @@ def parse_setting(key: str) -> SettingDefinition:
 register_setting("currency", SettingType.STRING, json.dumps("EUR"))
 register_setting("round_prices", SettingType.BOOLEAN, json.dumps(obj=False))
 register_setting("print_presets", SettingType.ARRAY, json.dumps([]))
+register_setting("print_presets_filament", SettingType.ARRAY, json.dumps([]))
 
 register_setting("extra_fields_vendor", SettingType.ARRAY, json.dumps([]))
 register_setting("extra_fields_filament", SettingType.ARRAY, json.dumps([]))


### PR DESCRIPTION
## Summary
**filament label printing foundation**

Provides a means to print labels for Filaments, not just spools.  This is useful for labeling test coupons/filament color swatches that are not spool connected.

![Print filaments](https://github.com/user-attachments/assets/80f84329-9175-47bc-b3d6-3ce673250b8d)

Note, further, earlier additional functionality that used to be inside this PR is moved to other PRs to limit scope and simplify review.

## Code Quality Compliance ✅
Per https://github.com/Donkie/Spoolman/wiki/Contribute#style
- ESLint (frontend) ✓
- Prettier (frontend) ✓
- Ruff (backend) ✓
- Pre-commit hooks validated ✓

## Included
- Filament label printing entry points from filament list/show
- Dedicated filament printing page + selection modal
- Filament QR-code printing dialog and filament-specific print preset plumbing (`print_presets_filament`)
- Spool presets remain on `print_presets` in this PR
- Shared print dialog wiring for filament printing
- Filament selector performance fix for large datasets (server pagination in selector table)
- Clarified print page headers to show context (filament vs spool)
- Filament pre-print selection UX now mirrors the same general selection-step pattern used by the spool-side selection UX PR (#869):
  - backend-backed `?search=` param across the full filament dataset (vendor name, name, material, article number, ID)
  - viewport-fill table height
  - visible pagination controls
  - bulk selection tied to visible rows
- Changelog entry for printing updates

## Latest Fixes
- The filament selector now uses a single debounced `?search=` API call for full-dataset search, consistent with the spool selector pattern in #869. Searching for a vendor or material is no longer limited to the currently visible page.
- The filament API endpoint now exposes a unified `search` query parameter (matching the spool API), backed by the existing `_build_search_filters()` helper.
- Filament QR print dialogs now handle older or manually edited `base_url` settings without crashing when that value was stored as a plain string.

## Code Quality Improvements 🔧

**Performance Optimizations Applied:**
- Added `useCallback` memoization to `selectUnselectFiltered`, `handleSelectItem`, `handlePageChange`, and `handlePageSizeChange` callbacks in `filamentSelectModal.tsx`
- Prevents unnecessary re-renders of child components (Table pagination, checkboxes, buttons)
- Stable function references now persist across renders, improving React.memo effectiveness for downstream components

**Backend Refactoring:**
- Extracted search filter logic from `filament.find()` to dedicated `_build_search_filters()` helper function
- Reduced cyclomatic complexity and improves code maintainability
- Dedicated helper clarifies search term parsing logic (exact match vs fuzzy matching)
- Added unified `?search=` query parameter to the filament list API endpoint

**React Immutability Fixes Applied:**
- Replaced prop mutations with spread copies in `qrCodePrintingDialog.tsx` (×5 sites), `filamentQrCodePrintingDialog.tsx` (×3 sites), `spoolQrCodePrintingDialog.tsx` (×3 sites)
- Pattern: `curPreset.field = value; updateCurrentPreset(curPreset)` → `updateCurrentPreset({ ...curPreset, field: value })`
- Nested-object sites use double-spread: `{ ...curPreset, subObj: { ...curPreset.subObj, key: value } }`

**Selection Performance Fix (spoolSelectModal):**
- Replaced O(n) `selectedItems.includes(id)` calls (once per row per render) with O(1) `selectedSet.has(id)` via `useMemo(() => new Set(selectedItems), [selectedItems])`

## Related
- Fixes #824 (filament QR/label printing).
- Related context (partial): filament/spool custom-field visibility discussions
  - https://github.com/Donkie/Spoolman/issues/334

## Scope Boundary
- Feature requests addressed:
  - Filament label printing foundation (parity with spool label printing flow)
  - Filament print entry points from filament list/show pages
- Feature request links:
  - Tracking PR: https://github.com/Donkie/Spoolman/pull/846
  - Related label workflow context: https://github.com/Donkie/Spoolman/issues/74
- Deliberately excluded from this PR:
  - Separate export flows/pages (filament/spool labels export UX): `#869`
  - AML ZIP/template export follow-ups: `#860`
  - General search/index/performance/table UX improvements: `#861`, `#862`
  - Cross spool/filament preset sharing; preset storage remains intentionally separate in this PR
  - Export flows (AML/PNG/ZIP), filename templates, and broader print/export selector UX (moved to follow-up PRs)

## Database Impact
- None (this PR does not introduce schema/index/data migrations).

## Relationship / Merge Notes
- This PR is the filament printing foundation base.
- `#860` is stacked on top of `#846`.
- `#857` is stacked on top of `#860`.
- `#872` is stacked on top of `#857`.
- `#869` remains intentionally independent and improves the spool-side pre-print selection UX.
- `#846` and `#869` now use parallel selection-step UX patterns, both using a single debounced `?search=` API call for full-dataset search.
- Until both are merged, any shared selection UX changes must be mirrored/rebased deliberately between the two branches.
- `#869` does not replace this PR; it brings spool selection UX up to the same general level as the filament-side selection flow here.
- `#846` does **not** depend on `#862`.

**Compatibility pre-patch (`d65860a`) for combined-branch merges:**
- `onPrint` made optional (was required) — allows #860 callers to conditionally render only an Export button
- `onExport?` callback + conditional Export Labels button added — mirrors `SpoolSelectModal` pattern from #860
- `initialSelectedIds?` added — enables URL-parameter pre-selection used by #860's routing
- `printing.qrcode.exportButton` locale key added

## Test Checklist

Verified locally on March 27, 2026 via Playwright against the PR app at `http://localhost:9846`.

- [x] Filament list page has Print entry point accessible
- [x] Filament show page has Print entry point accessible
- [x] Filament search works for vendor/material names across full dataset (single `?search=` API call)
- [x] QR codes generate correctly for filament labels
- [x] Print presets (filament-specific) save and restore correctly
- [x] Dialog handles older base_url settings without crashing
- [x] Print page headers display "Filament" context correctly
- [x] Bulk selection in filament selector works and mirrors spool patterns
- [x] Filament selector pagination responds smoothly with callback memoization
- [x] Button clicks and interactions remain responsive
- [x] No console warnings related to prop changes or re-renders
