### PR TITLE
feat(ui/tables): resizable columns with horizontal scroll + autofit

### DIFF
--- a/client/src/components/column.tsx
+++ b/client/src/components/column.tsx
@@ -273,7 +273,10 @@ export function ActionsColumn<Obj extends Entity>(
 ): ColumnType<Obj> | undefined {
   return {
     title,
+    key: "actions",
     responsive: ["lg"],
+    fixed: "right",
+    width: 190,
     render: (_, record) => {
       const buttons = actionsFn(record).map((action) => {
         if (action.link) {

--- a/client/src/components/column.tsx
+++ b/client/src/components/column.tsx
@@ -80,6 +80,9 @@ function Column<Obj extends Entity>(
   const t = props.t;
   const navigate = props.navigate;
 
+  // Keep the shared table wiring in one place so list pages can opt into sorting,
+  // filtering, saved widths, and custom rendering without duplicating column setup.
+
   // Hide if not in showColumns
   const id = Array.isArray(props.id) ? props.id.join(".") : props.id;
   if (props.tableState.showColumns && !props.tableState.showColumns.includes(id)) {

--- a/client/src/components/resizableTable.tsx
+++ b/client/src/components/resizableTable.tsx
@@ -53,12 +53,16 @@ function serializeDataIndex(dataIndex: unknown): string | undefined {
 function columnIdentifier<RecordType extends AnyObject>(column: ColumnType<RecordType>, index: number, parentId: string): string {
   const key = column.key != null ? String(column.key) : undefined;
   const dataIndex = serializeDataIndex(column.dataIndex);
+  // Widths are persisted, so the identifier must stay stable across renders even when
+  // the table reorders or re-renders its column objects.
   return key ?? dataIndex ?? `${parentId}-${index}`;
 }
 
 function measureIntrinsicElementWidth(element: HTMLElement): number {
   const clone = element.cloneNode(true) as HTMLElement;
   clone.querySelectorAll(".resizable-table-header-handle").forEach((handle) => handle.remove());
+  // Measure a detached clone so auto-fit can use the content's natural width instead
+  // of the already-constrained width inside the current table cell.
   clone.style.position = "fixed";
   clone.style.left = "-99999px";
   clone.style.top = "-99999px";
@@ -238,6 +242,8 @@ function ResizableTable<RecordType extends AnyObject>(props: ResizableTableProps
               let hasOverflow = hasCellOverflow(currentHeaderCell);
 
               if (tableContainer) {
+                // Auto-fit should account for the widest visible body cell so a header
+                // label alone does not produce a column that still truncates row data.
                 const bodyRows = Array.from(tableContainer.querySelectorAll("tbody tr"));
                 bodyRows.forEach((row) => {
                   if (!(row instanceof HTMLTableRowElement)) {
@@ -288,6 +294,8 @@ function ResizableTable<RecordType extends AnyObject>(props: ResizableTableProps
 
   const resolvedScroll = useMemo(() => {
     const nextScroll = { ...(scroll ?? {}) };
+    // Keep horizontal scrolling enabled once the sum of leaf-column minimums exceeds the
+    // available width, otherwise resized columns would collapse unpredictably.
     if (nextScroll.x === undefined) {
       nextScroll.x = requiredMinWidth;
     } else if (typeof nextScroll.x === "number") {

--- a/client/src/components/resizableTable.tsx
+++ b/client/src/components/resizableTable.tsx
@@ -15,7 +15,14 @@ interface ResizableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement
 
 // Keep resize-handle gestures separate from the header cell itself so resizing
 // does not accidentally trigger the table's built-in sort interactions.
-function ResizableHeaderCell({ className, onResizeStart, onResizeAutoFit, resizable, children, ...restProps }: ResizableHeaderCellProps) {
+function ResizableHeaderCell({
+  className,
+  onResizeStart,
+  onResizeAutoFit,
+  resizable,
+  children,
+  ...restProps
+}: ResizableHeaderCellProps) {
   return (
     <th {...restProps} className={`${className ?? ""}${resizable ? " resizable-table-header-cell" : ""}`}>
       {children}
@@ -52,7 +59,11 @@ function serializeDataIndex(dataIndex: unknown): string | undefined {
   return undefined;
 }
 
-function columnIdentifier<RecordType extends AnyObject>(column: ColumnType<RecordType>, index: number, parentId: string): string {
+function columnIdentifier<RecordType extends AnyObject>(
+  column: ColumnType<RecordType>,
+  index: number,
+  parentId: string,
+): string {
   const key = column.key != null ? String(column.key) : undefined;
   const dataIndex = serializeDataIndex(column.dataIndex);
   // Widths are persisted, so the identifier must stay stable across renders even when
@@ -263,7 +274,9 @@ function ResizableTable<RecordType extends AnyObject>(props: ResizableTableProps
               }
 
               const autoFitWidth = Math.max(minColumnWidth, nextWidth);
-              const finalWidth = hasOverflow ? autoFitWidth : Math.max(minColumnWidth, Math.min(currentWidth, autoFitWidth));
+              const finalWidth = hasOverflow
+                ? autoFitWidth
+                : Math.max(minColumnWidth, Math.min(currentWidth, autoFitWidth));
               setColumnWidths((previous) => {
                 if (previous[id] === finalWidth) {
                   return previous;

--- a/client/src/components/resizableTable.tsx
+++ b/client/src/components/resizableTable.tsx
@@ -1,0 +1,310 @@
+import { Table } from "antd";
+import type { TableProps } from "antd";
+import type { AnyObject } from "antd/es/_util/type";
+import type { ColumnType, ColumnsType } from "antd/es/table";
+import { useMemo } from "react";
+import type { HTMLAttributes, MouseEvent as ReactMouseEvent, ThHTMLAttributes } from "react";
+import { useSavedState } from "../utils/saveload";
+import "../utils/overrides.css";
+
+interface ResizableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  onResizeStart?: (event: ReactMouseEvent<HTMLSpanElement>) => void;
+  onResizeAutoFit?: (event: ReactMouseEvent<HTMLSpanElement>) => void;
+  resizable?: boolean;
+}
+
+function ResizableHeaderCell({ className, onResizeStart, onResizeAutoFit, resizable, children, ...restProps }: ResizableHeaderCellProps) {
+  return (
+    <th {...restProps} className={`${className ?? ""}${resizable ? " resizable-table-header-cell" : ""}`}>
+      {children}
+      {resizable && (
+        <span
+          className="resizable-table-header-handle"
+          onMouseDown={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onResizeStart?.(event);
+          }}
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+          }}
+          onDoubleClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onResizeAutoFit?.(event);
+          }}
+        />
+      )}
+    </th>
+  );
+}
+
+function serializeDataIndex(dataIndex: unknown): string | undefined {
+  if (Array.isArray(dataIndex)) {
+    return dataIndex.map((part) => String(part)).join(".");
+  }
+  if (typeof dataIndex === "string" || typeof dataIndex === "number") {
+    return String(dataIndex);
+  }
+  return undefined;
+}
+
+function columnIdentifier<RecordType extends AnyObject>(column: ColumnType<RecordType>, index: number, parentId: string): string {
+  const key = column.key != null ? String(column.key) : undefined;
+  const dataIndex = serializeDataIndex(column.dataIndex);
+  return key ?? dataIndex ?? `${parentId}-${index}`;
+}
+
+function measureIntrinsicElementWidth(element: HTMLElement): number {
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(".resizable-table-header-handle").forEach((handle) => handle.remove());
+  clone.style.position = "fixed";
+  clone.style.left = "-99999px";
+  clone.style.top = "-99999px";
+  clone.style.width = "max-content";
+  clone.style.maxWidth = "none";
+  clone.style.minWidth = "0";
+  clone.style.display = "inline-block";
+  clone.style.whiteSpace = "nowrap";
+  clone.style.visibility = "hidden";
+  document.body.appendChild(clone);
+  const measuredWidth = clone.getBoundingClientRect().width;
+  clone.remove();
+  return measuredWidth;
+}
+
+function measureCellAutoFitWidth(cell: HTMLTableCellElement): number {
+  const style = window.getComputedStyle(cell);
+  const paddingLeft = Number.parseFloat(style.paddingLeft || "0") || 0;
+  const paddingRight = Number.parseFloat(style.paddingRight || "0") || 0;
+  const horizontalPadding = paddingLeft + paddingRight;
+
+  const childElements = Array.from(cell.children).filter((child): child is HTMLElement => child instanceof HTMLElement);
+  if (childElements.length > 0) {
+    const widestChild = childElements.reduce((maxWidth, child) => {
+      return Math.max(maxWidth, measureIntrinsicElementWidth(child));
+    }, 0);
+    return Math.ceil(widestChild + horizontalPadding);
+  }
+
+  const text = cell.textContent?.trim() ?? "";
+  if (text.length === 0) {
+    return Math.ceil(horizontalPadding);
+  }
+
+  const textProbe = document.createElement("span");
+  textProbe.textContent = text;
+  textProbe.style.position = "fixed";
+  textProbe.style.left = "-99999px";
+  textProbe.style.top = "-99999px";
+  textProbe.style.whiteSpace = "nowrap";
+  textProbe.style.font = style.font;
+  textProbe.style.fontSize = style.fontSize;
+  textProbe.style.fontWeight = style.fontWeight;
+  textProbe.style.letterSpacing = style.letterSpacing;
+  textProbe.style.visibility = "hidden";
+  document.body.appendChild(textProbe);
+  const textWidth = textProbe.getBoundingClientRect().width;
+  textProbe.remove();
+
+  return Math.ceil(textWidth + horizontalPadding);
+}
+
+function hasCellOverflow(cell: HTMLTableCellElement): boolean {
+  if (cell.scrollWidth > cell.clientWidth + 1) {
+    return true;
+  }
+
+  return Array.from(cell.children).some((child) => {
+    if (!(child instanceof HTMLElement)) {
+      return false;
+    }
+    return child.scrollWidth > child.clientWidth + 1;
+  });
+}
+
+export interface ResizableTableProps<RecordType extends AnyObject> extends TableProps<RecordType> {
+  columnResizeKey: string;
+  minColumnWidth?: number;
+}
+
+function ResizableTable<RecordType extends AnyObject>(props: ResizableTableProps<RecordType>) {
+  const { columns, components, columnResizeKey, minColumnWidth = 72, scroll, sticky, ...tableProps } = props;
+  const [columnWidths, setColumnWidths] = useSavedState<Record<string, number>>(
+    `table-column-widths-${columnResizeKey}`,
+    {},
+  );
+
+  const { resolvedColumns, requiredMinWidth } = useMemo(() => {
+    if (!columns) {
+      return { resolvedColumns: columns, requiredMinWidth: minColumnWidth };
+    }
+
+    let minWidthSum = 0;
+
+    const withResize = (input: ColumnsType<RecordType>, parentId: string): ColumnsType<RecordType> => {
+      return input.map((column, index) => {
+        const id = columnIdentifier(column, index, parentId);
+        const columnWidth =
+          typeof columnWidths[id] === "number"
+            ? columnWidths[id]
+            : typeof column.width === "number"
+              ? column.width
+              : undefined;
+
+        const columnChildren = (column as { children?: ColumnsType<RecordType> }).children;
+        const hasChildren = Array.isArray(columnChildren) && columnChildren.length > 0;
+        const nextColumn: ColumnsType<RecordType>[number] = {
+          ...column,
+        };
+
+        if (hasChildren) {
+          (nextColumn as { children?: ColumnsType<RecordType> }).children = withResize(columnChildren, id);
+          return nextColumn;
+        }
+
+        const leafColumn = nextColumn as ColumnType<RecordType>;
+        const existingMinWidth =
+          typeof (leafColumn as { minWidth?: number }).minWidth === "number"
+            ? (leafColumn as { minWidth?: number }).minWidth
+            : undefined;
+        const effectiveMinWidth = Math.max(minColumnWidth, existingMinWidth ?? 0);
+
+        if (typeof columnWidth === "number") {
+          leafColumn.width = Math.max(effectiveMinWidth, columnWidth);
+        }
+        (leafColumn as { minWidth?: number }).minWidth = effectiveMinWidth;
+
+        minWidthSum += typeof leafColumn.width === "number" ? leafColumn.width : effectiveMinWidth;
+
+        const originalOnHeaderCell = (column as ColumnType<RecordType>).onHeaderCell;
+        leafColumn.onHeaderCell = (col) => {
+          const existingProps = (originalOnHeaderCell?.(col as never) ?? {}) as Record<string, unknown>;
+          return {
+            ...existingProps,
+            resizable: true,
+            onResizeStart: (event: ReactMouseEvent<HTMLSpanElement>) => {
+              const startX = event.clientX;
+              const currentHeaderCell = event.currentTarget.closest("th");
+              const baseWidth = Math.max(
+                minColumnWidth,
+                currentHeaderCell?.getBoundingClientRect().width ?? columnWidth ?? minColumnWidth,
+              );
+              const originalCursor = document.body.style.cursor;
+              const originalUserSelect = document.body.style.userSelect;
+              document.body.style.cursor = "col-resize";
+              document.body.style.userSelect = "none";
+
+              const onMouseMove = (moveEvent: MouseEvent) => {
+                const nextWidth = Math.max(minColumnWidth, baseWidth + moveEvent.clientX - startX);
+                setColumnWidths((previous) => {
+                  if (previous[id] === nextWidth) {
+                    return previous;
+                  }
+                  return {
+                    ...previous,
+                    [id]: nextWidth,
+                  };
+                });
+              };
+
+              const onMouseUp = () => {
+                document.removeEventListener("mousemove", onMouseMove);
+                document.removeEventListener("mouseup", onMouseUp);
+                document.body.style.cursor = originalCursor;
+                document.body.style.userSelect = originalUserSelect;
+              };
+
+              document.addEventListener("mousemove", onMouseMove);
+              document.addEventListener("mouseup", onMouseUp);
+            },
+            onResizeAutoFit: (event: ReactMouseEvent<HTMLSpanElement>) => {
+              const currentHeaderCell = event.currentTarget.closest("th");
+              const headerRow = currentHeaderCell?.parentElement;
+              if (!(currentHeaderCell instanceof HTMLTableCellElement) || !(headerRow instanceof HTMLTableRowElement)) {
+                return;
+              }
+
+              const headerCells = Array.from(headerRow.cells);
+              const columnIndex = headerCells.indexOf(currentHeaderCell);
+              if (columnIndex === -1) {
+                return;
+              }
+
+              const tableContainer = currentHeaderCell.closest(".ant-table-container");
+              const currentWidth = Math.ceil(currentHeaderCell.getBoundingClientRect().width);
+              let nextWidth = measureCellAutoFitWidth(currentHeaderCell);
+              let hasOverflow = hasCellOverflow(currentHeaderCell);
+
+              if (tableContainer) {
+                const bodyRows = Array.from(tableContainer.querySelectorAll("tbody tr"));
+                bodyRows.forEach((row) => {
+                  if (!(row instanceof HTMLTableRowElement)) {
+                    return;
+                  }
+                  const cell = row.cells.item(columnIndex);
+                  if (cell) {
+                    nextWidth = Math.max(nextWidth, measureCellAutoFitWidth(cell));
+                    hasOverflow = hasOverflow || hasCellOverflow(cell);
+                  }
+                });
+              }
+
+              const autoFitWidth = Math.max(minColumnWidth, nextWidth);
+              const finalWidth = hasOverflow ? autoFitWidth : Math.max(minColumnWidth, Math.min(currentWidth, autoFitWidth));
+              setColumnWidths((previous) => {
+                if (previous[id] === finalWidth) {
+                  return previous;
+                }
+                return {
+                  ...previous,
+                  [id]: finalWidth,
+                };
+              });
+            },
+          } as unknown as HTMLAttributes<HTMLElement>;
+        };
+
+        return nextColumn;
+      });
+    };
+
+    return {
+      resolvedColumns: withResize(columns as ColumnsType<RecordType>, "root"),
+      requiredMinWidth: minWidthSum,
+    };
+  }, [columns, columnWidths, minColumnWidth, setColumnWidths]);
+
+  const mergedComponents = useMemo(() => {
+    return {
+      ...components,
+      header: {
+        ...components?.header,
+        cell: ResizableHeaderCell,
+      },
+    };
+  }, [components]);
+
+  const resolvedScroll = useMemo(() => {
+    const nextScroll = { ...(scroll ?? {}) };
+    if (nextScroll.x === undefined) {
+      nextScroll.x = requiredMinWidth;
+    } else if (typeof nextScroll.x === "number") {
+      nextScroll.x = Math.max(nextScroll.x, requiredMinWidth);
+    }
+    return nextScroll;
+  }, [requiredMinWidth, scroll]);
+
+  return (
+    <Table<RecordType>
+      {...tableProps}
+      columns={resolvedColumns}
+      components={mergedComponents}
+      scroll={resolvedScroll}
+      sticky={sticky ?? true}
+    />
+  );
+}
+
+export default ResizableTable;

--- a/client/src/components/resizableTable.tsx
+++ b/client/src/components/resizableTable.tsx
@@ -13,6 +13,8 @@ interface ResizableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement
   resizable?: boolean;
 }
 
+// Keep resize-handle gestures separate from the header cell itself so resizing
+// does not accidentally trigger the table's built-in sort interactions.
 function ResizableHeaderCell({ className, onResizeStart, onResizeAutoFit, resizable, children, ...restProps }: ResizableHeaderCellProps) {
   return (
     <th {...restProps} className={`${className ?? ""}${resizable ? " resizable-table-header-cell" : ""}`}>
@@ -129,10 +131,13 @@ function hasCellOverflow(cell: HTMLTableCellElement): boolean {
 }
 
 export interface ResizableTableProps<RecordType extends AnyObject> extends TableProps<RecordType> {
+  // Saved widths are keyed per table, so each page keeps its own resize state.
   columnResizeKey: string;
   minColumnWidth?: number;
 }
 
+// Wrap AntD's Table with stable per-column identifiers and persisted widths so
+// resize/autofit behavior stays reusable across list and settings screens.
 function ResizableTable<RecordType extends AnyObject>(props: ResizableTableProps<RecordType>) {
   const { columns, components, columnResizeKey, minColumnWidth = 72, scroll, sticky, ...tableProps } = props;
   const [columnWidths, setColumnWidths] = useSavedState<Record<string, number>>(

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined, EyeOutlined, FileOutlined, FilterOutlined, PlusSquareOutlined } from "@ant-design/icons";
 import { List, useTable } from "@refinedev/antd";
 import { useInvalidate, useNavigation, useTranslate } from "@refinedev/core";
-import { Button, Dropdown, Table } from "antd";
+import { Button, Dropdown } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useMemo, useState } from "react";
@@ -17,6 +17,7 @@ import {
   SpoolIconColumn,
 } from "../../components/column";
 import { useLiveify } from "../../components/liveify";
+import ResizableTable from "../../components/resizableTable";
 import {
   useSpoolmanArticleNumbers,
   useSpoolmanFilamentNames,
@@ -216,7 +217,8 @@ export const FilamentList = () => {
         </>
       )}
     >
-      <Table<IFilamentCollapsed>
+      <ResizableTable<IFilamentCollapsed>
+        columnResizeKey="filament-list-table"
         {...tableProps}
         sticky
         tableLayout="auto"

--- a/client/src/pages/settings/extraFieldsSettings.tsx
+++ b/client/src/pages/settings/extraFieldsSettings.tsx
@@ -11,7 +11,6 @@ import {
   Popconfirm,
   Select,
   Space,
-  Table,
   message,
 } from "antd";
 import { FormItemProps, Rule } from "antd/es/form";
@@ -25,6 +24,7 @@ import { Trans } from "react-i18next";
 import { useParams } from "react-router";
 import { DateTimePicker } from "../../components/dateTimePicker";
 import { InputNumberRange } from "../../components/inputNumberRange";
+import ResizableTable from "../../components/resizableTable";
 import { EntityType, Field, FieldType, useDeleteField, useGetFields, useSetField } from "../../utils/queryFields";
 
 dayjs.extend(utc);
@@ -608,7 +608,8 @@ export function ExtraFieldsSettings() {
         }}
       />
       <Form form={form} component={false} disabled={isSubmitting}>
-        <Table
+        <ResizableTable
+          columnResizeKey={`extra-fields-${entityType}`}
           components={{
             body: {
               cell: EditableCell,

--- a/client/src/pages/spools/list.tsx
+++ b/client/src/pages/spools/list.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ant-design/icons";
 import { List, useTable } from "@refinedev/antd";
 import { useInvalidate, useNavigation, useTranslate } from "@refinedev/core";
-import { Button, Dropdown, Modal, Table } from "antd";
+import { Button, Dropdown, Modal } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useCallback, useMemo, useState } from "react";
@@ -27,6 +27,7 @@ import {
   SpoolIconColumn,
 } from "../../components/column";
 import { useLiveify } from "../../components/liveify";
+import ResizableTable from "../../components/resizableTable";
 import {
   useSpoolmanFilamentFilter,
   useSpoolmanLocations,
@@ -326,7 +327,8 @@ export const SpoolList = () => {
       )}
     >
       {spoolAdjustModal}
-      <Table
+      <ResizableTable
+        columnResizeKey="spool-list-table"
         {...tableProps}
         sticky
         tableLayout="auto"

--- a/client/src/pages/vendors/list.tsx
+++ b/client/src/pages/vendors/list.tsx
@@ -1,7 +1,7 @@
 import { EditOutlined, EyeOutlined, FilterOutlined, PlusSquareOutlined } from "@ant-design/icons";
 import { List, useTable } from "@refinedev/antd";
 import { useInvalidate, useNavigation, useTranslate } from "@refinedev/core";
-import { Button, Dropdown, Table } from "antd";
+import { Button, Dropdown } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useCallback, useMemo, useState } from "react";
@@ -15,6 +15,7 @@ import {
   SortedColumn,
 } from "../../components/column";
 import { useLiveify } from "../../components/liveify";
+import ResizableTable from "../../components/resizableTable";
 import { removeUndefined } from "../../utils/filtering";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { TableState, useInitialTableState, useStoreInitialState } from "../../utils/saveload";
@@ -159,7 +160,8 @@ export const VendorList = () => {
         </>
       )}
     >
-      <Table
+      <ResizableTable
+        columnResizeKey="vendor-list-table"
         {...tableProps}
         sticky
         tableLayout="auto"

--- a/client/src/utils/overrides.css
+++ b/client/src/utils/overrides.css
@@ -1,3 +1,33 @@
 #qty-input {
   text-align: center !important;
 }
+
+.resizable-table-header-cell {
+  position: relative;
+}
+
+.resizable-table-header-handle {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 2;
+}
+
+.resizable-table-header-handle::after {
+  content: "";
+  position: absolute;
+  top: 18%;
+  bottom: 18%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 1px;
+  background: rgba(255, 255, 255, 0.2);
+  transition: background-color 0.15s ease;
+}
+
+.resizable-table-header-handle:hover::after {
+  background: #d07a36;
+}

--- a/client/src/utils/saveload.ts
+++ b/client/src/utils/saveload.ts
@@ -6,6 +6,17 @@ interface Pagination {
   pageSize: number;
 }
 
+function parseSavedJSON<T>(value: string | null, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 export interface TableState {
   sorters: CrudSort[];
   filters: CrudFilter[];
@@ -93,7 +104,7 @@ export function useStoreInitialState(tableId: string, state: TableState) {
 export function useSavedState<T>(id: string, defaultValue: T) {
   const [state, setState] = useState<T>(() => {
     const savedState = isLocalStorageAvailable ? localStorage.getItem(`savedStates-${id}`) : null;
-    return savedState ? JSON.parse(savedState) : defaultValue;
+    return parseSavedJSON(savedState, defaultValue);
   });
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
This PR introduces a reusable table interaction layer for column resizing and horizontal-scroll behavior across key list/settings tables. It also guards the new saved column-width state so a malformed local-storage entry recovers to defaults instead of blanking the page.

## Why This Matters
- Wide datasets are hard to scan when columns cannot be resized to fit real content.
- Auto-fit on double-click removes repetitive manual resizing.
- Stable horizontal scrolling and persisted widths improve day-to-day table usability.
- Persisted width state should not be able to white-page a list screen.

## What Changed
### Reusable table interaction primitive
- Added a shared `ResizableTable` wrapper for AntD tables.
- Added drag-based header column resize handles.
- Added double-click auto-fit on the resize handle.
- Added per-table column width persistence through existing saved-state flow.
- Ensured table horizontal scroll width tracks effective column minimum width.

### Hardening
- Guarded saved column-width state parsing in `useSavedState` so invalid persisted JSON falls back to defaults and self-heals on reload.

### Wired pages
- Filament list table
- Spool list table
- Vendor list table
- Settings → Extra Fields table

### Files of interest
- `client/src/components/column.tsx`
- `client/src/components/resizableTable.tsx`
- `client/src/pages/filaments/list.tsx`
- `client/src/pages/settings/extraFieldsSettings.tsx`
- `client/src/pages/spools/list.tsx`
- `client/src/pages/vendors/list.tsx`
- `client/src/utils/overrides.css`
- `client/src/utils/saveload.ts`

## Scope / Independence
- Standalone UI/table behavior PR.
- No backend API/query/index changes.
- No migration/schema/data changes.
- Search/filter/performance dropdown behavior remains in `#862`.

## Testing Performed
- `cd client && npm ci`
- `cd client && ./node_modules/.bin/eslint src/utils/saveload.ts src/components/resizableTable.tsx src/components/column.tsx src/pages/filaments/list.tsx src/pages/spools/list.tsx src/pages/vendors/list.tsx src/pages/settings/extraFieldsSettings.tsx`
- `cd client && ./node_modules/.bin/prettier --check src/utils/saveload.ts src/components/resizableTable.tsx src/components/column.tsx src/pages/filaments/list.tsx src/pages/spools/list.tsx src/pages/vendors/list.tsx src/pages/settings/extraFieldsSettings.tsx`
- `cd client && VITE_APIURL=/api/v1 npm run build`
- Local runtime: `uv run uvicorn spoolman.main:app --host 0.0.0.0 --port 9861`
- Seeded local validation data via the local API for vendor, filament, spool, and vendor extra-field rows
- Playwright on `http://localhost:9861/filament`
  - verified resize handles render
  - dragged the `Name` column wider and confirmed the width updated immediately
  - double-clicked the `Name` column handle and confirmed auto-fit returned it to content width
  - reloaded and confirmed the saved width persisted
  - injected malformed saved width JSON and confirmed the page recovered and rewrote the state to `{}` instead of blanking
- Playwright on `http://localhost:9861/filament` at `800x900`
  - confirmed horizontal overflow is present
  - confirmed the `Actions` column is hidden below `lg`
- Playwright on `http://localhost:9861/filament` at `1000x900`
  - confirmed horizontal overflow is present
  - confirmed the `Actions` column remains pinned while the table body scrolls horizontally
- Playwright smoke checks
  - `http://localhost:9861/spool`
  - `http://localhost:9861/vendor`
  - `http://localhost:9861/settings/extra/vendor`
  - confirmed resize handles render with populated rows on each page
- Playwright on `http://localhost:9861/spool`
  - confirmed drag-resize on spool list columns (`Material`, `Price`)
  - confirmed double-click auto-fit on the `Location` column
  - confirmed resized widths persist after reload
- Playwright on `http://localhost:9861/vendor`
  - confirmed drag-resize on the `Name` column
  - confirmed double-click auto-fit on the `Name` column
  - confirmed resized widths persist after reload
- Playwright on `http://localhost:9861/settings/extra/vendor`
  - confirmed drag-resize on the `Name` column
  - confirmed double-click auto-fit on the `Name` column
  - confirmed resized widths persist after reload
- Explicit reset-path validation
  - widened the filament `Name` column
  - removed the saved width entry from browser storage
  - reloaded and confirmed the column returned to its default width

## Test Checklist
- [x] Filament list renders resize handles
- [x] Filament list drag-resize updates column width immediately
- [x] Filament list double-click auto-fit adjusts the column to content width
- [x] Filament list saved width persists after reload
- [x] Filament list recovers from malformed saved width JSON without blanking
- [x] Filament list shows horizontal overflow at narrower desktop widths
- [x] Filament list keeps the `Actions` column pinned while horizontally scrolling at desktop widths
- [x] Filament list hides the `Actions` column below `lg`
- [x] Spool list renders resize handles with populated rows
- [x] Vendor list renders resize handles with populated rows
- [x] Settings → Extra Fields (vendor) renders resize handles with populated rows
- [x] Spool list drag-resize and auto-fit were manually exercised
- [x] Vendor list drag-resize and auto-fit were manually exercised
- [x] Settings → Extra Fields drag-resize and auto-fit were manually exercised
- [x] Clearing browser storage was explicitly tested as a reset path
- [ ] Mobile/touch resize behavior was tested on an actual touch device
