### PR TITLE
Add filament calibration feature

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -18,6 +18,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env.production
 
 npm-debug.log*
 yarn-debug.log*

--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -395,5 +395,86 @@
         "new_location": "New Location",
         "no_location": "No Location",
         "no_locations_help": "This page lets you organize your spools in locations, add some spools to get started!"
+    },
+    "calibration": {
+        "title": "Calibration",
+        "no_data": "No calibration data yet.",
+        "recommended_title": "Calibrated Settings",
+        "no_recommended": "No recommended values set yet.",
+        "buttons": {
+            "start": "Start Calibration",
+            "edit_session": "Edit",
+            "delete_session": "Delete",
+            "add_step": "Add Result",
+            "edit_step": "Edit",
+            "delete_step": "Delete",
+            "save": "Save"
+        },
+        "fields": {
+            "last_session": "Last session",
+            "history": "Calibration History",
+            "steps_count": "{{count}} step(s) recorded",
+            "no_steps": "No step results recorded yet.",
+            "printer_name": "Printer Name",
+            "nozzle_diameter": "Nozzle Diameter (mm)",
+            "notes": "Notes",
+            "status": "Status",
+            "step_type": "Calibration Step",
+            "confidence": "Confidence",
+            "inputs": "Inputs",
+            "outputs_and_recommended": "Outputs & Recommended Values"
+        },
+        "session_form": {
+            "create_title": "Start Calibration Session",
+            "edit_title": "Edit Calibration Session"
+        },
+        "step_form": {
+            "add_title": "Add Step Result",
+            "edit_title": "Edit Step Result",
+            "recommended_hint": "Values here appear as recommended settings on the spool page."
+        },
+        "status": {
+            "planned": "Planned",
+            "in_progress": "In Progress",
+            "complete": "Complete",
+            "archived": "Archived"
+        },
+        "confidence": {
+            "high": "High",
+            "medium": "Medium",
+            "low": "Low"
+        },
+        "step_types": {
+            "temperature": "Temperature",
+            "volumetric_speed": "Volumetric Speed",
+            "pressure_advance": "Pressure Advance",
+            "flow_rate": "Flow Rate",
+            "retraction": "Retraction",
+            "tolerance": "Tolerance",
+            "cornering": "Cornering",
+            "input_shaping": "Input Shaping",
+            "vfa": "VFA"
+        },
+        "delete_session_confirm": "Delete this calibration session and all its step results?",
+        "delete_step_confirm": "Delete this step result?",
+        "wizard": {
+            "title": "Calibration Wizard",
+            "subtitle": "Follow the OrcaSlicer calibration guide, step by step. You can skip any step and resume later.",
+            "start": "Start Wizard",
+            "resume": "Resume Wizard",
+            "step_of": "Step {{current}} of {{total}}",
+            "already_done": "Already recorded",
+            "buttons": {
+                "back": "Back",
+                "skip": "Skip",
+                "save_continue": "Save & Continue",
+                "save_finish": "Save & Finish",
+                "skip_finish": "Skip & Finish",
+                "finish": "Finish",
+                "cancel": "Cancel"
+            },
+            "skip_finish_confirm": "Mark this session as complete without saving this step?",
+            "session_complete": "Calibration session marked as complete."
+        }
     }
 }

--- a/client/src/pages/calibration/CalibrationSection.tsx
+++ b/client/src/pages/calibration/CalibrationSection.tsx
@@ -1,0 +1,536 @@
+import {
+  BookOutlined,
+  DeleteOutlined,
+  DownOutlined,
+  EditOutlined,
+  ExclamationCircleOutlined,
+  ExperimentOutlined,
+  OrderedListOutlined,
+  PlusOutlined,
+} from "@ant-design/icons";
+import { useCreate, useDelete, useList, useTranslate } from "@refinedev/core";
+import { Button, Card, Col, Collapse, Dropdown, Row, Space, Tag, Tooltip, Typography, theme } from "antd";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { CalibrationStatus, ICalibrationSession, ICalibrationStepResult } from "./model";
+import { CalibrationWizard } from "./CalibrationWizard";
+import { SessionFormModal } from "./SessionFormModal";
+import { StepResultDrawer } from "./StepResultDrawer";
+import { STEP_CONFIGS } from "./stepConfig";
+import { WIZARD_COPY } from "./wizardCopy";
+
+dayjs.extend(utc);
+
+const { Text, Title } = Typography;
+
+const STATUS_COLORS: Record<CalibrationStatus, string> = {
+  planned: "blue",
+  in_progress: "orange",
+  complete: "green",
+  archived: "default",
+};
+
+const STEP_LABELS: Record<string, string> = {
+  temperature: "Temperature",
+  volumetric_speed: "Volumetric Speed",
+  pressure_advance: "Pressure Advance",
+  flow_rate: "Flow Rate",
+  retraction: "Retraction",
+  tolerance: "Tolerance",
+  cornering: "Cornering",
+  input_shaping: "Input Shaping",
+  vfa: "VFA",
+};
+
+// ---- Inline confirm-delete button ----------------------------------------
+
+interface ConfirmDeleteButtonProps {
+  onConfirm: () => void;
+  size?: "small" | "middle" | "large";
+}
+
+function ConfirmDeleteButton({ onConfirm, size = "small" }: ConfirmDeleteButtonProps) {
+  const [confirming, setConfirming] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!confirming) {
+      setConfirming(true);
+      timerRef.current = setTimeout(() => setConfirming(false), 3000);
+    } else {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setConfirming(false);
+      onConfirm();
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  return (
+    <Tooltip title={confirming ? "Click again to confirm" : "Delete"}>
+      <Button
+        size={size}
+        danger
+        type={confirming ? "primary" : "default"}
+        icon={<DeleteOutlined />}
+        onClick={handleClick}
+        style={{ transition: "all 0.2s", minWidth: confirming ? 80 : undefined }}
+      >
+        {confirming ? "Sure?" : undefined}
+      </Button>
+    </Tooltip>
+  );
+}
+
+// ---- Recommended settings summary ----------------------------------------
+
+function RecommendedSummary({ sessions }: { sessions: ICalibrationSession[] }) {
+  const t = useTranslate();
+  const { token } = theme.useToken();
+
+  // Collect the latest step per type that has selected_values, iterating oldest-first
+  const latestByType: Record<string, ICalibrationStepResult> = {};
+  for (const session of [...sessions].reverse()) {
+    for (const step of session.steps) {
+      if (step.selected_values && Object.keys(step.selected_values).length > 0) {
+        latestByType[step.step_type] = step;
+      }
+    }
+  }
+
+  const entries = Object.entries(latestByType);
+  if (entries.length === 0) return null;
+
+  // Resolve a value to a human-readable string — uses select option labels where applicable
+  const resolveValue = (stepType: string, key: string, value: unknown): string => {
+    const config = STEP_CONFIGS[stepType as keyof typeof STEP_CONFIGS];
+    if (!config) return String(value);
+    const field = [...config.inputFields, ...config.outputFields].find((f) => f.key === key);
+    if (!field) return String(value);
+    if (field.type === "select" && field.options) {
+      const opt = field.options.find((o) => o.value === value);
+      if (opt) return opt.label;
+    }
+    const unit = field.unit ? ` ${field.unit}` : "";
+    return `${value}${unit}`;
+  };
+
+  return (
+    <Card
+      size="small"
+      style={{ background: token.colorSuccessBg, borderColor: token.colorSuccessBorder }}
+      title={
+        <Text strong style={{ color: token.colorSuccess, fontSize: 12 }}>
+          {t("calibration.recommended_title")}
+        </Text>
+      }
+    >
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
+        {entries.map(([stepType, step]) => {
+          const config = STEP_CONFIGS[stepType as keyof typeof STEP_CONFIGS];
+          if (!config) return null;
+
+          const vals = config.recommendedKeys
+            .filter((k) => step.selected_values?.[k] !== undefined && step.selected_values?.[k] !== null)
+            .map((k) => ({
+              key: k,
+              label: config.outputFields.find((f) => f.key === k)?.label ?? k,
+              value: resolveValue(stepType, k, step.selected_values![k]),
+            }));
+          if (vals.length === 0) return null;
+
+          // Step-specific tile content
+          let content: ReactNode;
+          if (stepType === "input_shaping") {
+            const typeX = vals.find((v) => v.key === "shaper_type_x")?.value;
+            const freqX = vals.find((v) => v.key === "frequency_x")?.value;
+            const typeY = vals.find((v) => v.key === "shaper_type_y")?.value;
+            const freqY = vals.find((v) => v.key === "frequency_y")?.value;
+            content = (
+              <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                {(typeX || freqX) && (
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 5 }}>
+                    <Text style={{ fontSize: 10, fontWeight: 600, opacity: 0.5, flexShrink: 0 }}>X</Text>
+                    <Text strong style={{ fontSize: 13 }}>
+                      {[typeX, freqX ? `@ ${freqX}` : null].filter(Boolean).join(" ")}
+                    </Text>
+                  </div>
+                )}
+                {(typeY || freqY) && (
+                  <div style={{ display: "flex", alignItems: "baseline", gap: 5 }}>
+                    <Text style={{ fontSize: 10, fontWeight: 600, opacity: 0.5, flexShrink: 0 }}>Y</Text>
+                    <Text strong style={{ fontSize: 13 }}>
+                      {[typeY, freqY ? `@ ${freqY}` : null].filter(Boolean).join(" ")}
+                    </Text>
+                  </div>
+                )}
+              </div>
+            );
+          } else if (stepType === "vfa" && vals.length === 2) {
+            const min = vals.find((v) => v.key === "min_avoidance_speed")?.value;
+            const max = vals.find((v) => v.key === "max_avoidance_speed")?.value;
+            const minNum = min?.replace(/\s+mm\/s$/, "");
+            content = (
+              <Text strong style={{ fontSize: 16 }}>
+                {minNum} – {max}
+              </Text>
+            );
+          } else if (vals.length === 1) {
+            content = (
+              <Text strong style={{ fontSize: 16 }}>
+                {vals[0].value}
+              </Text>
+            );
+          } else {
+            content = (
+              <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                {vals.map((v) => (
+                  <div
+                    key={v.key}
+                    style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}
+                  >
+                    <Text style={{ fontSize: 10, opacity: 0.55, flexShrink: 0 }}>{v.label}</Text>
+                    <Text strong style={{ fontSize: 13 }}>
+                      {v.value}
+                    </Text>
+                  </div>
+                ))}
+              </div>
+            );
+          }
+
+          return (
+            <div
+              key={stepType}
+              style={{
+                flex: "1 1 140px",
+                maxWidth: 240,
+                padding: "10px 14px",
+                background: token.colorBgContainer,
+                borderRadius: token.borderRadius,
+                border: `1px solid ${token.colorSuccessBorder}`,
+                borderLeft: `3px solid ${token.colorSuccess}`,
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 10,
+                  fontWeight: 700,
+                  letterSpacing: "0.08em",
+                  textTransform: "uppercase",
+                  display: "block",
+                  marginBottom: 6,
+                  opacity: 0.5,
+                }}
+              >
+                {STEP_LABELS[stepType] ?? stepType}
+              </Text>
+              {content}
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+// ---- Step list inside a session ------------------------------------------
+
+interface StepListProps {
+  session: ICalibrationSession;
+  onEditStep: (step: ICalibrationStepResult) => void;
+  onDeleteStep: (step: ICalibrationStepResult) => void;
+}
+
+function StepList({ session, onEditStep, onDeleteStep }: StepListProps) {
+  const t = useTranslate();
+  const { token } = theme.useToken();
+  if (session.steps.length === 0) {
+    return <Text type="secondary">{t("calibration.fields.no_steps")}</Text>;
+  }
+  return (
+    <Space direction="vertical" style={{ width: "100%" }} size={4}>
+      {session.steps.map((step) => {
+        // _skipped sentinel: set by handleSaveAsSkipped in CalibrationWizard when a user
+        // deliberately skips a step (e.g. Input Shaping on a printer with built-in IS).
+        const isSkipped = step.outputs?._skipped === true;
+        const hasRecommended = !isSkipped && step.selected_values && Object.keys(step.selected_values).length > 0;
+        const isIncomplete = !isSkipped && !hasRecommended;
+        return (
+          <div
+            key={step.id}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "4px 0",
+              borderBottom: `1px solid ${token.colorBorderSecondary}`,
+            }}
+          >
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 4, flexWrap: "wrap" }}>
+              <Tag style={{ margin: 0 }}>{STEP_LABELS[step.step_type] ?? step.step_type}</Tag>
+              {WIZARD_COPY[step.step_type as keyof typeof WIZARD_COPY]?.wikiUrl && (
+                <Tooltip title="OrcaSlicer wiki">
+                  <a
+                    href={WIZARD_COPY[step.step_type as keyof typeof WIZARD_COPY].wikiUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    style={{ color: "inherit", opacity: 0.45, lineHeight: 1 }}
+                  >
+                    <BookOutlined style={{ fontSize: 11 }} />
+                  </a>
+                </Tooltip>
+              )}
+              {isSkipped && <Tag style={{ fontSize: 11, margin: 0 }}>Skipped</Tag>}
+              {hasRecommended && (
+                <Tag color="success" style={{ fontSize: 11, margin: 0 }}>
+                  ✓ Done
+                </Tag>
+              )}
+              {isIncomplete && (
+                <Tag color="warning" icon={<ExclamationCircleOutlined />} style={{ fontSize: 11, margin: 0 }}>
+                  Incomplete
+                </Tag>
+              )}
+              {step.confidence && (
+                <Text type="secondary" style={{ fontSize: 11 }}>
+                  {step.confidence} confidence
+                </Text>
+              )}
+            </span>
+            <Space size={4}>
+              <Tooltip title={t("calibration.buttons.edit_step")}>
+                <Button size="small" icon={<EditOutlined />} onClick={() => onEditStep(step)} />
+              </Tooltip>
+              <ConfirmDeleteButton onConfirm={() => onDeleteStep(step)} />
+            </Space>
+          </div>
+        );
+      })}
+    </Space>
+  );
+}
+
+// ---- Main section --------------------------------------------------------
+
+interface Props {
+  filamentId: number | undefined;
+}
+
+export const CalibrationSection = ({ filamentId }: Props) => {
+  const t = useTranslate();
+
+  const { result, query } = useList<ICalibrationSession>({
+    resource: "calibration/session",
+    meta: { queryParams: { filament_id: filamentId } },
+    queryOptions: { enabled: !!filamentId },
+    pagination: { mode: "off" },
+  });
+  const sessions = result?.data ?? [];
+  const isLoading = query.isLoading;
+  const refetch = query.refetch;
+
+  const { mutate: deleteItem } = useDelete();
+  const { mutate: createSession } = useCreate<ICalibrationSession>();
+
+  const inProgressSessions = sessions.filter((s) => s.status === "in_progress");
+  const [wizardSession, setWizardSession] = useState<ICalibrationSession | null>(null);
+
+  const handleStartWizard = () => {
+    createSession(
+      {
+        resource: "calibration/session",
+        values: { filament_id: filamentId, status: "in_progress" },
+        successNotification: false,
+      },
+      {
+        onSuccess: (result) => {
+          refetch();
+          setWizardSession(result.data);
+        },
+      },
+    );
+  };
+
+  const [sessionModal, setSessionModal] = useState<{
+    open: boolean;
+    initialValues?: Partial<ICalibrationSession>;
+  }>({ open: false });
+
+  const [stepDrawer, setStepDrawer] = useState<{
+    open: boolean;
+    sessionId: number;
+    step?: ICalibrationStepResult;
+  } | null>(null);
+
+  const openEditSession = (session: ICalibrationSession) => setSessionModal({ open: true, initialValues: session });
+
+  const openAddStep = (session: ICalibrationSession) => setStepDrawer({ open: true, sessionId: session.id });
+
+  const openEditStep = (session: ICalibrationSession, step: ICalibrationStepResult) =>
+    setStepDrawer({ open: true, sessionId: session.id, step });
+
+  const handleDeleteSession = (session: ICalibrationSession) => {
+    deleteItem(
+      { resource: "calibration/session", id: session.id, successNotification: false },
+      { onSuccess: () => refetch() },
+    );
+  };
+
+  const handleDeleteStep = (step: ICalibrationStepResult) => {
+    deleteItem(
+      { resource: "calibration/step", id: step.id, successNotification: false },
+      { onSuccess: () => refetch() },
+    );
+  };
+
+  const collapseItems = sessions.map((session) => ({
+    key: String(session.id),
+    label: (
+      <span>
+        <Tag color={STATUS_COLORS[session.status]}>{t(`calibration.status.${session.status}`)}</Tag>
+        {dayjs.utc(session.registered).local().format("YYYY-MM-DD HH:mm")}
+        {session.printer_name && <Text type="secondary"> &mdash; {session.printer_name}</Text>}
+        {session.nozzle_diameter && <Text type="secondary"> &mdash; {session.nozzle_diameter}mm</Text>}
+      </span>
+    ),
+    extra: (
+      <Space size={4} onClick={(e) => e.stopPropagation()}>
+        <Button size="small" icon={<PlusOutlined />} onClick={() => openAddStep(session)}>
+          {t("calibration.buttons.add_step")}
+        </Button>
+        <Tooltip title={t("calibration.buttons.edit_session")}>
+          <Button size="small" icon={<EditOutlined />} onClick={() => openEditSession(session)} />
+        </Tooltip>
+        <ConfirmDeleteButton onConfirm={() => handleDeleteSession(session)} />
+      </Space>
+    ),
+    children: (
+      <StepList session={session} onEditStep={(step) => openEditStep(session, step)} onDeleteStep={handleDeleteStep} />
+    ),
+  }));
+
+  return (
+    <>
+      <Card
+        size="small"
+        style={{ marginTop: 24 }}
+        title={
+          <span>
+            <ExperimentOutlined style={{ marginRight: 8 }} />
+            {t("calibration.title")}
+          </span>
+        }
+        extra={
+          <Space size={4}>
+            {inProgressSessions.length === 0 ? (
+              <Button
+                size="small"
+                type="primary"
+                icon={<OrderedListOutlined />}
+                onClick={handleStartWizard}
+                disabled={!filamentId || isLoading}
+              >
+                {t("calibration.wizard.start")}
+              </Button>
+            ) : inProgressSessions.length === 1 ? (
+              <Button
+                size="small"
+                icon={<OrderedListOutlined />}
+                onClick={() => setWizardSession(inProgressSessions[0])}
+                disabled={!filamentId || isLoading}
+              >
+                {t("calibration.wizard.resume")}
+              </Button>
+            ) : (
+              <Dropdown
+                menu={{
+                  items: inProgressSessions.map((s) => ({
+                    key: String(s.id),
+                    label: `${dayjs.utc(s.registered).local().format("MM-DD HH:mm")}${s.printer_name ? ` — ${s.printer_name}` : ""}`,
+                    onClick: () => setWizardSession(s),
+                  })),
+                }}
+                disabled={!filamentId || isLoading}
+              >
+                <Button size="small" icon={<OrderedListOutlined />}>
+                  {t("calibration.wizard.resume")} ({inProgressSessions.length}) <DownOutlined />
+                </Button>
+              </Dropdown>
+            )}
+          </Space>
+        }
+      >
+        {isLoading && <Text type="secondary">{t("loading")}</Text>}
+
+        {!isLoading && sessions.length === 0 && <Text type="secondary">{t("calibration.no_data")}</Text>}
+
+        {!isLoading &&
+          sessions.length > 0 &&
+          (() => {
+            const hasRecommendedData = sessions.some((s) =>
+              s.steps.some((step) => step.selected_values && Object.keys(step.selected_values).length > 0),
+            );
+            return (
+              <Row gutter={[20, 16]}>
+                {hasRecommendedData && (
+                  <Col xs={24} md={12}>
+                    <RecommendedSummary sessions={sessions} />
+                  </Col>
+                )}
+                <Col xs={24} md={hasRecommendedData ? 12 : 24}>
+                  <Title level={5} style={{ marginTop: 0 }}>
+                    {t("calibration.fields.history")}
+                  </Title>
+                  <Collapse size="small" items={collapseItems} />
+                </Col>
+              </Row>
+            );
+          })()}
+      </Card>
+
+      <SessionFormModal
+        open={sessionModal.open}
+        mode="edit"
+        filamentId={filamentId}
+        initialValues={sessionModal.initialValues}
+        onSuccess={() => refetch()}
+        onClose={() => setSessionModal((s) => ({ ...s, open: false }))}
+      />
+
+      {stepDrawer && (
+        <StepResultDrawer
+          open={stepDrawer.open}
+          sessionId={stepDrawer.sessionId}
+          step={stepDrawer.step}
+          onSuccess={() => refetch()}
+          onClose={() => setStepDrawer(null)}
+        />
+      )}
+
+      {wizardSession && (
+        <CalibrationWizard
+          open={!!wizardSession}
+          session={wizardSession}
+          onClose={() => {
+            setWizardSession(null);
+            refetch();
+          }}
+          onComplete={() => {
+            setWizardSession(null);
+            refetch();
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+export default CalibrationSection;

--- a/client/src/pages/calibration/CalibrationWizard.tsx
+++ b/client/src/pages/calibration/CalibrationWizard.tsx
@@ -1,0 +1,1132 @@
+/**
+ * CalibrationWizard — guided multi-step calibration modal.
+ *
+ * Layout: clickable vertical step sidebar on the left, focused content panel on the right.
+ * Form: "Test Setup" (inputs) + "Your Result" (outputs+selected_values merged — saves to both).
+ * Supports resume, skip, back, and pause (session stays in_progress).
+ */
+
+import {
+  BookOutlined,
+  CheckOutlined,
+  DeleteOutlined,
+  InfoCircleOutlined,
+  PauseCircleOutlined,
+  PlusOutlined,
+  ThunderboltOutlined,
+} from "@ant-design/icons";
+import { useCreate, useTranslate, useUpdate } from "@refinedev/core";
+import {
+  Alert,
+  Button,
+  Col,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Row,
+  Segmented,
+  Select,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from "antd";
+import { useForm } from "antd/es/form/Form";
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { CalibrationStepType, ICalibrationSession, ICalibrationStepResult } from "./model";
+import { STEP_CONFIGS, StepField } from "./stepConfig";
+import { WIZARD_COPY, WIZARD_STEP_ORDER } from "./wizardCopy";
+
+const { Text, Title } = Typography;
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function FieldItem({ field, namePrefix }: { field: StepField; namePrefix: string }) {
+  const control =
+    field.type === "select" ? (
+      <Select options={field.options} style={{ width: "100%" }} />
+    ) : (
+      <InputNumber
+        min={field.min}
+        max={field.max}
+        step={field.step ?? 1}
+        precision={field.precision ?? 0}
+        addonAfter={field.unit}
+        style={{ width: "100%" }}
+      />
+    );
+  return (
+    <Form.Item name={[namePrefix, field.key]} label={field.label}>
+      {control}
+    </Form.Item>
+  );
+}
+
+function SectionLabel({ children, color }: { children: ReactNode; color?: string }) {
+  return (
+    <Text
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        display: "block",
+        marginBottom: 12,
+        color: color,
+        opacity: color ? 1 : 0.45,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Step content
+// ---------------------------------------------------------------------------
+
+function StepContent({ stepType, onSkipStep }: { stepType: CalibrationStepType; onSkipStep?: () => void }) {
+  const config = STEP_CONFIGS[stepType];
+  const copy = WIZARD_COPY[stepType];
+  const { token } = theme.useToken();
+  const form = Form.useFormInstance();
+
+  // Flow rate: interactive guided calculator state (only used for flow_rate step)
+  type FlowCalcMethod = "yolo" | "legacy";
+  type FlowCalcPhase = "idle" | "pass1" | "pass2";
+  const [flowCalcMethod, setFlowCalcMethod] = useState<FlowCalcMethod>("yolo");
+  const [flowCalcPhase, setFlowCalcPhase] = useState<FlowCalcPhase>("idle");
+  // YOLO method: flowRatioNew = flowRatioOld + modifier  (OrcaSlicer ≥ 2.3.0)
+  const [yoloFlowRatioOld, setYoloFlowRatioOld] = useState<number | null>(1.0);
+  const [yoloModifier, setYoloModifier] = useState<number | null>(null);
+  // Legacy method per pass: result = flowRatio * (100 + modifier) / 100
+  const [pass1FlowRatio, setPass1FlowRatio] = useState<number | null>(1.0);
+  const [pass1Modifier, setPass1Modifier] = useState<number | null>(null);
+  const [pass2FlowRatio, setPass2FlowRatio] = useState<number | null>(null);
+  const [pass2Modifier, setPass2Modifier] = useState<number | null>(null);
+
+  // VFA: artifact speeds table (only used for vfa step)
+  const [artifactSpeeds, setArtifactSpeeds] = useState<number[]>([]);
+  const [newArtifactSpeed, setNewArtifactSpeed] = useState<number | null>(null);
+
+  // PA: method selector (only used for pressure_advance step)
+  const [paMethod, setPaMethod] = useState<"tower" | "pattern">("tower");
+
+  // Reset all calculator state to idle
+  const resetFlowCalcState = () => {
+    setFlowCalcPhase("idle");
+    setYoloFlowRatioOld(1.0);
+    setYoloModifier(null);
+    setPass1FlowRatio(1.0);
+    setPass1Modifier(null);
+    setPass2FlowRatio(null);
+    setPass2Modifier(null);
+  };
+
+  // Reset everything (including method) when navigating to a different step
+  useEffect(() => {
+    setFlowCalcMethod("yolo");
+    resetFlowCalcState();
+    setArtifactSpeeds([]);
+    setNewArtifactSpeed(null);
+    setPaMethod("tower");
+  }, [stepType]);
+
+  const handleFlowMethodChange = (val: string | number) => {
+    setFlowCalcMethod(val as FlowCalcMethod);
+    resetFlowCalcState();
+  };
+
+  // Computed results
+  const yoloResult =
+    yoloFlowRatioOld !== null && yoloModifier !== null && !isNaN(yoloFlowRatioOld) && !isNaN(yoloModifier)
+      ? parseFloat((yoloFlowRatioOld + yoloModifier).toFixed(5))
+      : null;
+  const pass1Result =
+    pass1FlowRatio !== null && pass1Modifier !== null && !isNaN(pass1FlowRatio) && !isNaN(pass1Modifier)
+      ? parseFloat(((pass1FlowRatio * (100 + pass1Modifier)) / 100).toFixed(5))
+      : null;
+  const pass2Result =
+    pass2FlowRatio !== null && pass2Modifier !== null && !isNaN(pass2FlowRatio) && !isNaN(pass2Modifier)
+      ? parseFloat(((pass2FlowRatio * (100 + pass2Modifier)) / 100).toFixed(5))
+      : null;
+
+  const applyFlowCalc = () => {
+    const finalRatio = flowCalcMethod === "yolo" ? yoloResult : (pass2Result ?? pass1Result);
+    if (finalRatio !== null) {
+      const current = form.getFieldValue("result") ?? {};
+      form.setFieldValue("result", { ...current, flow_ratio: finalRatio });
+    }
+    resetFlowCalcState();
+  };
+
+  const handlePaMethodChange = (val: string | number) => {
+    setPaMethod(val as "tower" | "pattern");
+    form.setFieldValue("result", {});
+  };
+
+  // Auto-compute outputs from inputs whenever inputs change
+  const inputValues = Form.useWatch("inputs", form) as Record<string, number | null> | undefined;
+  useEffect(() => {
+    if (!config.autoCompute || !inputValues) return;
+    if (stepType === "pressure_advance" && paMethod === "pattern") return;
+    const computed = config.autoCompute(inputValues);
+    if (Object.keys(computed).length > 0) {
+      const current: Record<string, unknown> = form.getFieldValue("result") ?? {};
+      form.setFieldValue("result", { ...current, ...computed });
+    }
+  }, [inputValues, paMethod]);
+
+  // VFA: auto-compute min/max avoidance speed from artifact speeds list
+  useEffect(() => {
+    if (stepType !== "vfa") return;
+    const current: Record<string, unknown> = form.getFieldValue("result") ?? {};
+    if (artifactSpeeds.length === 0) {
+      form.setFieldValue("result", { ...current, min_avoidance_speed: null, max_avoidance_speed: null });
+    } else {
+      const min = Math.min(...artifactSpeeds);
+      const max = Math.max(...artifactSpeeds);
+      form.setFieldValue("result", { ...current, min_avoidance_speed: min, max_avoidance_speed: max });
+    }
+  }, [artifactSpeeds]);
+
+  const addArtifactSpeed = () => {
+    if (newArtifactSpeed === null || isNaN(newArtifactSpeed)) return;
+    setArtifactSpeeds((prev) => [...prev, newArtifactSpeed].sort((a, b) => a - b));
+    setNewArtifactSpeed(null);
+  };
+
+  const removeArtifactSpeed = (idx: number) => {
+    setArtifactSpeeds((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  // Show first sentence inline; full description via tooltip
+  const dotIdx = copy.description.indexOf(". ");
+  const shortDesc = dotIdx > 0 ? copy.description.slice(0, dotIdx + 1) : copy.description;
+  const hasMore = copy.description.length > shortDesc.length;
+
+  return (
+    <>
+      {/* Step header */}
+      <div style={{ marginBottom: 24 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+          <Title level={4} style={{ margin: 0 }}>
+            {copy.title}
+          </Title>
+          {hasMore && (
+            <Tooltip title={copy.description} overlayStyle={{ maxWidth: 440 }}>
+              <InfoCircleOutlined style={{ color: token.colorTextTertiary, fontSize: 15, cursor: "help" }} />
+            </Tooltip>
+          )}
+          <Tooltip title="Open OrcaSlicer wiki for this step">
+            <a
+              href={copy.wikiUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 4,
+                fontSize: 12,
+                color: token.colorTextTertiary,
+                textDecoration: "none",
+                padding: "2px 6px",
+                borderRadius: token.borderRadius,
+                border: `1px solid ${token.colorBorderSecondary}`,
+                lineHeight: 1.5,
+                transition: "all 0.2s",
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.color = token.colorPrimary;
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = token.colorPrimary;
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLAnchorElement).style.color = token.colorTextTertiary;
+                (e.currentTarget as HTMLAnchorElement).style.borderColor = token.colorBorderSecondary;
+              }}
+            >
+              <BookOutlined style={{ fontSize: 12 }} />
+              Wiki
+            </a>
+          </Tooltip>
+        </div>
+        <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.5 }}>
+          {shortDesc}
+        </Text>
+      </div>
+
+      {/* Flow Rate: interactive guided pass result calculator — shown above inputs */}
+      {stepType === "flow_rate" && (
+        <div
+          style={{
+            marginBottom: 20,
+            borderRadius: token.borderRadiusLG,
+            border: `1px solid ${flowCalcPhase === "idle" ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
+            overflow: "hidden",
+            transition: "border-color 0.25s",
+          }}
+        >
+          {/* Header bar with phase progress */}
+          <div
+            style={{
+              padding: "8px 16px",
+              background: flowCalcPhase === "idle" ? token.colorFillAlter : token.colorPrimaryBg,
+              borderBottom: `1px solid ${flowCalcPhase === "idle" ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              transition: "background 0.25s, border-color 0.25s",
+            }}
+          >
+            <Text
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                letterSpacing: "0.1em",
+                textTransform: "uppercase",
+                color: flowCalcPhase !== "idle" ? token.colorPrimary : undefined,
+                opacity: flowCalcPhase === "idle" ? 0.45 : 1,
+                transition: "color 0.2s",
+              }}
+            >
+              Pass Result Calculator
+            </Text>
+            {/* Progress indicator — visible during active phases only */}
+            {flowCalcPhase !== "idle" &&
+              (flowCalcMethod === "yolo" ? (
+                /* YOLO: single-pass badge */
+                <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>
+                  YOLO
+                </Tag>
+              ) : (
+                /* Legacy: two-node pass progress */
+                <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                  {/* Pass 1 node */}
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <div
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: "50%",
+                        flexShrink: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: flowCalcPhase === "pass1" ? token.colorPrimary : token.colorSuccessBg,
+                        border: flowCalcPhase !== "pass1" ? `1px solid ${token.colorSuccessBorder}` : "none",
+                        fontSize: 9,
+                        fontWeight: 700,
+                      }}
+                    >
+                      {flowCalcPhase === "pass1" ? (
+                        <span style={{ color: token.colorWhite }}>1</span>
+                      ) : (
+                        <CheckOutlined style={{ color: token.colorSuccess, fontSize: 9 }} />
+                      )}
+                    </div>
+                    <Text
+                      style={{
+                        fontSize: 12,
+                        fontWeight: flowCalcPhase === "pass1" ? 500 : 400,
+                        color: flowCalcPhase === "pass1" ? token.colorPrimaryText : token.colorTextSecondary,
+                      }}
+                    >
+                      Pass 1
+                    </Text>
+                    {flowCalcPhase === "pass2" && pass1Result !== null && (
+                      <Tag style={{ margin: 0, fontSize: 11, lineHeight: "18px" }}>{pass1Result}</Tag>
+                    )}
+                  </div>
+                  {/* Connector line */}
+                  <div style={{ width: 20, height: 1, background: token.colorBorderSecondary, flexShrink: 0 }} />
+                  {/* Pass 2 node */}
+                  <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                    <div
+                      style={{
+                        width: 18,
+                        height: 18,
+                        borderRadius: "50%",
+                        flexShrink: 0,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        background: flowCalcPhase === "pass2" ? token.colorPrimary : token.colorFillSecondary,
+                        fontSize: 9,
+                        fontWeight: 700,
+                      }}
+                    >
+                      <span style={{ color: flowCalcPhase === "pass2" ? token.colorWhite : token.colorTextTertiary }}>
+                        2
+                      </span>
+                    </div>
+                    <Text
+                      style={{
+                        fontSize: 12,
+                        fontWeight: flowCalcPhase === "pass2" ? 500 : 400,
+                        color: flowCalcPhase === "pass2" ? token.colorPrimaryText : token.colorTextTertiary,
+                      }}
+                    >
+                      Pass 2
+                    </Text>
+                  </div>
+                </div>
+              ))}
+          </div>
+
+          {/* Calculator body */}
+          <div style={{ padding: "14px 16px" }}>
+            {/* Idle phase */}
+            {flowCalcPhase === "idle" && (
+              <div>
+                <div style={{ marginBottom: 12 }}>
+                  <Segmented
+                    options={[
+                      { label: "YOLO (Recommended)", value: "yolo" },
+                      { label: "Legacy (2-Pass)", value: "legacy" },
+                    ]}
+                    value={flowCalcMethod}
+                    onChange={handleFlowMethodChange}
+                    size="small"
+                  />
+                </div>
+                <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}>
+                  <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55, flex: 1 }}>
+                    {flowCalcMethod === "yolo"
+                      ? "Single-pass calibration using the Archimedean Chords pattern (OrcaSlicer ≥ 2.3.0). Enter your current flow ratio and the correction value observed on the print."
+                      : "Two-pass calibration. Step through your first and second pass results to calculate your final flow ratio."}
+                  </Text>
+                  <Button
+                    type="primary"
+                    ghost
+                    size="small"
+                    onClick={() => setFlowCalcPhase("pass1")}
+                    style={{ flexShrink: 0, whiteSpace: "nowrap" }}
+                  >
+                    Start →
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Pass 1 phase — YOLO (single-pass, additive) */}
+            {flowCalcPhase === "pass1" && flowCalcMethod === "yolo" && (
+              <div>
+                <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}>
+                  Print the Archimedean Chords test model. Enter your current flow ratio and the correction value shown
+                  on the print. The new flow ratio is calculated automatically.
+                </Text>
+                <Row gutter={[10, 0]} align="bottom">
+                  <Col span={8}>
+                    <Form.Item label="Current Flow Ratio" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={yoloFlowRatioOld}
+                        onChange={(v) => setYoloFlowRatioOld(v)}
+                        min={0.1}
+                        max={2}
+                        step={0.001}
+                        precision={5}
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={yoloModifier}
+                        onChange={(v) => setYoloModifier(v)}
+                        min={-1}
+                        max={1}
+                        step={0.001}
+                        precision={5}
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item
+                      label={
+                        <span style={{ color: yoloResult !== null ? token.colorPrimary : undefined, fontWeight: 500 }}>
+                          New Flow Ratio
+                        </span>
+                      }
+                      style={{ marginBottom: 8 }}
+                    >
+                      <InputNumber value={yoloResult ?? undefined} disabled precision={5} style={{ width: "100%" }} />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                  <Button
+                    size="small"
+                    type="text"
+                    onClick={() => {
+                      setFlowCalcPhase("idle");
+                      setYoloFlowRatioOld(1.0);
+                      setYoloModifier(null);
+                    }}
+                    style={{ color: token.colorTextTertiary }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button size="small" type="primary" disabled={yoloResult === null} onClick={applyFlowCalc}>
+                    Apply to Form ✓
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Pass 1 phase — Legacy (two-pass, percentage modifier) */}
+            {flowCalcPhase === "pass1" && flowCalcMethod === "legacy" && (
+              <div>
+                <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}>
+                  Print your first pass test model. Enter your starting flow ratio and the correction percentage
+                  observed on the print.
+                </Text>
+                <Row gutter={[10, 0]} align="bottom">
+                  <Col span={8}>
+                    <Form.Item label="Flow Ratio" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={pass1FlowRatio}
+                        onChange={(v) => setPass1FlowRatio(v)}
+                        min={0.1}
+                        max={2}
+                        step={0.00001}
+                        precision={5}
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={pass1Modifier}
+                        onChange={(v) => setPass1Modifier(v)}
+                        min={-50}
+                        max={50}
+                        step={0.1}
+                        precision={1}
+                        addonAfter="%"
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item
+                      label={
+                        <span style={{ color: pass1Result !== null ? token.colorPrimary : undefined, fontWeight: 500 }}>
+                          Result
+                        </span>
+                      }
+                      style={{ marginBottom: 8 }}
+                    >
+                      <InputNumber value={pass1Result ?? undefined} disabled precision={5} style={{ width: "100%" }} />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                  <Button
+                    size="small"
+                    type="text"
+                    onClick={() => {
+                      setFlowCalcPhase("idle");
+                      setPass1FlowRatio(1.0);
+                      setPass1Modifier(null);
+                    }}
+                    style={{ color: token.colorTextTertiary }}
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    size="small"
+                    type="primary"
+                    disabled={pass1Result === null}
+                    onClick={() => {
+                      setPass2FlowRatio(pass1Result);
+                      setFlowCalcPhase("pass2");
+                    }}
+                  >
+                    Next: Pass 2 →
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {/* Pass 2 phase */}
+            {flowCalcPhase === "pass2" && (
+              <div>
+                <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}>
+                  Set your slicer flow ratio to the Pass 1 result, reprint the test model, then enter the new correction
+                  percentage.
+                </Text>
+                <Row gutter={[10, 0]} align="bottom">
+                  <Col span={8}>
+                    <Form.Item label="Flow Ratio" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={pass2FlowRatio}
+                        onChange={(v) => setPass2FlowRatio(v)}
+                        min={0.1}
+                        max={2}
+                        step={0.00001}
+                        precision={5}
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                      <InputNumber
+                        value={pass2Modifier}
+                        onChange={(v) => setPass2Modifier(v)}
+                        min={-50}
+                        max={50}
+                        step={0.1}
+                        precision={1}
+                        addonAfter="%"
+                        style={{ width: "100%" }}
+                      />
+                    </Form.Item>
+                  </Col>
+                  <Col span={8}>
+                    <Form.Item
+                      label={
+                        <span style={{ color: pass2Result !== null ? token.colorPrimary : undefined, fontWeight: 500 }}>
+                          Result
+                        </span>
+                      }
+                      style={{ marginBottom: 8 }}
+                    >
+                      <InputNumber value={pass2Result ?? undefined} disabled precision={5} style={{ width: "100%" }} />
+                    </Form.Item>
+                  </Col>
+                </Row>
+                <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                  <Button
+                    size="small"
+                    onClick={() => {
+                      setFlowCalcPhase("pass1");
+                      setPass2Modifier(null);
+                    }}
+                  >
+                    ← Back
+                  </Button>
+                  <Button size="small" type="primary" disabled={pass2Result === null} onClick={applyFlowCalc}>
+                    Apply to Form ✓
+                  </Button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Input Shaping: built-in IS advisory */}
+      {stepType === "input_shaping" && (
+        <Alert
+          type="info"
+          showIcon
+          icon={<ThunderboltOutlined />}
+          style={{ marginBottom: 20 }}
+          message={<strong>Got a modern printer? You might not need this.</strong>}
+          description={
+            <div>
+              <span style={{ fontSize: 13, lineHeight: 1.55 }}>
+                Most modern CoreXY printers running Klipper with an accelerometer (ADXL345) or any Bambu Lab printer
+                already handle input shaping automatically — and way more accurately than a manual test tower ever
+                could. If this applies to you, skip this step and save yourself the hassle.
+              </span>
+              {onSkipStep && (
+                <div style={{ marginTop: 10 }}>
+                  <Button size="small" onClick={onSkipStep}>
+                    My printer handles this — skip it →
+                  </Button>
+                </div>
+              )}
+            </div>
+          }
+        />
+      )}
+
+      {/* Pressure Advance: method selector */}
+      {stepType === "pressure_advance" && (
+        <div style={{ marginBottom: 20 }}>
+          <SectionLabel>Test Method</SectionLabel>
+          <div style={{ display: "flex", alignItems: "flex-start", gap: 16, flexWrap: "wrap" }}>
+            <Segmented
+              options={[
+                { label: "Tower (Recommended)", value: "tower" },
+                { label: "Pattern / Line", value: "pattern" },
+              ]}
+              value={paMethod}
+              onChange={handlePaMethodChange}
+              size="small"
+              style={{ flexShrink: 0 }}
+            />
+            <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55 }}>
+              {paMethod === "tower"
+                ? "Print the PA tower test. Enter your extruder type, the PA step value (A), and the measured height (B) at the best-looking layer. PA is auto-calculated as A × B."
+                : "Print the PA pattern or line test. Identify the optimal line and enter its PA value directly below."}
+            </Text>
+          </div>
+        </div>
+      )}
+
+      {/* Test Setup */}
+      {config.inputFields.length > 0 && !(stepType === "pressure_advance" && paMethod === "pattern") && (
+        <div style={{ marginBottom: 20 }}>
+          <SectionLabel>Test Setup</SectionLabel>
+          <Row gutter={[16, 0]}>
+            {config.inputFields.map((f) => (
+              <Col key={f.key} span={f.colSpan ?? (f.type === "select" ? 24 : 12)}>
+                <FieldItem field={f} namePrefix="inputs" />
+              </Col>
+            ))}
+          </Row>
+        </div>
+      )}
+
+      {/* VFA: Artifact speeds table */}
+      {stepType === "vfa" && (
+        <div style={{ marginBottom: 20 }}>
+          <SectionLabel>Artifact Speeds</SectionLabel>
+          <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.5, display: "block", marginBottom: 12 }}>
+            Print the VFA test tower and mark each speed where you observe VFA artifacts. Min and Max Avoidance Speed
+            are auto-computed from this list.
+          </Text>
+          {artifactSpeeds.length > 0 && (
+            <div style={{ marginBottom: 10 }}>
+              {artifactSpeeds.map((speed, idx) => (
+                <div
+                  key={idx}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    padding: "4px 10px",
+                    marginBottom: 4,
+                    background: token.colorFillAlter,
+                    borderRadius: token.borderRadius,
+                    border: `1px solid ${token.colorBorderSecondary}`,
+                  }}
+                >
+                  <Text>{speed} mm/s</Text>
+                  <Button
+                    type="text"
+                    size="small"
+                    danger
+                    icon={<DeleteOutlined />}
+                    onClick={() => removeArtifactSpeed(idx)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+          <Row gutter={[8, 0]} align="middle">
+            <Col flex="auto">
+              <InputNumber
+                value={newArtifactSpeed}
+                onChange={(v) => setNewArtifactSpeed(v)}
+                min={0}
+                precision={0}
+                addonAfter="mm/s"
+                placeholder="Speed"
+                style={{ width: "100%" }}
+                onPressEnter={addArtifactSpeed}
+              />
+            </Col>
+            <Col flex="none">
+              <Button
+                type="dashed"
+                icon={<PlusOutlined />}
+                onClick={addArtifactSpeed}
+                disabled={newArtifactSpeed === null}
+              >
+                Add Speed
+              </Button>
+            </Col>
+          </Row>
+        </div>
+      )}
+
+      {/* Your Result — saves to both outputs and selected_values */}
+      <div
+        style={{
+          background: token.colorPrimaryBg,
+          border: `1px solid ${token.colorPrimaryBorder}`,
+          borderRadius: token.borderRadiusLG,
+          padding: "16px 16px 4px",
+          marginBottom: 20,
+        }}
+      >
+        <SectionLabel color={token.colorPrimary}>
+          Your Result
+          {((config.autoCompute && !(stepType === "pressure_advance" && paMethod === "pattern")) ||
+            stepType === "vfa") && (
+            <span
+              style={{
+                fontWeight: 400,
+                fontStyle: "italic",
+                letterSpacing: 0,
+                textTransform: "none",
+                marginLeft: 6,
+                opacity: 0.75,
+              }}
+            >
+              · auto-computed
+            </span>
+          )}
+        </SectionLabel>
+        <Row gutter={[16, 0]}>
+          {config.outputFields.map((f) => (
+            <Col key={f.key} span={f.colSpan ?? (config.outputFields.length > 1 && f.type !== "select" ? 12 : 24)}>
+              <FieldItem field={f} namePrefix="result" />
+            </Col>
+          ))}
+        </Row>
+      </div>
+
+      {/* Confidence + Notes */}
+      <Row gutter={[16, 0]}>
+        <Col span={8}>
+          <Form.Item name="confidence" label="Confidence">
+            <Select
+              options={[
+                { value: "high", label: "High" },
+                { value: "medium", label: "Medium" },
+                { value: "low", label: "Low" },
+              ]}
+              allowClear
+              placeholder="Optional"
+            />
+          </Form.Item>
+        </Col>
+        <Col span={16}>
+          <Form.Item name="notes" label="Notes">
+            <Input.TextArea rows={2} maxLength={1024} placeholder="Optional notes…" />
+          </Form.Item>
+        </Col>
+      </Row>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main wizard
+// ---------------------------------------------------------------------------
+
+interface Props {
+  open: boolean;
+  session: ICalibrationSession;
+  onClose: () => void;
+  onComplete: () => void;
+}
+
+export const CalibrationWizard = ({ open, session, onClose, onComplete }: Props) => {
+  const t = useTranslate();
+  const [form] = useForm();
+  const { token } = theme.useToken();
+
+  const { mutate: createStep, mutation: createMutation } = useCreate<ICalibrationStepResult>();
+  const { mutate: updateSession, mutation: updateMutation } = useUpdate<ICalibrationSession>();
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+
+  const [currentIdx, setCurrentIdx] = useState(0);
+  const currentIdxRef = useRef(0);
+  const setStep = (idx: number) => {
+    currentIdxRef.current = idx;
+    setCurrentIdx(idx);
+  };
+
+  const doneTypes = useRef(new Set(session.steps.map((s) => s.step_type as CalibrationStepType)));
+  const savedValues = useRef<Partial<Record<CalibrationStepType, Record<string, unknown>>>>({});
+
+  // ---- Init / reset on open ---------------------------------------------
+
+  useEffect(() => {
+    if (!open) return;
+
+    doneTypes.current = new Set(session.steps.map((s) => s.step_type as CalibrationStepType));
+    savedValues.current = {};
+    for (const step of session.steps) {
+      savedValues.current[step.step_type as CalibrationStepType] = {
+        inputs: step.inputs ?? {},
+        result: step.selected_values ?? step.outputs ?? {},
+        notes: step.notes,
+        confidence: step.confidence,
+      };
+    }
+
+    const firstPending = WIZARD_STEP_ORDER.findIndex((st) => !doneTypes.current.has(st));
+    const startIdx = firstPending >= 0 ? firstPending : 0;
+
+    form.resetFields();
+    const startType = WIZARD_STEP_ORDER[startIdx];
+    if (savedValues.current[startType]) {
+      form.setFieldsValue(savedValues.current[startType]);
+    }
+    setStep(startIdx);
+  }, [open]);
+
+  // ---- Navigation -------------------------------------------------------
+
+  const navigateTo = (newIdx: number) => {
+    const stepType = WIZARD_STEP_ORDER[currentIdxRef.current];
+    savedValues.current[stepType] = form.getFieldsValue(true);
+    form.resetFields();
+    const nextType = WIZARD_STEP_ORDER[newIdx];
+    if (savedValues.current[nextType]) {
+      form.setFieldsValue(savedValues.current[nextType]);
+    }
+    setStep(newIdx);
+  };
+
+  const currentStepType = WIZARD_STEP_ORDER[currentIdx];
+  const isFirst = currentIdx === 0;
+  const isLast = currentIdx === WIZARD_STEP_ORDER.length - 1;
+  const isCurrentDone = doneTypes.current.has(currentStepType);
+
+  // ---- Save + complete --------------------------------------------------
+
+  const saveCurrentStep = (onDone: () => void) => {
+    const values = form.getFieldsValue(true);
+    const result = values.result ?? null;
+    createStep(
+      {
+        resource: `calibration/session/${session.id}/step`,
+        values: {
+          step_type: currentStepType,
+          inputs: values.inputs ?? null,
+          outputs: result,
+          selected_values: result,
+          notes: values.notes ?? null,
+          confidence: values.confidence ?? null,
+        },
+        successNotification: false,
+      },
+      {
+        onSuccess: () => {
+          doneTypes.current.add(currentStepType);
+          onDone();
+        },
+      },
+    );
+  };
+
+  const markComplete = () => {
+    updateSession(
+      { resource: "calibration/session", id: session.id, values: { status: "complete" }, successNotification: false },
+      { onSuccess: onComplete },
+    );
+  };
+
+  // ---- Button handlers --------------------------------------------------
+
+  const handleSkip = () => {
+    if (isLast) {
+      Modal.confirm({
+        title: t("calibration.wizard.skip_finish_confirm"),
+        okText: t("calibration.wizard.buttons.finish"),
+        cancelText: t("calibration.wizard.buttons.cancel"),
+        onOk: markComplete,
+      });
+    } else {
+      navigateTo(currentIdx + 1);
+    }
+  };
+
+  const handleSaveAndContinue = () => {
+    if (isLast) {
+      saveCurrentStep(markComplete);
+    } else {
+      saveCurrentStep(() => navigateTo(currentIdx + 1));
+    }
+  };
+
+  const handleSaveAsSkipped = () => {
+    // Sentinel convention: outputs: { _skipped: true } marks a step the user deliberately skipped
+    // (e.g. Input Shaping on a printer with built-in IS). CalibrationSection reads this to show
+    // a "Skipped" tag instead of "Done" / "Incomplete".
+    createStep(
+      {
+        resource: `calibration/session/${session.id}/step`,
+        values: {
+          step_type: currentStepType,
+          inputs: null,
+          outputs: { _skipped: true },
+          selected_values: null,
+          notes: null,
+          confidence: null,
+        },
+        successNotification: false,
+      },
+      {
+        onSuccess: () => {
+          doneTypes.current.add(currentStepType);
+          if (isLast) markComplete();
+          else navigateTo(currentIdx + 1);
+        },
+      },
+    );
+  };
+
+  // ---- Render -----------------------------------------------------------
+
+  return (
+    <Modal
+      title={
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingRight: 36,
+          }}
+        >
+          <span>{t("calibration.wizard.title")}</span>
+          <Space size={8}>
+            {isCurrentDone && (
+              <Tag color="blue" style={{ margin: 0 }}>
+                Revisiting
+              </Tag>
+            )}
+            <Text type="secondary" style={{ fontSize: 13, fontWeight: 400 }}>
+              {currentIdx + 1} / {WIZARD_STEP_ORDER.length}
+            </Text>
+          </Space>
+        </div>
+      }
+      open={open}
+      onCancel={onClose}
+      width={880}
+      centered
+      styles={{
+        content: { display: "flex", flexDirection: "column", maxHeight: "90vh" },
+        body: { padding: 0, flex: 1, minHeight: 0, overflow: "hidden" },
+      }}
+      footer={
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <Button
+            type="text"
+            icon={<PauseCircleOutlined />}
+            onClick={onClose}
+            style={{ color: token.colorTextSecondary }}
+          >
+            {t("calibration.wizard.buttons.cancel")}
+          </Button>
+          <Space>
+            <Button disabled={isFirst || isLoading} onClick={() => navigateTo(currentIdx - 1)}>
+              {t("calibration.wizard.buttons.back")}
+            </Button>
+            <Button disabled={isLoading} onClick={handleSkip}>
+              {isLast ? t("calibration.wizard.buttons.skip_finish") : t("calibration.wizard.buttons.skip")}
+            </Button>
+            <Button type="primary" loading={isLoading} onClick={handleSaveAndContinue}>
+              {isLast ? t("calibration.wizard.buttons.save_finish") : t("calibration.wizard.buttons.save_continue")}
+            </Button>
+          </Space>
+        </div>
+      }
+    >
+      <div style={{ display: "flex", flex: 1, minHeight: 440, overflow: "hidden" }}>
+        {/* Sidebar — custom fixed-height nav to prevent reflow on wrap */}
+        <div
+          style={{
+            width: 190,
+            flexShrink: 0,
+            padding: "12px 8px",
+            borderRight: `1px solid ${token.colorBorderSecondary}`,
+            background: token.colorBgLayout,
+            overflowY: "auto",
+          }}
+        >
+          {WIZARD_STEP_ORDER.map((stepType, idx) => {
+            const isCurrent = idx === currentIdx;
+            const isDone = doneTypes.current.has(stepType);
+            return (
+              <div
+                key={stepType}
+                onClick={() => navigateTo(idx)}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  height: 36,
+                  padding: "0 8px",
+                  borderRadius: token.borderRadius,
+                  cursor: "pointer",
+                  userSelect: "none",
+                  background: isCurrent ? token.colorPrimaryBg : "transparent",
+                  transition: "background 0.15s",
+                  marginBottom: 2,
+                }}
+                onMouseEnter={(e) => {
+                  if (!isCurrent) (e.currentTarget as HTMLDivElement).style.background = token.colorFillAlter;
+                }}
+                onMouseLeave={(e) => {
+                  if (!isCurrent) (e.currentTarget as HTMLDivElement).style.background = "transparent";
+                }}
+              >
+                {/* Step indicator circle */}
+                <div
+                  style={{
+                    width: 20,
+                    height: 20,
+                    borderRadius: "50%",
+                    flexShrink: 0,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    lineHeight: 1,
+                    background: isCurrent
+                      ? token.colorPrimary
+                      : isDone
+                        ? token.colorSuccessBg
+                        : token.colorFillSecondary,
+                    color: isCurrent ? token.colorWhite : isDone ? token.colorSuccess : token.colorTextTertiary,
+                    border: isDone && !isCurrent ? `1px solid ${token.colorSuccessBorder}` : "none",
+                  }}
+                >
+                  {isDone && !isCurrent ? <CheckOutlined style={{ fontSize: 10 }} /> : idx + 1}
+                </div>
+                {/* Step title — nowrap + ellipsis prevents reflow */}
+                <span
+                  style={{
+                    fontSize: 13,
+                    lineHeight: 1.2,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                    color: isCurrent ? token.colorPrimaryText : isDone ? token.colorTextSecondary : token.colorText,
+                    fontWeight: isCurrent ? 500 : 400,
+                  }}
+                >
+                  {WIZARD_COPY[stepType].title}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Content panel */}
+        <div
+          style={{
+            flex: 1,
+            padding: "24px 28px 16px",
+            overflowY: "auto",
+          }}
+        >
+          <Form form={form} layout="vertical">
+            <StepContent stepType={currentStepType} onSkipStep={handleSaveAsSkipped} />
+          </Form>
+        </div>
+      </div>
+    </Modal>
+  );
+};
+
+export default CalibrationWizard;

--- a/client/src/pages/calibration/SessionFormModal.tsx
+++ b/client/src/pages/calibration/SessionFormModal.tsx
@@ -1,0 +1,106 @@
+import { useCreate, useTranslate, useUpdate } from "@refinedev/core";
+import { Form, Input, InputNumber, Modal, Select } from "antd";
+import { useForm } from "antd/es/form/Form";
+import { useEffect } from "react";
+import { CalibrationStatus, ICalibrationSession } from "./model";
+
+interface Props {
+  open: boolean;
+  mode: "create" | "edit";
+  filamentId?: number;
+  initialValues?: Partial<ICalibrationSession>;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+const STATUS_OPTIONS: { label: string; value: CalibrationStatus }[] = [
+  { label: "Planned", value: "planned" },
+  { label: "In Progress", value: "in_progress" },
+  { label: "Complete", value: "complete" },
+  { label: "Archived", value: "archived" },
+];
+
+export const SessionFormModal = ({ open, mode, filamentId, initialValues, onSuccess, onClose }: Props) => {
+  const t = useTranslate();
+  const [form] = useForm();
+
+  const { mutate: createSession, mutation: createMutation } = useCreate<ICalibrationSession>();
+  const { mutate: updateSession, mutation: updateMutation } = useUpdate<ICalibrationSession>();
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+
+  useEffect(() => {
+    if (open) {
+      form.resetFields();
+      if (initialValues) {
+        form.setFieldsValue({
+          status: initialValues.status ?? "planned",
+          printer_name: initialValues.printer_name,
+          nozzle_diameter: initialValues.nozzle_diameter,
+          notes: initialValues.notes,
+        });
+      }
+    }
+  }, [open, initialValues, form]);
+
+  const onFinish = (values: Record<string, unknown>) => {
+    if (mode === "create") {
+      createSession(
+        {
+          resource: "calibration/session",
+          values: { ...values, filament_id: filamentId },
+          successNotification: false,
+        },
+        {
+          onSuccess: () => {
+            onSuccess();
+            onClose();
+          },
+        },
+      );
+    } else if (initialValues?.id !== undefined) {
+      updateSession(
+        {
+          resource: "calibration/session",
+          id: initialValues.id,
+          values,
+          successNotification: false,
+        },
+        {
+          onSuccess: () => {
+            onSuccess();
+            onClose();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Modal
+      title={mode === "create" ? t("calibration.session_form.create_title") : t("calibration.session_form.edit_title")}
+      open={open}
+      onCancel={onClose}
+      onOk={form.submit}
+      okText={t("calibration.buttons.save")}
+      confirmLoading={isLoading}
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" onFinish={onFinish} initialValues={{ status: "planned" }}>
+        <Form.Item name="status" label={t("calibration.fields.status")}>
+          <Select options={STATUS_OPTIONS} />
+        </Form.Item>
+        <Form.Item name="printer_name" label={t("calibration.fields.printer_name")}>
+          <Input maxLength={256} placeholder="e.g. Bambu X1C, Ender 3" />
+        </Form.Item>
+        <Form.Item name="nozzle_diameter" label={t("calibration.fields.nozzle_diameter")}>
+          <InputNumber min={0.1} max={2.0} step={0.1} precision={2} addonAfter="mm" style={{ width: "100%" }} />
+        </Form.Item>
+        <Form.Item name="notes" label={t("calibration.fields.notes")}>
+          <Input.TextArea rows={3} maxLength={1024} />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+};
+
+export default SessionFormModal;

--- a/client/src/pages/calibration/StepResultDrawer.tsx
+++ b/client/src/pages/calibration/StepResultDrawer.tsx
@@ -1,0 +1,917 @@
+import { BookOutlined, CheckOutlined, DeleteOutlined, PlusOutlined, ThunderboltOutlined } from "@ant-design/icons";
+import { useCreate, useTranslate, useUpdate } from "@refinedev/core";
+import {
+  Alert,
+  Button,
+  Col,
+  Divider,
+  Drawer,
+  Form,
+  Input,
+  InputNumber,
+  Row,
+  Segmented,
+  Select,
+  Space,
+  Tag,
+  Tooltip,
+  Typography,
+  theme,
+} from "antd";
+import { useForm } from "antd/es/form/Form";
+import { type ReactNode, useEffect, useState } from "react";
+import { CalibrationStepType, ICalibrationStepResult } from "./model";
+import { STEP_CONFIGS, StepField } from "./stepConfig";
+import { WIZARD_COPY } from "./wizardCopy";
+
+const { Text } = Typography;
+
+const STEP_TYPE_OPTIONS: { value: CalibrationStepType; label: string }[] = [
+  { value: "temperature", label: "Temperature" },
+  { value: "volumetric_speed", label: "Volumetric Speed" },
+  { value: "pressure_advance", label: "Pressure Advance" },
+  { value: "flow_rate", label: "Flow Rate" },
+  { value: "retraction", label: "Retraction" },
+  { value: "tolerance", label: "Tolerance" },
+  { value: "cornering", label: "Cornering" },
+  { value: "input_shaping", label: "Input Shaping" },
+  { value: "vfa", label: "VFA" },
+];
+
+const CONFIDENCE_OPTIONS = [
+  { value: "high", label: "High" },
+  { value: "medium", label: "Medium" },
+  { value: "low", label: "Low" },
+];
+
+// ---------------------------------------------------------------------------
+// Shared sub-components (mirrors CalibrationWizard)
+// ---------------------------------------------------------------------------
+
+function FieldItem({ field, namePrefix }: { field: StepField; namePrefix: string }) {
+  const control =
+    field.type === "select" ? (
+      <Select options={field.options} style={{ width: "100%" }} />
+    ) : (
+      <InputNumber
+        min={field.min}
+        max={field.max}
+        step={field.step ?? 1}
+        precision={field.precision ?? 0}
+        addonAfter={field.unit}
+        style={{ width: "100%" }}
+      />
+    );
+  return (
+    <Form.Item name={[namePrefix, field.key]} label={field.label}>
+      {control}
+    </Form.Item>
+  );
+}
+
+function SectionLabel({ children, color }: { children: ReactNode; color?: string }) {
+  return (
+    <Text
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: "0.1em",
+        textTransform: "uppercase",
+        display: "block",
+        marginBottom: 12,
+        color: color,
+        opacity: color ? 1 : 0.45,
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Drawer
+// ---------------------------------------------------------------------------
+
+interface Props {
+  open: boolean;
+  sessionId: number;
+  step?: ICalibrationStepResult;
+  onSuccess: () => void;
+  onClose: () => void;
+}
+
+export const StepResultDrawer = ({ open, sessionId, step, onSuccess, onClose }: Props) => {
+  const t = useTranslate();
+  const [form] = useForm();
+  const { token } = theme.useToken();
+  const isEditing = step !== undefined;
+
+  const { mutate: createStep, mutation: createMutation } = useCreate<ICalibrationStepResult>();
+  const { mutate: updateStep, mutation: updateMutation } = useUpdate<ICalibrationStepResult>();
+  const isLoading = createMutation.isPending || updateMutation.isPending;
+
+  const stepType: CalibrationStepType | undefined = Form.useWatch("step_type", form);
+  const config = stepType ? STEP_CONFIGS[stepType] : null;
+  const copy = stepType ? WIZARD_COPY[stepType] : null;
+
+  // ---- Flow rate calculator state (mirrors CalibrationWizard) ----
+  type FlowCalcMethod = "yolo" | "legacy";
+  type FlowCalcPhase = "idle" | "pass1" | "pass2";
+  const [flowCalcMethod, setFlowCalcMethod] = useState<FlowCalcMethod>("yolo");
+  const [flowCalcPhase, setFlowCalcPhase] = useState<FlowCalcPhase>("idle");
+  const [yoloFlowRatioOld, setYoloFlowRatioOld] = useState<number | null>(1.0);
+  const [yoloModifier, setYoloModifier] = useState<number | null>(null);
+  const [pass1FlowRatio, setPass1FlowRatio] = useState<number | null>(1.0);
+  const [pass1Modifier, setPass1Modifier] = useState<number | null>(null);
+  const [pass2FlowRatio, setPass2FlowRatio] = useState<number | null>(null);
+  const [pass2Modifier, setPass2Modifier] = useState<number | null>(null);
+
+  // ---- VFA artifact speeds state (mirrors CalibrationWizard) ----
+  const [artifactSpeeds, setArtifactSpeeds] = useState<number[]>([]);
+  const [newArtifactSpeed, setNewArtifactSpeed] = useState<number | null>(null);
+
+  // ---- PA method selector (mirrors CalibrationWizard) ----
+  const [paMethod, setPaMethod] = useState<"tower" | "pattern">("tower");
+
+  const resetFlowCalcState = () => {
+    setFlowCalcPhase("idle");
+    setYoloFlowRatioOld(1.0);
+    setYoloModifier(null);
+    setPass1FlowRatio(1.0);
+    setPass1Modifier(null);
+    setPass2FlowRatio(null);
+    setPass2Modifier(null);
+  };
+
+  const handleFlowMethodChange = (val: string | number) => {
+    setFlowCalcMethod(val as FlowCalcMethod);
+    resetFlowCalcState();
+  };
+
+  // Reset all calculator/special UI state when step type changes
+  useEffect(() => {
+    setFlowCalcMethod("yolo");
+    resetFlowCalcState();
+    setArtifactSpeeds([]);
+    setNewArtifactSpeed(null);
+    setPaMethod("tower");
+  }, [stepType]);
+
+  const handlePaMethodChange = (val: string | number) => {
+    setPaMethod(val as "tower" | "pattern");
+    form.setFieldValue("result", {});
+  };
+
+  // Init / reset when drawer opens
+  useEffect(() => {
+    if (!open) return;
+    form.resetFields();
+    setFlowCalcMethod("yolo");
+    resetFlowCalcState();
+    setArtifactSpeeds([]);
+    setNewArtifactSpeed(null);
+    if (step) {
+      form.setFieldsValue({
+        step_type: step.step_type,
+        inputs: step.inputs ?? {},
+        result: step.selected_values ?? step.outputs ?? {},
+        notes: step.notes,
+        confidence: step.confidence,
+      });
+      // Infer PA method from saved inputs: tower has pa_step_a / measured_height_b
+      if (step.step_type === "pressure_advance") {
+        const hasTowerInputs =
+          step.inputs != null && (step.inputs.pa_step_a !== undefined || step.inputs.measured_height_b !== undefined);
+        setPaMethod(hasTowerInputs ? "tower" : "pattern");
+      } else {
+        setPaMethod("tower");
+      }
+    } else {
+      setPaMethod("tower");
+    }
+  }, [open, step]);
+
+  // Auto-compute result fields from inputs
+  const inputValues = Form.useWatch("inputs", form) as Record<string, number | null> | undefined;
+  useEffect(() => {
+    if (!config?.autoCompute || !inputValues) return;
+    if (stepType === "pressure_advance" && paMethod === "pattern") return;
+    const computed = config.autoCompute(inputValues);
+    if (Object.keys(computed).length > 0) {
+      const current: Record<string, unknown> = form.getFieldValue("result") ?? {};
+      form.setFieldValue("result", { ...current, ...computed });
+    }
+  }, [inputValues, paMethod]);
+
+  // VFA: auto-compute avoidance speed range from artifact speeds list
+  useEffect(() => {
+    if (stepType !== "vfa") return;
+    const current: Record<string, unknown> = form.getFieldValue("result") ?? {};
+    if (artifactSpeeds.length === 0) {
+      form.setFieldValue("result", { ...current, min_avoidance_speed: null, max_avoidance_speed: null });
+    } else {
+      const min = Math.min(...artifactSpeeds);
+      const max = Math.max(...artifactSpeeds);
+      form.setFieldValue("result", { ...current, min_avoidance_speed: min, max_avoidance_speed: max });
+    }
+  }, [artifactSpeeds]);
+
+  // Computed flow results
+  const yoloResult =
+    yoloFlowRatioOld !== null && yoloModifier !== null && !isNaN(yoloFlowRatioOld) && !isNaN(yoloModifier)
+      ? parseFloat((yoloFlowRatioOld + yoloModifier).toFixed(5))
+      : null;
+  const pass1Result =
+    pass1FlowRatio !== null && pass1Modifier !== null && !isNaN(pass1FlowRatio) && !isNaN(pass1Modifier)
+      ? parseFloat(((pass1FlowRatio * (100 + pass1Modifier)) / 100).toFixed(5))
+      : null;
+  const pass2Result =
+    pass2FlowRatio !== null && pass2Modifier !== null && !isNaN(pass2FlowRatio) && !isNaN(pass2Modifier)
+      ? parseFloat(((pass2FlowRatio * (100 + pass2Modifier)) / 100).toFixed(5))
+      : null;
+
+  const applyFlowCalc = () => {
+    const finalRatio = flowCalcMethod === "yolo" ? yoloResult : (pass2Result ?? pass1Result);
+    if (finalRatio !== null) {
+      const current = form.getFieldValue("result") ?? {};
+      form.setFieldValue("result", { ...current, flow_ratio: finalRatio });
+    }
+    resetFlowCalcState();
+  };
+
+  const addArtifactSpeed = () => {
+    if (newArtifactSpeed === null || isNaN(newArtifactSpeed)) return;
+    setArtifactSpeeds((prev) => [...prev, newArtifactSpeed].sort((a, b) => a - b));
+    setNewArtifactSpeed(null);
+  };
+
+  const removeArtifactSpeed = (idx: number) => {
+    setArtifactSpeeds((prev) => prev.filter((_, i) => i !== idx));
+  };
+
+  const onFinish = (values: Record<string, unknown>) => {
+    const payload = {
+      step_type: values.step_type,
+      inputs: values.inputs ?? null,
+      outputs: values.result ?? null,
+      selected_values: values.result ?? null,
+      notes: values.notes ?? null,
+      confidence: values.confidence ?? null,
+    };
+    if (!isEditing) {
+      createStep(
+        { resource: `calibration/session/${sessionId}/step`, values: payload, successNotification: false },
+        {
+          onSuccess: () => {
+            onSuccess();
+            onClose();
+          },
+        },
+      );
+    } else {
+      updateStep(
+        { resource: "calibration/step", id: step.id, values: payload, successNotification: false },
+        {
+          onSuccess: () => {
+            onSuccess();
+            onClose();
+          },
+        },
+      );
+    }
+  };
+
+  return (
+    <Drawer
+      title={isEditing ? t("calibration.step_form.edit_title") : t("calibration.step_form.add_title")}
+      open={open}
+      onClose={onClose}
+      width={520}
+      extra={
+        <Button type="primary" onClick={form.submit} loading={isLoading}>
+          {t("calibration.buttons.save")}
+        </Button>
+      }
+      destroyOnClose
+    >
+      <Form form={form} layout="vertical" onFinish={onFinish}>
+        {/* Step type selector */}
+        <Form.Item
+          name="step_type"
+          label={t("calibration.fields.step_type")}
+          rules={[{ required: true, message: "Please select a calibration step." }]}
+        >
+          <Select options={STEP_TYPE_OPTIONS} disabled={isEditing} placeholder="Select a calibration step" />
+        </Form.Item>
+
+        {config && copy && (
+          <>
+            {/* Step description + wiki link */}
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 20 }}>
+              <Text type="secondary" style={{ fontSize: 13, flex: 1, lineHeight: 1.5 }}>
+                {copy.description.split(". ")[0] + "."}
+              </Text>
+              {copy.wikiUrl && (
+                <Tooltip title="Open OrcaSlicer wiki for this step">
+                  <a
+                    href={copy.wikiUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: 4,
+                      fontSize: 12,
+                      color: token.colorTextTertiary,
+                      textDecoration: "none",
+                      padding: "2px 6px",
+                      borderRadius: token.borderRadius,
+                      border: `1px solid ${token.colorBorderSecondary}`,
+                      flexShrink: 0,
+                      lineHeight: 1.5,
+                    }}
+                  >
+                    <BookOutlined style={{ fontSize: 12 }} />
+                    Wiki
+                  </a>
+                </Tooltip>
+              )}
+            </div>
+
+            {/* Input Shaping: built-in IS advisory */}
+            {stepType === "input_shaping" && (
+              <Alert
+                type="info"
+                showIcon
+                icon={<ThunderboltOutlined />}
+                style={{ marginBottom: 20 }}
+                message={<strong>Got a modern printer? You might not need this.</strong>}
+                description={
+                  <div>
+                    <span style={{ fontSize: 13, lineHeight: 1.55 }}>
+                      Most modern CoreXY printers running Klipper with an accelerometer (ADXL345) or any Bambu Lab
+                      printer already handle input shaping automatically — and way more accurately than a manual test
+                      tower ever could. If this applies to you, just close this drawer without saving.
+                    </span>
+                  </div>
+                }
+              />
+            )}
+
+            {/* Flow Rate: pass result calculator */}
+            {stepType === "flow_rate" && (
+              <div
+                style={{
+                  marginBottom: 20,
+                  borderRadius: token.borderRadiusLG,
+                  border: `1px solid ${flowCalcPhase === "idle" ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
+                  overflow: "hidden",
+                  transition: "border-color 0.25s",
+                }}
+              >
+                {/* Header */}
+                <div
+                  style={{
+                    padding: "8px 16px",
+                    background: flowCalcPhase === "idle" ? token.colorFillAlter : token.colorPrimaryBg,
+                    borderBottom: `1px solid ${flowCalcPhase === "idle" ? token.colorBorderSecondary : token.colorPrimaryBorder}`,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    transition: "background 0.25s, border-color 0.25s",
+                  }}
+                >
+                  <Text
+                    style={{
+                      fontSize: 10,
+                      fontWeight: 700,
+                      letterSpacing: "0.1em",
+                      textTransform: "uppercase",
+                      color: flowCalcPhase !== "idle" ? token.colorPrimary : undefined,
+                      opacity: flowCalcPhase === "idle" ? 0.45 : 1,
+                      transition: "color 0.2s",
+                    }}
+                  >
+                    Pass Result Calculator
+                  </Text>
+                  {flowCalcPhase !== "idle" &&
+                    (flowCalcMethod === "yolo" ? (
+                      <Tag color="blue" style={{ margin: 0, fontSize: 11 }}>
+                        YOLO
+                      </Tag>
+                    ) : (
+                      <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                          <div
+                            style={{
+                              width: 18,
+                              height: 18,
+                              borderRadius: "50%",
+                              flexShrink: 0,
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              background: flowCalcPhase === "pass1" ? token.colorPrimary : token.colorSuccessBg,
+                              border: flowCalcPhase !== "pass1" ? `1px solid ${token.colorSuccessBorder}` : "none",
+                              fontSize: 9,
+                              fontWeight: 700,
+                            }}
+                          >
+                            {flowCalcPhase === "pass1" ? (
+                              <span style={{ color: token.colorWhite }}>1</span>
+                            ) : (
+                              <CheckOutlined style={{ color: token.colorSuccess, fontSize: 9 }} />
+                            )}
+                          </div>
+                          <Text
+                            style={{
+                              fontSize: 12,
+                              fontWeight: flowCalcPhase === "pass1" ? 500 : 400,
+                              color: flowCalcPhase === "pass1" ? token.colorPrimaryText : token.colorTextSecondary,
+                            }}
+                          >
+                            Pass 1
+                          </Text>
+                          {flowCalcPhase === "pass2" && pass1Result !== null && (
+                            <Tag style={{ margin: 0, fontSize: 11, lineHeight: "18px" }}>{pass1Result}</Tag>
+                          )}
+                        </div>
+                        <div style={{ width: 20, height: 1, background: token.colorBorderSecondary, flexShrink: 0 }} />
+                        <div style={{ display: "flex", alignItems: "center", gap: 4 }}>
+                          <div
+                            style={{
+                              width: 18,
+                              height: 18,
+                              borderRadius: "50%",
+                              flexShrink: 0,
+                              display: "flex",
+                              alignItems: "center",
+                              justifyContent: "center",
+                              background: flowCalcPhase === "pass2" ? token.colorPrimary : token.colorFillSecondary,
+                              fontSize: 9,
+                              fontWeight: 700,
+                            }}
+                          >
+                            <span
+                              style={{ color: flowCalcPhase === "pass2" ? token.colorWhite : token.colorTextTertiary }}
+                            >
+                              2
+                            </span>
+                          </div>
+                          <Text
+                            style={{
+                              fontSize: 12,
+                              fontWeight: flowCalcPhase === "pass2" ? 500 : 400,
+                              color: flowCalcPhase === "pass2" ? token.colorPrimaryText : token.colorTextTertiary,
+                            }}
+                          >
+                            Pass 2
+                          </Text>
+                        </div>
+                      </div>
+                    ))}
+                </div>
+
+                {/* Body */}
+                <div style={{ padding: "14px 16px" }}>
+                  {/* Idle */}
+                  {flowCalcPhase === "idle" && (
+                    <div>
+                      <div style={{ marginBottom: 12 }}>
+                        <Segmented
+                          options={[
+                            { label: "YOLO (Recommended)", value: "yolo" },
+                            { label: "Legacy (2-Pass)", value: "legacy" },
+                          ]}
+                          value={flowCalcMethod}
+                          onChange={handleFlowMethodChange}
+                          size="small"
+                        />
+                      </div>
+                      <div
+                        style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16 }}
+                      >
+                        <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55, flex: 1 }}>
+                          {flowCalcMethod === "yolo"
+                            ? "Single-pass calibration using the Archimedean Chords pattern (OrcaSlicer ≥ 2.3.0). Enter your current flow ratio and the correction value observed on the print."
+                            : "Two-pass calibration. Step through your first and second pass results to calculate your final flow ratio."}
+                        </Text>
+                        <Button
+                          type="primary"
+                          ghost
+                          size="small"
+                          onClick={() => setFlowCalcPhase("pass1")}
+                          style={{ flexShrink: 0, whiteSpace: "nowrap" }}
+                        >
+                          Start →
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* YOLO pass 1 */}
+                  {flowCalcPhase === "pass1" && flowCalcMethod === "yolo" && (
+                    <div>
+                      <Text
+                        type="secondary"
+                        style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}
+                      >
+                        Print the Archimedean Chords test model. Enter your current flow ratio and the correction value
+                        shown on the print.
+                      </Text>
+                      <Row gutter={[10, 0]} align="bottom">
+                        <Col span={8}>
+                          <Form.Item label="Current Flow Ratio" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={yoloFlowRatioOld}
+                              onChange={(v) => setYoloFlowRatioOld(v)}
+                              min={0.1}
+                              max={2}
+                              step={0.001}
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={yoloModifier}
+                              onChange={(v) => setYoloModifier(v)}
+                              min={-1}
+                              max={1}
+                              step={0.001}
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item
+                            label={
+                              <span
+                                style={{ color: yoloResult !== null ? token.colorPrimary : undefined, fontWeight: 500 }}
+                              >
+                                New Flow Ratio
+                              </span>
+                            }
+                            style={{ marginBottom: 8 }}
+                          >
+                            <InputNumber
+                              value={yoloResult ?? undefined}
+                              disabled
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                      </Row>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                        <Button
+                          size="small"
+                          type="text"
+                          onClick={() => {
+                            setFlowCalcPhase("idle");
+                            setYoloFlowRatioOld(1.0);
+                            setYoloModifier(null);
+                          }}
+                          style={{ color: token.colorTextTertiary }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button size="small" type="primary" disabled={yoloResult === null} onClick={applyFlowCalc}>
+                          Apply to Form ✓
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Legacy pass 1 */}
+                  {flowCalcPhase === "pass1" && flowCalcMethod === "legacy" && (
+                    <div>
+                      <Text
+                        type="secondary"
+                        style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}
+                      >
+                        Print your first pass test model. Enter your starting flow ratio and the correction percentage
+                        observed on the print.
+                      </Text>
+                      <Row gutter={[10, 0]} align="bottom">
+                        <Col span={8}>
+                          <Form.Item label="Flow Ratio" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={pass1FlowRatio}
+                              onChange={(v) => setPass1FlowRatio(v)}
+                              min={0.1}
+                              max={2}
+                              step={0.00001}
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={pass1Modifier}
+                              onChange={(v) => setPass1Modifier(v)}
+                              min={-50}
+                              max={50}
+                              step={0.1}
+                              precision={1}
+                              addonAfter="%"
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item
+                            label={
+                              <span
+                                style={{
+                                  color: pass1Result !== null ? token.colorPrimary : undefined,
+                                  fontWeight: 500,
+                                }}
+                              >
+                                Result
+                              </span>
+                            }
+                            style={{ marginBottom: 8 }}
+                          >
+                            <InputNumber
+                              value={pass1Result ?? undefined}
+                              disabled
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                      </Row>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                        <Button
+                          size="small"
+                          type="text"
+                          onClick={() => {
+                            setFlowCalcPhase("idle");
+                            setPass1FlowRatio(1.0);
+                            setPass1Modifier(null);
+                          }}
+                          style={{ color: token.colorTextTertiary }}
+                        >
+                          Cancel
+                        </Button>
+                        <Button
+                          size="small"
+                          type="primary"
+                          disabled={pass1Result === null}
+                          onClick={() => {
+                            setPass2FlowRatio(pass1Result);
+                            setFlowCalcPhase("pass2");
+                          }}
+                        >
+                          Next: Pass 2 →
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+
+                  {/* Legacy pass 2 */}
+                  {flowCalcPhase === "pass2" && (
+                    <div>
+                      <Text
+                        type="secondary"
+                        style={{ fontSize: 13, lineHeight: 1.55, display: "block", marginBottom: 14 }}
+                      >
+                        Set your slicer flow ratio to the Pass 1 result, reprint the test model, then enter the new
+                        correction percentage.
+                      </Text>
+                      <Row gutter={[10, 0]} align="bottom">
+                        <Col span={8}>
+                          <Form.Item label="Flow Ratio" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={pass2FlowRatio}
+                              onChange={(v) => setPass2FlowRatio(v)}
+                              min={0.1}
+                              max={2}
+                              step={0.00001}
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item label="Modifier" style={{ marginBottom: 8 }}>
+                            <InputNumber
+                              value={pass2Modifier}
+                              onChange={(v) => setPass2Modifier(v)}
+                              min={-50}
+                              max={50}
+                              step={0.1}
+                              precision={1}
+                              addonAfter="%"
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                        <Col span={8}>
+                          <Form.Item
+                            label={
+                              <span
+                                style={{
+                                  color: pass2Result !== null ? token.colorPrimary : undefined,
+                                  fontWeight: 500,
+                                }}
+                              >
+                                Result
+                              </span>
+                            }
+                            style={{ marginBottom: 8 }}
+                          >
+                            <InputNumber
+                              value={pass2Result ?? undefined}
+                              disabled
+                              precision={5}
+                              style={{ width: "100%" }}
+                            />
+                          </Form.Item>
+                        </Col>
+                      </Row>
+                      <div style={{ display: "flex", justifyContent: "space-between", marginTop: 4 }}>
+                        <Button
+                          size="small"
+                          onClick={() => {
+                            setFlowCalcPhase("pass1");
+                            setPass2Modifier(null);
+                          }}
+                        >
+                          ← Back
+                        </Button>
+                        <Button size="small" type="primary" disabled={pass2Result === null} onClick={applyFlowCalc}>
+                          Apply to Form ✓
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {/* Pressure Advance: method selector */}
+            {stepType === "pressure_advance" && (
+              <div style={{ marginBottom: 20 }}>
+                <SectionLabel>Test Method</SectionLabel>
+                <div style={{ display: "flex", alignItems: "flex-start", gap: 16, flexWrap: "wrap" }}>
+                  <Segmented
+                    options={[
+                      { label: "Tower (Recommended)", value: "tower" },
+                      { label: "Pattern / Line", value: "pattern" },
+                    ]}
+                    value={paMethod}
+                    onChange={handlePaMethodChange}
+                    size="small"
+                    style={{ flexShrink: 0 }}
+                  />
+                  <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.55 }}>
+                    {paMethod === "tower"
+                      ? "Print the PA tower test. Enter your extruder type, the PA step value (A), and the measured height (B) at the best-looking layer. PA is auto-calculated as A × B."
+                      : "Print the PA pattern or line test. Identify the optimal line and enter its PA value directly below."}
+                  </Text>
+                </div>
+              </div>
+            )}
+
+            {/* Test Setup */}
+            {config.inputFields.length > 0 && !(stepType === "pressure_advance" && paMethod === "pattern") && (
+              <div style={{ marginBottom: 20 }}>
+                <SectionLabel>Test Setup</SectionLabel>
+                <Row gutter={[16, 0]}>
+                  {config.inputFields.map((f) => (
+                    <Col key={f.key} span={f.colSpan ?? (f.type === "select" ? 24 : 12)}>
+                      <FieldItem field={f} namePrefix="inputs" />
+                    </Col>
+                  ))}
+                </Row>
+              </div>
+            )}
+
+            {/* VFA: Artifact speeds table */}
+            {stepType === "vfa" && (
+              <div style={{ marginBottom: 20 }}>
+                <SectionLabel>Artifact Speeds</SectionLabel>
+                <Text type="secondary" style={{ fontSize: 13, lineHeight: 1.5, display: "block", marginBottom: 12 }}>
+                  Print the VFA test tower and mark each speed where you observe VFA artifacts. Min and Max Avoidance
+                  Speed are auto-computed from this list.
+                </Text>
+                {artifactSpeeds.length > 0 && (
+                  <div style={{ marginBottom: 10 }}>
+                    {artifactSpeeds.map((speed, idx) => (
+                      <div
+                        key={idx}
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                          padding: "4px 10px",
+                          marginBottom: 4,
+                          background: token.colorFillAlter,
+                          borderRadius: token.borderRadius,
+                          border: `1px solid ${token.colorBorderSecondary}`,
+                        }}
+                      >
+                        <Text>{speed} mm/s</Text>
+                        <Button
+                          type="text"
+                          size="small"
+                          danger
+                          icon={<DeleteOutlined />}
+                          onClick={() => removeArtifactSpeed(idx)}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <Row gutter={[8, 0]} align="middle">
+                  <Col flex="auto">
+                    <InputNumber
+                      value={newArtifactSpeed}
+                      onChange={(v) => setNewArtifactSpeed(v)}
+                      min={0}
+                      precision={0}
+                      addonAfter="mm/s"
+                      placeholder="Speed"
+                      style={{ width: "100%" }}
+                      onPressEnter={addArtifactSpeed}
+                    />
+                  </Col>
+                  <Col flex="none">
+                    <Button
+                      type="dashed"
+                      icon={<PlusOutlined />}
+                      onClick={addArtifactSpeed}
+                      disabled={newArtifactSpeed === null}
+                    >
+                      Add Speed
+                    </Button>
+                  </Col>
+                </Row>
+              </div>
+            )}
+
+            {/* Your Result */}
+            <div
+              style={{
+                background: token.colorPrimaryBg,
+                border: `1px solid ${token.colorPrimaryBorder}`,
+                borderRadius: token.borderRadiusLG,
+                padding: "16px 16px 4px",
+                marginBottom: 20,
+              }}
+            >
+              <SectionLabel color={token.colorPrimary}>
+                Your Result
+                {((config.autoCompute && !(stepType === "pressure_advance" && paMethod === "pattern")) ||
+                  stepType === "vfa") && (
+                  <span
+                    style={{
+                      fontWeight: 400,
+                      fontStyle: "italic",
+                      letterSpacing: 0,
+                      textTransform: "none",
+                      marginLeft: 6,
+                      opacity: 0.75,
+                    }}
+                  >
+                    · auto-computed
+                  </span>
+                )}
+              </SectionLabel>
+              <Row gutter={[16, 0]}>
+                {config.outputFields.map((f) => (
+                  <Col
+                    key={f.key}
+                    span={f.colSpan ?? (config.outputFields.length > 1 && f.type !== "select" ? 12 : 24)}
+                  >
+                    <FieldItem field={f} namePrefix="result" />
+                  </Col>
+                ))}
+              </Row>
+            </div>
+
+            <Divider style={{ margin: "4px 0 20px" }} />
+          </>
+        )}
+
+        <Space direction="vertical" style={{ width: "100%" }} size={0}>
+          <Form.Item name="confidence" label={t("calibration.fields.confidence")}>
+            <Select options={CONFIDENCE_OPTIONS} allowClear placeholder="Optional" />
+          </Form.Item>
+          <Form.Item name="notes" label={t("calibration.fields.notes")}>
+            <Input.TextArea rows={3} maxLength={1024} />
+          </Form.Item>
+        </Space>
+      </Form>
+    </Drawer>
+  );
+};
+
+export default StepResultDrawer;

--- a/client/src/pages/calibration/model.ts
+++ b/client/src/pages/calibration/model.ts
@@ -1,0 +1,37 @@
+export type CalibrationStatus = "planned" | "in_progress" | "complete" | "archived";
+
+export type CalibrationStepType =
+  | "temperature"
+  | "volumetric_speed"
+  | "pressure_advance"
+  | "flow_rate"
+  | "retraction"
+  | "tolerance"
+  | "cornering"
+  | "input_shaping"
+  | "vfa";
+
+export interface ICalibrationStepResult {
+  id: number;
+  session_id: number;
+  step_type: CalibrationStepType;
+  inputs?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  selected_values?: Record<string, unknown>;
+  notes?: string;
+  confidence?: string;
+  recorded_at: string;
+}
+
+export interface ICalibrationSession {
+  id: number;
+  registered: string;
+  filament_id: number;
+  status: CalibrationStatus;
+  started_at?: string;
+  completed_at?: string;
+  printer_name?: string;
+  nozzle_diameter?: number;
+  notes?: string;
+  steps: ICalibrationStepResult[];
+}

--- a/client/src/pages/calibration/stepConfig.ts
+++ b/client/src/pages/calibration/stepConfig.ts
@@ -1,0 +1,479 @@
+/**
+ * Per-step-type field definitions for the calibration step result form.
+ * Drives form rendering and the recommended settings summary display.
+ *
+ * Order matches the OrcaSlicer wiki calibration guide exactly:
+ * Temperature → Volumetric Speed → Pressure Advance → Flow Rate →
+ * Retraction → Tolerance → Cornering → Input Shaping → VFA
+ *
+ * Auto-compute formula approach inspired by the Orca-Slicer-Assistant project:
+ * https://github.com/ItsDeidara/Orca-Slicer-Assistant
+ * Authors: ItsDeidara, SoCuul, Ulfzerk, nyghtly-derek
+ */
+
+import { CalibrationStepType } from "./model";
+
+export interface StepField {
+  key: string;
+  label: string;
+  unit?: string;
+  type: "number" | "select" | "boolean";
+  min?: number;
+  max?: number;
+  step?: number;
+  precision?: number;
+  options?: { label: string; value: string }[];
+  section: "inputs" | "outputs";
+  /** Override the default Ant Design Col span (1–24) for this field */
+  colSpan?: number;
+}
+
+export interface StepConfig {
+  inputFields: StepField[];
+  outputFields: StepField[];
+  /** Key(s) from outputFields whose values go into selected_values */
+  recommendedKeys: string[];
+  /**
+   * Auto-compute output (result) values from current input values.
+   * Called reactively in the wizard whenever inputs change.
+   * Returns a partial record of output keys → computed values.
+   */
+  autoCompute?: (inputs: Record<string, number | null>) => Partial<Record<string, number>>;
+}
+
+export const STEP_CONFIGS: Record<CalibrationStepType, StepConfig> = {
+  temperature: {
+    inputFields: [
+      {
+        key: "start_temp",
+        label: "Start Temp",
+        unit: "°C",
+        type: "number",
+        min: 100,
+        max: 400,
+        precision: 0,
+        section: "inputs",
+      },
+      {
+        key: "end_temp",
+        label: "End Temp",
+        unit: "°C",
+        type: "number",
+        min: 100,
+        max: 400,
+        precision: 0,
+        section: "inputs",
+      },
+      {
+        key: "step_size",
+        label: "Step Size",
+        unit: "°C",
+        type: "number",
+        min: 1,
+        max: 20,
+        precision: 0,
+        section: "inputs",
+      },
+    ],
+    outputFields: [
+      {
+        key: "temperature",
+        label: "Optimal Temp",
+        unit: "°C",
+        type: "number",
+        min: 100,
+        max: 400,
+        precision: 0,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["temperature"],
+  },
+
+  volumetric_speed: {
+    inputFields: [
+      {
+        key: "start_speed",
+        label: "Start Speed",
+        unit: "mm³/s",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+      { key: "step_size", label: "Step Size", unit: "mm³/s", type: "number", min: 0, precision: 1, section: "inputs" },
+      {
+        key: "measured_height",
+        label: "Measured Height",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+    ],
+    outputFields: [
+      {
+        key: "max_volumetric_speed",
+        label: "Max Volumetric Speed",
+        unit: "mm³/s",
+        type: "number",
+        min: 0,
+        precision: 2,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["max_volumetric_speed"],
+    // max_speed = start + measured_height × step_size  (OrcaSlicer wiki)
+    autoCompute: (inputs) => {
+      const start = inputs.start_speed;
+      const step = inputs.step_size;
+      const h = inputs.measured_height;
+      if (start !== null && step !== null && h !== null && !isNaN(start) && !isNaN(step) && !isNaN(h)) {
+        return { max_volumetric_speed: parseFloat((start + h * step).toFixed(2)) };
+      }
+      return {};
+    },
+  },
+
+  pressure_advance: {
+    inputFields: [
+      {
+        key: "extruder_type",
+        label: "Extruder Type",
+        type: "select",
+        options: [
+          { label: "Direct Drive", value: "direct_drive" },
+          { label: "Bowden", value: "bowden" },
+        ],
+        section: "inputs",
+      },
+      { key: "pa_step_a", label: "PA Step (A)", type: "number", min: 0, step: 0.001, precision: 4, section: "inputs" },
+      {
+        key: "measured_height_b",
+        label: "Measured Height (B)",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+    ],
+    outputFields: [
+      {
+        key: "pressure_advance",
+        label: "PA Value",
+        type: "number",
+        min: 0,
+        max: 2,
+        step: 0.001,
+        precision: 4,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["pressure_advance"],
+    // PA = A × B  (OrcaSlicer wiki)
+    autoCompute: (inputs) => {
+      const a = inputs.pa_step_a;
+      const b = inputs.measured_height_b;
+      if (a !== null && b !== null && !isNaN(a) && !isNaN(b)) {
+        return { pressure_advance: parseFloat((a * b).toFixed(4)) };
+      }
+      return {};
+    },
+  },
+
+  flow_rate: {
+    inputFields: [],
+    outputFields: [
+      {
+        key: "flow_ratio",
+        label: "Flow Ratio",
+        type: "number",
+        min: 0.5,
+        max: 1.5,
+        step: 0.00001,
+        precision: 5,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["flow_ratio"],
+  },
+
+  retraction: {
+    inputFields: [
+      {
+        key: "start_retract",
+        label: "Start Retraction",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        max: 10,
+        step: 0.1,
+        precision: 2,
+        section: "inputs",
+      },
+      {
+        key: "measured_height",
+        label: "Measured Height",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+      { key: "factor", label: "Factor", type: "number", min: 0, step: 0.01, precision: 3, section: "inputs" },
+    ],
+    outputFields: [
+      {
+        key: "retraction_length",
+        label: "Recommended Retraction",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        max: 10,
+        step: 0.00001,
+        precision: 5,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["retraction_length"],
+    // retraction = start + measured_height × factor  (OrcaSlicer wiki)
+    autoCompute: (inputs) => {
+      const start = inputs.start_retract;
+      const h = inputs.measured_height;
+      const factor = inputs.factor;
+      if (start !== null && h !== null && factor !== null && !isNaN(start) && !isNaN(h) && !isNaN(factor)) {
+        return { retraction_length: parseFloat((start + h * factor).toFixed(5)) };
+      }
+      return {};
+    },
+  },
+
+  tolerance: {
+    inputFields: [
+      {
+        key: "test_size",
+        label: "Test Feature Size",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        precision: 2,
+        section: "inputs",
+      },
+      {
+        key: "measured_size",
+        label: "Measured Size",
+        unit: "mm",
+        type: "number",
+        min: 0,
+        precision: 3,
+        section: "inputs",
+      },
+    ],
+    outputFields: [
+      {
+        key: "tolerance_offset",
+        label: "Tolerance Offset",
+        unit: "mm",
+        type: "number",
+        step: 0.01,
+        precision: 3,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["tolerance_offset"],
+    autoCompute: (inputs) => {
+      const t = inputs.test_size;
+      const m = inputs.measured_size;
+      if (t !== null && m !== null && !isNaN(t) && !isNaN(m)) {
+        return { tolerance_offset: parseFloat((t - m).toFixed(3)) };
+      }
+      return {};
+    },
+  },
+
+  cornering: {
+    inputFields: [
+      {
+        key: "firmware_type",
+        label: "Firmware / Feature",
+        type: "select",
+        options: [
+          { label: "Junction Deviation (Marlin 2.x / RepRapFirmware)", value: "junction_deviation" },
+          { label: "Jerk (Classic Marlin)", value: "jerk" },
+          { label: "Square Corner Velocity (Klipper)", value: "square_corner_velocity" },
+        ],
+        section: "inputs",
+      },
+      { key: "start_value", label: "Start Value", type: "number", min: 0, step: 0.01, precision: 3, section: "inputs" },
+      { key: "end_value", label: "End Value", type: "number", min: 0, step: 0.01, precision: 3, section: "inputs" },
+    ],
+    outputFields: [
+      {
+        key: "cornering_value",
+        label: "Recommended Value",
+        type: "number",
+        min: 0,
+        step: 0.01,
+        precision: 3,
+        section: "outputs",
+      },
+    ],
+    recommendedKeys: ["cornering_value"],
+  },
+
+  input_shaping: {
+    inputFields: [
+      {
+        key: "shaper_type",
+        label: "Shaper Type",
+        type: "select",
+        options: [
+          { label: "MZV", value: "mzv" },
+          { label: "EI", value: "ei" },
+          { label: "ZV", value: "zv" },
+          { label: "2HUMP_EI", value: "2hump_ei" },
+          { label: "3HUMP_EI", value: "3hump_ei" },
+        ],
+        section: "inputs",
+      },
+      {
+        key: "frequency_x",
+        label: "Resonance Freq X",
+        unit: "Hz",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+      {
+        key: "frequency_y",
+        label: "Resonance Freq Y",
+        unit: "Hz",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "inputs",
+      },
+    ],
+    outputFields: [
+      {
+        key: "shaper_type_x",
+        label: "X Recommended Shaper",
+        type: "select",
+        options: [
+          { label: "MZV", value: "mzv" },
+          { label: "EI", value: "ei" },
+          { label: "ZV", value: "zv" },
+          { label: "2HUMP_EI", value: "2hump_ei" },
+          { label: "3HUMP_EI", value: "3hump_ei" },
+        ],
+        section: "outputs",
+        colSpan: 12,
+      },
+      {
+        key: "frequency_x",
+        label: "Tuned Freq X",
+        unit: "Hz",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "outputs",
+        colSpan: 12,
+      },
+      {
+        key: "shaper_type_y",
+        label: "Y Recommended Shaper",
+        type: "select",
+        options: [
+          { label: "MZV", value: "mzv" },
+          { label: "EI", value: "ei" },
+          { label: "ZV", value: "zv" },
+          { label: "2HUMP_EI", value: "2hump_ei" },
+          { label: "3HUMP_EI", value: "3hump_ei" },
+        ],
+        section: "outputs",
+        colSpan: 12,
+      },
+      {
+        key: "frequency_y",
+        label: "Tuned Freq Y",
+        unit: "Hz",
+        type: "number",
+        min: 0,
+        precision: 1,
+        section: "outputs",
+        colSpan: 12,
+      },
+    ],
+    recommendedKeys: ["shaper_type_x", "frequency_x", "shaper_type_y", "frequency_y"],
+  },
+
+  vfa: {
+    inputFields: [
+      {
+        key: "start_speed",
+        label: "Start Speed",
+        unit: "mm/s",
+        type: "number",
+        min: 0,
+        precision: 0,
+        section: "inputs",
+        colSpan: 8,
+      },
+      {
+        key: "end_speed",
+        label: "End Speed",
+        unit: "mm/s",
+        type: "number",
+        min: 0,
+        precision: 0,
+        section: "inputs",
+        colSpan: 8,
+      },
+      {
+        key: "step_size",
+        label: "Step Size",
+        unit: "mm/s",
+        type: "number",
+        min: 0,
+        precision: 0,
+        section: "inputs",
+        colSpan: 8,
+      },
+    ],
+    outputFields: [
+      {
+        key: "min_avoidance_speed",
+        label: "Min Avoidance Speed",
+        unit: "mm/s",
+        type: "number",
+        min: 0,
+        precision: 0,
+        section: "outputs",
+        colSpan: 12,
+      },
+      {
+        key: "max_avoidance_speed",
+        label: "Max Avoidance Speed",
+        unit: "mm/s",
+        type: "number",
+        min: 0,
+        precision: 0,
+        section: "outputs",
+        colSpan: 12,
+      },
+    ],
+    recommendedKeys: ["min_avoidance_speed", "max_avoidance_speed"],
+  },
+};
+
+/** Display label for a recommended value, including its unit. */
+export function formatRecommendedValue(stepType: CalibrationStepType, key: string, value: unknown): string {
+  const allFields = [...STEP_CONFIGS[stepType].inputFields, ...STEP_CONFIGS[stepType].outputFields];
+  const field = allFields.find((f) => f.key === key);
+  if (!field) return String(value);
+  const unit = field.unit ? ` ${field.unit}` : "";
+  return `${value}${unit}`;
+}

--- a/client/src/pages/calibration/wizardCopy.ts
+++ b/client/src/pages/calibration/wizardCopy.ts
@@ -1,0 +1,94 @@
+/**
+ * Short, practical instructional copy for each calibration step in the wizard.
+ * Tool-agnostic — does not require OrcaSlicer. Order matches the OrcaSlicer
+ * wiki calibration guide exactly.
+ */
+
+import { CalibrationStepType } from "./model";
+
+export interface WizardStepCopy {
+  title: string;
+  description: string;
+  /** Direct link to the OrcaSlicer wiki page for this calibration step. */
+  wikiUrl: string;
+}
+
+const WIKI_BASE = "https://github.com/SoftFever/OrcaSlicer/wiki";
+
+export const WIZARD_COPY: Record<CalibrationStepType, WizardStepCopy> = {
+  temperature: {
+    title: "Temperature",
+    description:
+      "Find the optimal printing temperature for this filament. Print a temperature tower and look for the layer that gives the best balance of layer adhesion, surface quality, and minimal stringing. Hotter improves bonding; cooler reduces ooze and stringing.",
+    wikiUrl: `${WIKI_BASE}/temp-calib`,
+  },
+
+  volumetric_speed: {
+    title: "Volumetric Speed",
+    description:
+      "Determine the maximum volumetric flow rate your hotend can sustain with this filament before under-extrusion appears. Print a flow-rate ramp test or a series of single-wall cubes at increasing speeds, and note the speed just before quality degrades.",
+    wikiUrl: `${WIKI_BASE}/volumetric-speed-calib`,
+  },
+
+  pressure_advance: {
+    title: "Pressure Advance",
+    description:
+      "Tune Pressure Advance (Klipper / Bambu) or Linear Advance (Marlin) to eliminate corner bulging and improve sharp-corner quality. Print a PA test pattern and dial in the value that gives the cleanest, sharpest corners. Enable Adaptive PA if supported by your firmware.",
+    wikiUrl: `${WIKI_BASE}/pressure-advance-calib`,
+  },
+
+  flow_rate: {
+    title: "Flow Rate",
+    description:
+      "Fine-tune the extrusion multiplier so that the actual amount of plastic deposited matches the slicer's expectation. Print two calibration cubes (one at 98%, one at 100%) and measure their walls with calipers to calculate the correct flow ratio.",
+    wikiUrl: `${WIKI_BASE}/flow-rate-calib`,
+  },
+
+  retraction: {
+    title: "Retraction",
+    description:
+      "Find the minimum retraction length and speed that eliminates stringing without grinding the filament or causing clogs. Print a retraction distance tower and pick the lowest setting that produces clean travel moves.",
+    wikiUrl: `${WIKI_BASE}/retraction-calib`,
+  },
+
+  tolerance: {
+    title: "Tolerance",
+    description:
+      "Measure how accurately your printer reproduces feature sizes. Print a tolerance test model, measure the target features with calipers, and record the offset. Apply the result in your slicer's dimensional accuracy / xy compensation settings.",
+    wikiUrl: `${WIKI_BASE}/tolerance-calib`,
+  },
+
+  cornering: {
+    title: "Cornering",
+    description:
+      "Tune cornering behavior to balance print speed against ringing and artifacts at direction changes. Use Junction Deviation (Marlin 2.x / RepRapFirmware), classic Jerk (older Marlin), or Square Corner Velocity (Klipper). Print a cornering test pattern and reduce the value until ringing disappears.",
+    wikiUrl: `${WIKI_BASE}/cornering-calib`,
+  },
+
+  input_shaping: {
+    title: "Input Shaping",
+    description:
+      "Reduce ghosting and ringing by applying resonance compensation. Measure the resonance frequency of your printer (accelerometer recommended, or use a visual ringing tower). Select the shaper type and frequencies that minimise artifacts, then enter them below.",
+    wikiUrl: `${WIKI_BASE}/input-shaping-calib`,
+  },
+
+  vfa: {
+    title: "VFA (Vertical Fine Artifacts)",
+    description:
+      "Find the maximum print speed before vertical surface artifacts (VFA / ribbing) become visible. Print a speed-ramp test on a smooth-walled object and note the speed just before regular ribbing appears on the surface.",
+    wikiUrl: `${WIKI_BASE}/vfa-calib`,
+  },
+};
+
+/** The canonical wizard step order, matching the OrcaSlicer wiki exactly. */
+export const WIZARD_STEP_ORDER: CalibrationStepType[] = [
+  "temperature",
+  "volumetric_speed",
+  "pressure_advance",
+  "flow_rate",
+  "retraction",
+  "tolerance",
+  "cornering",
+  "input_shaping",
+  "vfa",
+];

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -1,5 +1,6 @@
 import { DateField, NumberField, Show, TextField } from "@refinedev/antd";
 import { useShow, useTranslate } from "@refinedev/core";
+import { CalibrationSection } from "../calibration/CalibrationSection";
 import { Button, Typography } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -151,6 +152,7 @@ export const FilamentShow = () => {
       {extraFields?.data?.map((field, index) => (
         <ExtraFieldDisplay key={index} field={field} value={record?.extra[field.key]} />
       ))}
+      <CalibrationSection filamentId={record?.id} />
     </Show>
   );
 };

--- a/migrations/versions/2025_02_19_1200-c3a7f2e8b091_calibration_tables.py
+++ b/migrations/versions/2025_02_19_1200-c3a7f2e8b091_calibration_tables.py
@@ -1,0 +1,58 @@
+"""calibration_tables.
+
+Revision ID: c3a7f2e8b091
+Revises: 415a8f855e14
+Create Date: 2025-02-19 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3a7f2e8b091"
+down_revision = "415a8f855e14"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Perform the upgrade."""
+    op.create_table(
+        "calibration_session",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("registered", sa.DateTime(), nullable=False),
+        sa.Column("spool_id", sa.Integer(), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("printer_name", sa.String(length=256), nullable=True),
+        sa.Column("nozzle_diameter", sa.Float(), nullable=True),
+        sa.Column("notes", sa.String(length=1024), nullable=True),
+        sa.ForeignKeyConstraint(["spool_id"], ["spool.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_calibration_session_id"), "calibration_session", ["id"], unique=False)
+
+    op.create_table(
+        "calibration_step_result",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("session_id", sa.Integer(), nullable=False),
+        sa.Column("step_type", sa.String(length=64), nullable=False),
+        sa.Column("inputs", sa.Text(), nullable=True),
+        sa.Column("outputs", sa.Text(), nullable=True),
+        sa.Column("selected_values", sa.Text(), nullable=True),
+        sa.Column("notes", sa.String(length=1024), nullable=True),
+        sa.Column("confidence", sa.String(length=32), nullable=True),
+        sa.Column("recorded_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["session_id"], ["calibration_session.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_calibration_step_result_id"), "calibration_step_result", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    """Perform the downgrade."""
+    op.drop_index(op.f("ix_calibration_step_result_id"), table_name="calibration_step_result")
+    op.drop_table("calibration_step_result")
+    op.drop_index(op.f("ix_calibration_session_id"), table_name="calibration_session")
+    op.drop_table("calibration_session")

--- a/migrations/versions/2026_02_20_1200-a1b2c3d4e5f6_calibration_filament_fk.py
+++ b/migrations/versions/2026_02_20_1200-a1b2c3d4e5f6_calibration_filament_fk.py
@@ -1,0 +1,59 @@
+"""calibration_filament_fk: move CalibrationSession FK from spool to filament.
+
+Revision ID: a1b2c3d4e5f6
+Revises: c3a7f2e8b091
+Create Date: 2026-02-20 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "a1b2c3d4e5f6"
+down_revision = "c3a7f2e8b091"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Move spool_id -> filament_id on calibration_session."""
+    connection = op.get_bind()
+
+    # 1. Add filament_id as nullable so we can populate it before constraining
+    with op.batch_alter_table("calibration_session") as batch_op:
+        batch_op.add_column(sa.Column("filament_id", sa.Integer(), nullable=True))
+
+    # 2. Populate filament_id from the related spool row
+    connection.execute(
+        sa.text(
+            "UPDATE calibration_session "
+            "SET filament_id = (SELECT filament_id FROM spool WHERE spool.id = calibration_session.spool_id)"
+        )
+    )
+
+    # 3. Recreate the table: drop spool_id, make filament_id NOT NULL with FK
+    with op.batch_alter_table("calibration_session", recreate="always") as batch_op:
+        batch_op.drop_column("spool_id")
+        batch_op.alter_column("filament_id", existing_type=sa.Integer(), nullable=False)
+        batch_op.create_foreign_key(
+            "fk_calibration_session_filament_id",
+            "filament",
+            ["filament_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    """Move filament_id -> spool_id (data cannot be recovered; spool_id will be NULL)."""
+    with op.batch_alter_table("calibration_session") as batch_op:
+        batch_op.add_column(sa.Column("spool_id", sa.Integer(), nullable=True))
+
+    with op.batch_alter_table("calibration_session", recreate="always") as batch_op:
+        batch_op.drop_column("filament_id")
+        batch_op.create_foreign_key(
+            "fk_calibration_session_spool_id",
+            "spool",
+            ["spool_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )

--- a/spoolman/api/v1/calibration.py
+++ b/spoolman/api/v1/calibration.py
@@ -1,0 +1,291 @@
+"""Calibration session and step result endpoints."""
+
+import json
+import logging
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from spoolman.api.v1.calibration_models import (
+    CalibrationSession,
+    CalibrationStatus,
+    CalibrationStepResult,
+    CalibrationStepType,
+)
+from spoolman.api.v1.models import Message
+from spoolman.database import calibration
+from spoolman.database.database import get_db_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/calibration",
+    tags=["calibration"],
+)
+
+# ruff: noqa: D103
+
+
+# ---------------------------------------------------------------------------
+# Request bodies
+# ---------------------------------------------------------------------------
+
+
+class CalibrationSessionParameters(BaseModel):
+    filament_id: int = Field(description="The ID of the filament this session belongs to.")
+    status: CalibrationStatus = Field(
+        default=CalibrationStatus.PLANNED,
+        description="Initial status of the session.",
+    )
+    printer_name: str | None = Field(None, max_length=256, description="Name of the printer used.")
+    nozzle_diameter: float | None = Field(
+        None,
+        gt=0,
+        description="Nozzle diameter in mm.",
+        examples=[0.4],
+    )
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes.")
+    started_at: datetime | None = Field(None, description="When calibration was started.")
+
+
+class CalibrationSessionUpdateParameters(BaseModel):
+    status: CalibrationStatus | None = Field(None, description="Updated status.")
+    printer_name: str | None = Field(None, max_length=256, description="Name of the printer used.")
+    nozzle_diameter: float | None = Field(None, gt=0, description="Nozzle diameter in mm.", examples=[0.4])
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes.")
+    started_at: datetime | None = Field(None, description="When calibration was started.")
+    completed_at: datetime | None = Field(None, description="When calibration was completed.")
+
+
+class CalibrationStepResultParameters(BaseModel):
+    step_type: CalibrationStepType = Field(description="The OrcaSlicer calibration step.")
+    inputs: dict | None = Field(None, description="Structured inputs for this step.")
+    outputs: dict | None = Field(None, description="Measured outputs from this step.")
+    selected_values: dict | None = Field(None, description="Recommended values from this step.")
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes.")
+    confidence: str | None = Field(None, max_length=32, description="Confidence level, e.g. 'high'.")
+    recorded_at: datetime | None = Field(None, description="When this result was recorded.")
+
+
+class CalibrationStepResultUpdateParameters(BaseModel):
+    step_type: CalibrationStepType | None = Field(None, description="The OrcaSlicer calibration step.")
+    inputs: dict | None = Field(None, description="Structured inputs for this step.")
+    outputs: dict | None = Field(None, description="Measured outputs from this step.")
+    selected_values: dict | None = Field(None, description="Recommended values from this step.")
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes.")
+    confidence: str | None = Field(None, max_length=32, description="Confidence level.")
+    recorded_at: datetime | None = Field(None, description="When this result was recorded.")
+
+
+# ---------------------------------------------------------------------------
+# Session endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/session",
+    name="Find calibration sessions",
+    description="Get a list of calibration sessions, optionally filtered by filament_id.",
+    response_model_exclude_none=True,
+    responses={200: {"model": list[CalibrationSession]}},
+)
+async def find_sessions(
+    *,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    filament_id: Annotated[int | None, Query(title="Filament ID", description="Filter by filament ID.")] = None,
+    limit: Annotated[int | None, Query(title="Limit", description="Maximum number of items in the response.")] = None,
+    offset: Annotated[int, Query(title="Offset", description="Offset in the full result set.")] = 0,
+) -> JSONResponse:
+    db_items, total_count = await calibration.list_sessions(
+        db=db,
+        filament_id=filament_id,
+        limit=limit,
+        offset=offset,
+    )
+    return JSONResponse(
+        content=jsonable_encoder(
+            [CalibrationSession.from_db(item) for item in db_items],
+            exclude_none=True,
+        ),
+        headers={"x-total-count": str(total_count)},
+    )
+
+
+@router.get(
+    "/session/{session_id}",
+    name="Get calibration session",
+    description="Get a specific calibration session with all its step results.",
+    response_model_exclude_none=True,
+    responses={
+        200: {"model": CalibrationSession},
+        404: {"model": Message},
+    },
+)
+async def get_session(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    session_id: int,
+) -> CalibrationSession:
+    db_item = await calibration.get_session(db, session_id)
+    return CalibrationSession.from_db(db_item)
+
+
+@router.post(
+    "/session",
+    name="Create calibration session",
+    description="Create a new calibration session for a spool.",
+    response_model_exclude_none=True,
+    response_model=CalibrationSession,  # noqa: FAST001
+    responses={
+        400: {"model": Message},
+        404: {"model": Message},
+    },
+)
+async def create_session(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    body: CalibrationSessionParameters,
+) -> CalibrationSession:
+    db_item = await calibration.create_session(
+        db=db,
+        filament_id=body.filament_id,
+        status=body.status.value,
+        printer_name=body.printer_name,
+        nozzle_diameter=body.nozzle_diameter,
+        notes=body.notes,
+        started_at=body.started_at,
+    )
+    return CalibrationSession.from_db(db_item)
+
+
+@router.patch(
+    "/session/{session_id}",
+    name="Update calibration session",
+    description="Update any attribute of a calibration session. Only supplied fields are affected.",
+    response_model_exclude_none=True,
+    response_model=CalibrationSession,  # noqa: FAST001
+    responses={
+        404: {"model": Message},
+    },
+)
+async def update_session(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    session_id: int,
+    body: CalibrationSessionUpdateParameters,
+) -> CalibrationSession:
+    patch_data = body.model_dump(exclude_unset=True)
+    # Convert enum to its string value for storage
+    if "status" in patch_data and isinstance(patch_data["status"], CalibrationStatus):
+        patch_data["status"] = patch_data["status"].value
+    db_item = await calibration.update_session(db, session_id, patch_data)
+    return CalibrationSession.from_db(db_item)
+
+
+@router.delete(
+    "/session/{session_id}",
+    name="Delete calibration session",
+    description="Delete a calibration session and all its step results.",
+    responses={404: {"model": Message}},
+)
+async def delete_session(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    session_id: int,
+) -> Message:
+    await calibration.delete_session(db, session_id)
+    return Message(message="Success!")
+
+
+# ---------------------------------------------------------------------------
+# Step result endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/session/{session_id}/step",
+    name="Add calibration step result",
+    description="Add a step result to an existing calibration session.",
+    response_model_exclude_none=True,
+    response_model=CalibrationStepResult,  # noqa: FAST001
+    responses={
+        404: {"model": Message},
+    },
+)
+async def create_step_result(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    session_id: int,
+    body: CalibrationStepResultParameters,
+) -> CalibrationStepResult:
+    db_item = await calibration.create_step_result(
+        db=db,
+        session_id=session_id,
+        step_type=body.step_type.value,
+        inputs=json.dumps(body.inputs) if body.inputs is not None else None,
+        outputs=json.dumps(body.outputs) if body.outputs is not None else None,
+        selected_values=json.dumps(body.selected_values) if body.selected_values is not None else None,
+        notes=body.notes,
+        confidence=body.confidence,
+        recorded_at=body.recorded_at,
+    )
+    return CalibrationStepResult.from_db(db_item)
+
+
+@router.get(
+    "/step/{step_id}",
+    name="Get calibration step result",
+    description="Get a specific calibration step result.",
+    response_model_exclude_none=True,
+    responses={
+        200: {"model": CalibrationStepResult},
+        404: {"model": Message},
+    },
+)
+async def get_step_result(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    step_id: int,
+) -> CalibrationStepResult:
+    db_item = await calibration.get_step_result(db, step_id)
+    return CalibrationStepResult.from_db(db_item)
+
+
+@router.patch(
+    "/step/{step_id}",
+    name="Update calibration step result",
+    description="Update any attribute of a calibration step result. Only supplied fields are affected.",
+    response_model_exclude_none=True,
+    response_model=CalibrationStepResult,  # noqa: FAST001
+    responses={
+        404: {"model": Message},
+    },
+)
+async def update_step_result(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    step_id: int,
+    body: CalibrationStepResultUpdateParameters,
+) -> CalibrationStepResult:
+    patch_data = body.model_dump(exclude_unset=True)
+    # Convert enum to string for storage
+    if "step_type" in patch_data and isinstance(patch_data["step_type"], CalibrationStepType):
+        patch_data["step_type"] = patch_data["step_type"].value
+    # Serialize dict fields to JSON text
+    for field in ("inputs", "outputs", "selected_values"):
+        if field in patch_data and patch_data[field] is not None:
+            patch_data[field] = json.dumps(patch_data[field])
+    db_item = await calibration.update_step_result(db, step_id, patch_data)
+    return CalibrationStepResult.from_db(db_item)
+
+
+@router.delete(
+    "/step/{step_id}",
+    name="Delete calibration step result",
+    description="Delete a calibration step result.",
+    responses={404: {"model": Message}},
+)
+async def delete_step_result(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+    step_id: int,
+) -> Message:
+    await calibration.delete_step_result(db, step_id)
+    return Message(message="Success!")

--- a/spoolman/api/v1/calibration_models.py
+++ b/spoolman/api/v1/calibration_models.py
@@ -1,0 +1,110 @@
+"""Pydantic data models for calibration API endpoints."""
+
+import json
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from spoolman.api.v1.models import SpoolmanDateTime
+from spoolman.database import models
+
+
+class CalibrationStepType(str, Enum):
+    """Calibration step types in OrcaSlicer wiki order."""
+
+    TEMPERATURE = "temperature"
+    VOLUMETRIC_SPEED = "volumetric_speed"
+    PRESSURE_ADVANCE = "pressure_advance"
+    FLOW_RATE = "flow_rate"
+    RETRACTION = "retraction"
+    TOLERANCE = "tolerance"
+    CORNERING = "cornering"
+    INPUT_SHAPING = "input_shaping"
+    VFA = "vfa"
+
+
+class CalibrationStatus(str, Enum):
+    """Status of a calibration session."""
+
+    PLANNED = "planned"
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+    ARCHIVED = "archived"
+
+
+class CalibrationStepResult(BaseModel):
+    id: int = Field(description="Unique internal ID of this step result.")
+    session_id: int = Field(description="ID of the parent calibration session.")
+    step_type: CalibrationStepType = Field(description="Which OrcaSlicer calibration step this result covers.")
+    inputs: dict[str, Any] | None = Field(
+        None,
+        description="Structured inputs used during this step, as a JSON object.",
+    )
+    outputs: dict[str, Any] | None = Field(
+        None,
+        description="Measured or observed outputs from this step, as a JSON object.",
+    )
+    selected_values: dict[str, Any] | None = Field(
+        None,
+        description="Recommended values selected from this step, as a JSON object.",
+    )
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes for this step.")
+    confidence: str | None = Field(
+        None,
+        max_length=32,
+        description="Subjective confidence level, e.g. 'high', 'medium', 'low'.",
+    )
+    recorded_at: SpoolmanDateTime = Field(description="When this result was recorded. UTC Timezone.")
+
+    @staticmethod
+    def from_db(item: models.CalibrationStepResult) -> "CalibrationStepResult":
+        """Build a response model from a database row."""
+        return CalibrationStepResult(
+            id=item.id,
+            session_id=item.session_id,
+            step_type=CalibrationStepType(item.step_type),
+            inputs=json.loads(item.inputs) if item.inputs else None,
+            outputs=json.loads(item.outputs) if item.outputs else None,
+            selected_values=json.loads(item.selected_values) if item.selected_values else None,
+            notes=item.notes,
+            confidence=item.confidence,
+            recorded_at=item.recorded_at,
+        )
+
+
+class CalibrationSession(BaseModel):
+    id: int = Field(description="Unique internal ID of this calibration session.")
+    registered: SpoolmanDateTime = Field(description="When the session was created. UTC Timezone.")
+    filament_id: int = Field(description="ID of the filament this session belongs to.")
+    status: CalibrationStatus = Field(description="Current status of the session.")
+    started_at: SpoolmanDateTime | None = Field(None, description="When calibration was started. UTC Timezone.")
+    completed_at: SpoolmanDateTime | None = Field(None, description="When calibration was completed. UTC Timezone.")
+    printer_name: str | None = Field(None, max_length=256, description="Name of the printer used.")
+    nozzle_diameter: float | None = Field(
+        None,
+        gt=0,
+        description="Nozzle diameter in mm.",
+        examples=[0.4],
+    )
+    notes: str | None = Field(None, max_length=1024, description="Free-text notes for this session.")
+    steps: list[CalibrationStepResult] = Field(
+        default_factory=list,
+        description="Step results recorded in this session.",
+    )
+
+    @staticmethod
+    def from_db(item: models.CalibrationSession) -> "CalibrationSession":
+        """Build a response model from a database row."""
+        return CalibrationSession(
+            id=item.id,
+            registered=item.registered,
+            filament_id=item.filament_id,
+            status=CalibrationStatus(item.status),
+            started_at=item.started_at,
+            completed_at=item.completed_at,
+            printer_name=item.printer_name,
+            nozzle_diameter=item.nozzle_diameter,
+            notes=item.notes,
+            steps=[CalibrationStepResult.from_db(step) for step in item.steps],
+        )

--- a/spoolman/api/v1/router.py
+++ b/spoolman/api/v1/router.py
@@ -15,7 +15,7 @@ from spoolman.database.database import backup_global_db
 from spoolman.exceptions import ItemNotFoundError
 from spoolman.ws import websocket_manager
 
-from . import export, externaldb, field, filament, models, other, setting, spool, vendor
+from . import calibration, export, externaldb, field, filament, models, other, setting, spool, vendor
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +104,7 @@ async def notify(
 
 
 # Add routers
+app.include_router(calibration.router)
 app.include_router(filament.router)
 app.include_router(spool.router)
 app.include_router(vendor.router)

--- a/spoolman/database/calibration.py
+++ b/spoolman/database/calibration.py
@@ -1,0 +1,182 @@
+"""Helper functions for interacting with calibration database objects."""
+
+import logging
+from datetime import datetime, timezone
+
+import sqlalchemy
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from spoolman.database import models
+from spoolman.exceptions import ItemNotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+def utc_timezone_naive(dt: datetime) -> datetime:
+    """Convert a datetime object to UTC and remove timezone info."""
+    return dt.astimezone(tz=timezone.utc).replace(tzinfo=None)
+
+
+# ---------------------------------------------------------------------------
+# CalibrationSession
+# ---------------------------------------------------------------------------
+
+
+async def create_session(
+    *,
+    db: AsyncSession,
+    filament_id: int,
+    status: str = "planned",
+    printer_name: str | None = None,
+    nozzle_diameter: float | None = None,
+    notes: str | None = None,
+    started_at: datetime | None = None,
+) -> models.CalibrationSession:
+    """Create a new calibration session attached to a filament."""
+    from spoolman.database import filament as filament_db  # noqa: PLC0415  # avoid circular import at module level
+
+    await filament_db.get_by_id(db, filament_id)  # raises ItemNotFoundError if filament missing
+
+    db_item = models.CalibrationSession(
+        registered=datetime.utcnow().replace(microsecond=0),
+        filament_id=filament_id,
+        status=status,
+        printer_name=printer_name,
+        nozzle_diameter=nozzle_diameter,
+        notes=notes,
+        started_at=utc_timezone_naive(started_at) if started_at is not None else None,
+    )
+    db.add(db_item)
+    await db.commit()
+    return await get_session(db, db_item.id)
+
+
+async def get_session(db: AsyncSession, session_id: int) -> models.CalibrationSession:
+    """Get a calibration session by ID, including its step results."""
+    result = await db.execute(
+        sqlalchemy.select(models.CalibrationSession)
+        .where(models.CalibrationSession.id == session_id)
+        .options(joinedload(models.CalibrationSession.steps))
+    )
+    item = result.unique().scalar_one_or_none()
+    if item is None:
+        raise ItemNotFoundError(f"No calibration session with ID {session_id} found.")
+    return item
+
+
+async def list_sessions(
+    *,
+    db: AsyncSession,
+    filament_id: int | None = None,
+    limit: int | None = None,
+    offset: int = 0,
+) -> tuple[list[models.CalibrationSession], int]:
+    """List calibration sessions, optionally filtered by filament_id."""
+    query = sqlalchemy.select(models.CalibrationSession)
+    if filament_id is not None:
+        query = query.where(models.CalibrationSession.filament_id == filament_id)
+
+    count_query = sqlalchemy.select(sqlalchemy.func.count()).select_from(query.subquery())
+    total_count = (await db.execute(count_query)).scalar_one()
+
+    query = query.order_by(models.CalibrationSession.registered.desc())
+    if offset:
+        query = query.offset(offset)
+    if limit is not None:
+        query = query.limit(limit)
+
+    # Eagerly load steps for each session
+    query = query.options(joinedload(models.CalibrationSession.steps))
+    result = await db.execute(query)
+    items = list(result.unique().scalars().all())
+    return items, total_count
+
+
+async def update_session(
+    db: AsyncSession,
+    session_id: int,
+    data: dict,
+) -> models.CalibrationSession:
+    """Update fields on a calibration session."""
+    db_item = await get_session(db, session_id)
+    for k, v in data.items():
+        if isinstance(v, datetime):
+            setattr(db_item, k, utc_timezone_naive(v))
+        else:
+            setattr(db_item, k, v)
+    await db.commit()
+    return await get_session(db, session_id)
+
+
+async def delete_session(db: AsyncSession, session_id: int) -> None:
+    """Delete a calibration session (cascades to step results)."""
+    db_item = await get_session(db, session_id)
+    await db.delete(db_item)
+
+
+# ---------------------------------------------------------------------------
+# CalibrationStepResult
+# ---------------------------------------------------------------------------
+
+
+async def create_step_result(
+    *,
+    db: AsyncSession,
+    session_id: int,
+    step_type: str,
+    inputs: str | None = None,
+    outputs: str | None = None,
+    selected_values: str | None = None,
+    notes: str | None = None,
+    confidence: str | None = None,
+    recorded_at: datetime | None = None,
+) -> models.CalibrationStepResult:
+    """Add a step result to an existing calibration session."""
+    await get_session(db, session_id)  # raises ItemNotFoundError if session missing
+
+    db_item = models.CalibrationStepResult(
+        session_id=session_id,
+        step_type=step_type,
+        inputs=inputs,
+        outputs=outputs,
+        selected_values=selected_values,
+        notes=notes,
+        confidence=confidence,
+        recorded_at=(
+            utc_timezone_naive(recorded_at) if recorded_at is not None else datetime.utcnow().replace(microsecond=0)
+        ),
+    )
+    db.add(db_item)
+    await db.commit()
+    return db_item
+
+
+async def get_step_result(db: AsyncSession, step_id: int) -> models.CalibrationStepResult:
+    """Get a calibration step result by ID."""
+    item = await db.get(models.CalibrationStepResult, step_id)
+    if item is None:
+        raise ItemNotFoundError(f"No calibration step result with ID {step_id} found.")
+    return item
+
+
+async def update_step_result(
+    db: AsyncSession,
+    step_id: int,
+    data: dict,
+) -> models.CalibrationStepResult:
+    """Update fields on a calibration step result."""
+    db_item = await get_step_result(db, step_id)
+    for k, v in data.items():
+        if isinstance(v, datetime):
+            setattr(db_item, k, utc_timezone_naive(v))
+        else:
+            setattr(db_item, k, v)
+    await db.commit()
+    return db_item
+
+
+async def delete_step_result(db: AsyncSession, step_id: int) -> None:
+    """Delete a calibration step result."""
+    db_item = await get_step_result(db, step_id)
+    await db.delete(db_item)

--- a/spoolman/database/models.py
+++ b/spoolman/database/models.py
@@ -83,6 +83,40 @@ class Spool(Base):
     )
 
 
+class CalibrationSession(Base):
+    __tablename__ = "calibration_session"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    registered: Mapped[datetime] = mapped_column()
+    filament_id: Mapped[int] = mapped_column(ForeignKey("filament.id", ondelete="CASCADE"))
+    status: Mapped[str] = mapped_column(String(32))
+    started_at: Mapped[datetime | None] = mapped_column()
+    completed_at: Mapped[datetime | None] = mapped_column()
+    printer_name: Mapped[str | None] = mapped_column(String(256))
+    nozzle_diameter: Mapped[float | None] = mapped_column()
+    notes: Mapped[str | None] = mapped_column(String(1024))
+    steps: Mapped[list["CalibrationStepResult"]] = relationship(
+        back_populates="session",
+        cascade="save-update, merge, delete, delete-orphan",
+        lazy="joined",
+    )
+
+
+class CalibrationStepResult(Base):
+    __tablename__ = "calibration_step_result"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    session_id: Mapped[int] = mapped_column(ForeignKey("calibration_session.id", ondelete="CASCADE"))
+    session: Mapped["CalibrationSession"] = relationship(back_populates="steps")
+    step_type: Mapped[str] = mapped_column(String(64))
+    inputs: Mapped[str | None] = mapped_column(Text())
+    outputs: Mapped[str | None] = mapped_column(Text())
+    selected_values: Mapped[str | None] = mapped_column(Text())
+    notes: Mapped[str | None] = mapped_column(String(1024))
+    confidence: Mapped[str | None] = mapped_column(String(32))
+    recorded_at: Mapped[datetime] = mapped_column()
+
+
 class Setting(Base):
     __tablename__ = "setting"
 

--- a/tests_integration/tests/calibration/conftest.py
+++ b/tests_integration/tests/calibration/conftest.py
@@ -1,0 +1,42 @@
+"""Fixtures for calibration integration tests."""
+
+from contextlib import contextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from ..conftest import URL, random_filament_impl
+
+
+@contextmanager
+def random_session_impl(filament_id: int):
+    """Create a calibration session and yield it; delete on exit."""
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={
+            "filament_id": filament_id,
+            "status": "planned",
+            "printer_name": "Test Printer",
+            "nozzle_diameter": 0.4,
+            "notes": "Integration test session",
+        },
+    )
+    result.raise_for_status()
+    session: dict[str, Any] = result.json()
+    yield session
+    httpx.delete(f"{URL}/api/v1/calibration/session/{session['id']}")
+
+
+@pytest.fixture
+def random_filament():
+    """Return a random filament."""
+    with random_filament_impl() as f:
+        yield f
+
+
+@pytest.fixture
+def random_session(random_filament: dict[str, Any]):
+    """Return a random calibration session."""
+    with random_session_impl(random_filament["id"]) as session:
+        yield session

--- a/tests_integration/tests/calibration/test_sessions.py
+++ b/tests_integration/tests/calibration/test_sessions.py
@@ -1,0 +1,168 @@
+"""Integration tests for calibration session endpoints."""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from ..conftest import URL, assert_dicts_compatible, assert_httpx_code
+
+
+def test_create_session(random_filament: dict[str, Any]):
+    """Create a calibration session and verify the response."""
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={
+            "filament_id": random_filament["id"],
+            "status": "planned",
+            "printer_name": "Ender 3",
+            "nozzle_diameter": 0.4,
+            "notes": "First calibration run",
+        },
+    )
+    result.raise_for_status()
+    session = result.json()
+
+    assert_dicts_compatible(
+        session,
+        {
+            "filament_id": random_filament["id"],
+            "status": "planned",
+            "printer_name": "Ender 3",
+            "nozzle_diameter": pytest.approx(0.4),
+            "notes": "First calibration run",
+        },
+    )
+    assert "id" in session
+    assert "registered" in session
+    assert session["steps"] == []
+
+    # Cleanup
+    httpx.delete(f"{URL}/api/v1/calibration/session/{session['id']}").raise_for_status()
+
+
+def test_create_session_minimal(random_filament: dict[str, Any]):
+    """Create a session with only required fields."""
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": random_filament["id"]},
+    )
+    result.raise_for_status()
+    session = result.json()
+    assert session["filament_id"] == random_filament["id"]
+    assert session["status"] == "planned"
+    assert session["steps"] == []
+
+    httpx.delete(f"{URL}/api/v1/calibration/session/{session['id']}").raise_for_status()
+
+
+def test_create_session_unknown_filament():
+    """Creating a session for a non-existent filament returns 404."""
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": 999999},
+    )
+    assert_httpx_code(result, 404)
+
+
+def test_get_session(random_session: dict[str, Any]):
+    """Get a session by ID."""
+    session_id = random_session["id"]
+    result = httpx.get(f"{URL}/api/v1/calibration/session/{session_id}")
+    result.raise_for_status()
+    assert result.json()["id"] == session_id
+
+
+def test_get_session_not_found():
+    """Getting a non-existent session returns 404."""
+    result = httpx.get(f"{URL}/api/v1/calibration/session/999999")
+    assert_httpx_code(result, 404)
+
+
+def test_list_sessions_by_filament(random_filament: dict[str, Any]):
+    """List sessions filtered by filament_id."""
+    # Create two sessions
+    s1 = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": random_filament["id"], "status": "planned"},
+    ).json()
+    s2 = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": random_filament["id"], "status": "complete"},
+    ).json()
+
+    result = httpx.get(f"{URL}/api/v1/calibration/session?filament_id={random_filament['id']}")
+    result.raise_for_status()
+    sessions = result.json()
+    ids = {s["id"] for s in sessions}
+    assert s1["id"] in ids
+    assert s2["id"] in ids
+    assert "x-total-count" in result.headers
+    assert int(result.headers["x-total-count"]) >= 2
+
+    # Cleanup
+    httpx.delete(f"{URL}/api/v1/calibration/session/{s1['id']}").raise_for_status()
+    httpx.delete(f"{URL}/api/v1/calibration/session/{s2['id']}").raise_for_status()
+
+
+def test_update_session(random_session: dict[str, Any]):
+    """Update a session's status and printer name."""
+    session_id = random_session["id"]
+    result = httpx.patch(
+        f"{URL}/api/v1/calibration/session/{session_id}",
+        json={"status": "in_progress", "printer_name": "Prusa MK4"},
+    )
+    result.raise_for_status()
+    updated = result.json()
+    assert updated["status"] == "in_progress"
+    assert updated["printer_name"] == "Prusa MK4"
+
+
+def test_update_session_not_found():
+    """Updating a non-existent session returns 404."""
+    result = httpx.patch(
+        f"{URL}/api/v1/calibration/session/999999",
+        json={"status": "complete"},
+    )
+    assert_httpx_code(result, 404)
+
+
+def test_delete_session(random_filament: dict[str, Any]):
+    """Delete a session."""
+    session = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": random_filament["id"]},
+    ).json()
+    session_id = session["id"]
+
+    result = httpx.delete(f"{URL}/api/v1/calibration/session/{session_id}")
+    result.raise_for_status()
+
+    # Confirm it's gone
+    assert_httpx_code(httpx.get(f"{URL}/api/v1/calibration/session/{session_id}"), 404)
+
+
+def test_delete_filament_cascades_to_sessions():
+    """Deleting a filament cascades to its calibration sessions."""
+    filament = httpx.post(
+        f"{URL}/api/v1/filament",
+        json={
+            "name": "Cascade Test Filament",
+            "material": "PLA",
+            "density": 1.24,
+            "diameter": 1.75,
+        },
+    ).json()
+    filament_id = filament["id"]
+
+    session = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": filament_id},
+    ).json()
+    session_id = session["id"]
+
+    # Delete the filament
+    httpx.delete(f"{URL}/api/v1/filament/{filament_id}").raise_for_status()
+
+    # Session should be gone too
+    assert_httpx_code(httpx.get(f"{URL}/api/v1/calibration/session/{session_id}"), 404)

--- a/tests_integration/tests/calibration/test_steps.py
+++ b/tests_integration/tests/calibration/test_steps.py
@@ -1,0 +1,179 @@
+"""Integration tests for calibration step result endpoints."""
+
+from typing import Any
+
+import httpx
+
+from ..conftest import URL, assert_dicts_compatible, assert_httpx_code
+
+
+def test_add_step_result(random_session: dict[str, Any]):
+    """Add a step result to a session."""
+    session_id = random_session["id"]
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={
+            "step_type": "temperature",
+            "inputs": {"start_temp": 195, "end_temp": 235, "step": 5},
+            "outputs": {"best_temp": 215},
+            "selected_values": {"temperature": 215},
+            "notes": "Tower looked good at 215",
+            "confidence": "high",
+        },
+    )
+    result.raise_for_status()
+    step = result.json()
+
+    assert_dicts_compatible(
+        step,
+        {
+            "session_id": session_id,
+            "step_type": "temperature",
+            "inputs": {"start_temp": 195, "end_temp": 235, "step": 5},
+            "outputs": {"best_temp": 215},
+            "selected_values": {"temperature": 215},
+            "notes": "Tower looked good at 215",
+            "confidence": "high",
+        },
+    )
+    assert "id" in step
+    assert "recorded_at" in step
+
+    # Cleanup
+    httpx.delete(f"{URL}/api/v1/calibration/step/{step['id']}").raise_for_status()
+
+
+def test_add_step_minimal(random_session: dict[str, Any]):
+    """Add a step result with only required fields."""
+    session_id = random_session["id"]
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={"step_type": "flow_rate"},
+    )
+    result.raise_for_status()
+    step = result.json()
+    assert step["step_type"] == "flow_rate"
+    assert step["session_id"] == session_id
+
+    httpx.delete(f"{URL}/api/v1/calibration/step/{step['id']}").raise_for_status()
+
+
+def test_add_step_invalid_session():
+    """Adding a step to a non-existent session returns 404."""
+    result = httpx.post(
+        f"{URL}/api/v1/calibration/session/999999/step",
+        json={"step_type": "temperature"},
+    )
+    assert_httpx_code(result, 404)
+
+
+def test_all_valid_step_types(random_session: dict[str, Any]):
+    """All OrcaSlicer-defined step types are accepted."""
+    valid_types = [
+        "temperature",
+        "volumetric_speed",
+        "pressure_advance",
+        "flow_rate",
+        "retraction",
+        "tolerance",
+        "cornering",
+        "input_shaping",
+        "vfa",
+    ]
+    session_id = random_session["id"]
+    created_ids = []
+    for step_type in valid_types:
+        result = httpx.post(
+            f"{URL}/api/v1/calibration/session/{session_id}/step",
+            json={"step_type": step_type},
+        )
+        result.raise_for_status()
+        created_ids.append(result.json()["id"])
+
+    # Verify session now has all steps
+    session = httpx.get(f"{URL}/api/v1/calibration/session/{session_id}").json()
+    assert len(session["steps"]) == len(valid_types)
+
+    # Cleanup
+    for step_id in created_ids:
+        httpx.delete(f"{URL}/api/v1/calibration/step/{step_id}").raise_for_status()
+
+
+def test_get_step(random_session: dict[str, Any]):
+    """Get a specific step result by ID."""
+    session_id = random_session["id"]
+    step = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={"step_type": "retraction"},
+    ).json()
+    step_id = step["id"]
+
+    result = httpx.get(f"{URL}/api/v1/calibration/step/{step_id}")
+    result.raise_for_status()
+    assert result.json()["id"] == step_id
+
+    httpx.delete(f"{URL}/api/v1/calibration/step/{step_id}").raise_for_status()
+
+
+def test_get_step_not_found():
+    """Getting a non-existent step returns 404."""
+    result = httpx.get(f"{URL}/api/v1/calibration/step/999999")
+    assert_httpx_code(result, 404)
+
+
+def test_update_step(random_session: dict[str, Any]):
+    """Update a step result."""
+    session_id = random_session["id"]
+    step = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={"step_type": "flow_rate"},
+    ).json()
+    step_id = step["id"]
+
+    result = httpx.patch(
+        f"{URL}/api/v1/calibration/step/{step_id}",
+        json={
+            "outputs": {"flow_ratio": 0.98},
+            "selected_values": {"flow_ratio": 0.98},
+            "confidence": "medium",
+        },
+    )
+    result.raise_for_status()
+    updated = result.json()
+    assert updated["outputs"] == {"flow_ratio": 0.98}
+    assert updated["selected_values"] == {"flow_ratio": 0.98}
+    assert updated["confidence"] == "medium"
+
+    httpx.delete(f"{URL}/api/v1/calibration/step/{step_id}").raise_for_status()
+
+
+def test_delete_step(random_session: dict[str, Any]):
+    """Delete a step result."""
+    session_id = random_session["id"]
+    step = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={"step_type": "cornering"},
+    ).json()
+    step_id = step["id"]
+
+    httpx.delete(f"{URL}/api/v1/calibration/step/{step_id}").raise_for_status()
+    assert_httpx_code(httpx.get(f"{URL}/api/v1/calibration/step/{step_id}"), 404)
+
+
+def test_delete_session_cascades_to_steps(random_filament: dict[str, Any]):
+    """Deleting a session removes its step results."""
+    session = httpx.post(
+        f"{URL}/api/v1/calibration/session",
+        json={"filament_id": random_filament["id"]},
+    ).json()
+    session_id = session["id"]
+
+    step = httpx.post(
+        f"{URL}/api/v1/calibration/session/{session_id}/step",
+        json={"step_type": "input_shaping"},
+    ).json()
+    step_id = step["id"]
+
+    httpx.delete(f"{URL}/api/v1/calibration/session/{session_id}").raise_for_status()
+
+    assert_httpx_code(httpx.get(f"{URL}/api/v1/calibration/step/{step_id}"), 404)


### PR DESCRIPTION
## Summary

- Adds a guided calibration workflow attached to **filaments**, allowing users to run and record results for standard FDM calibration steps (temperature tower, flow rate, pressure advance, VFA, input shaping, and more) directly within Spoolman
- Calibration data is linked to the filament (not a spool) so settings follow the material across all spools
- A **Calibration Wizard** walks users step-by-step with contextual instructions, test-setup inputs, auto-computed results (e.g. PA = step × height), and links to the OrcaSlicer wiki for each step
- Pressure Advance supports both **Tower** (auto-compute from step × height) and **Pattern / Line** (direct entry) methods
- Steps can be marked **Skipped** for printers where a step isn't applicable (e.g. Input Shaping on a printer with built-in IS)
- Calibrated settings are surfaced as a summary panel on the Filament show page

## Screenshots
<img width="2080" height="4676" alt="filament_page_with_calibration" src="https://github.com/user-attachments/assets/7aaefb8c-7862-4d2a-b1ac-d2648b9bc9e7" />

<img width="2080" height="4676" alt="filament_calibration_wizard" src="https://github.com/user-attachments/assets/65a387e8-a147-4767-8378-388fa106c3d3" />

## Changes

**Backend**
- New `calibration_session` and `calibration_step` DB models (`spoolman/database/models.py`) with two Alembic migrations
- REST API: full CRUD for sessions and steps under `/api/v1/calibration/` with Pydantic response models
- Integration tests covering create, get, list, update, and delete for both sessions and steps

**Frontend**
- `CalibrationSection` — embedded panel on the Filament show page; lists sessions with status badges and per-step results
- `CalibrationWizard` — step-by-step modal with instructions, inputs, auto-computed results, and OrcaSlicer wiki links
- `StepResultDrawer` — inline drawer for editing or re-recording a saved step result
- `SessionFormModal` — create/edit session metadata (printer name, nozzle diameter, notes)

**Other**
- Added `.env.production` to `client/.gitignore` to prevent local dev artifacts from being committed

## Test plan

- [ ] Create a calibration session on a filament
- [ ] Run through all wizard steps, including Skip on an inapplicable step
- [ ] Verify PA Tower auto-compute (PA = step × height) and Pattern/Line direct entry
- [ ] Edit a saved step result via the drawer
- [ ] Delete a step and a session
- [ ] Confirm calibrated settings summary panel updates correctly
- [ ] Run integration tests: `poe itest`

## Notes

- **i18n**: UI copy is currently English-only. Translations will be contributed to Weblate in a follow-up PR.
- The `_skipped` sentinel (`outputs: { _skipped: true }`) is a frontend convention stored in the step's JSON outputs field; it is not a separate DB column.