### PR TITLE
Remove overflow-y scroll from locations.css

### DIFF
--- a/client/src/pages/locations/locations.css
+++ b/client/src/pages/locations/locations.css
@@ -45,7 +45,6 @@
   flex-direction: column;
   gap: 0.5em;
   min-height: 3em;
-  overflow-y: scroll;
 }
 
 .loc-container .spool {


### PR DESCRIPTION
Since the `max-height` was removed in 251f7e2edee03720414eed50276cadb31f3c5ee2, there's no longer a reason to keep the scroll. This will remove the empty scroll bars, and make the UI neater