### PR TITLE
Build `client/` inside separate Docker stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
+FROM node:20-slim AS client-builder
+
+# Build client
+WORKDIR /app/client
+COPY client/package*.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
 FROM python:3.14-slim-bookworm AS python-builder
 
 ENV UV_COMPILE_BYTECODE=1
@@ -51,7 +60,7 @@ RUN groupmod -g 1000 users \
     && chown -R app:app /home/app/.local/share/spoolman
 
 # Copy built client
-COPY --chown=app:app ./client/dist /home/app/spoolman/client/dist
+COPY --chown=app:app --from=client-builder /app/client/dist /home/app/spoolman/client/dist
 
 # Copy built app
 COPY --chown=app:app --from=python-builder /home/app/spoolman /home/app/spoolman

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app/client
 COPY client/package*.json ./
 RUN npm ci
 COPY client/ ./
+ENV VITE_APIURL=/api/v1
 RUN npm run build
 
 FROM python:3.14-slim-bookworm AS python-builder


### PR DESCRIPTION
Attempting to fix #847

Notes:
- I _might not be building_ it correctly, yet, but it looks right as far as I can tell: just doing `npm run build`.
- Current approach: building `client/` _before_ Python, which might have implications for image layer caching.