### PR TITLE
feat(ui/colors): improve multi-color hex editing and spool/filament previews

### DIFF
--- a/client/src/components/colorHexPreview.tsx
+++ b/client/src/components/colorHexPreview.tsx
@@ -13,6 +13,8 @@ const SMALL_TEXT_STYLE = {
   lineHeight: 1.2,
 };
 
+// Stored color values omit the hash, but every preview path in the UI should render a
+// canonical uppercase #RRGGBB string so chips and labels stay visually consistent.
 const normalizeHex = (value: string) => `#${value.replace("#", "").toUpperCase()}`;
 
 export default function ColorHexPreview({ colorHex, multiColorHexes, multiColorDirection }: Readonly<ColorHexPreviewProps>) {
@@ -36,6 +38,8 @@ export default function ColorHexPreview({ colorHex, multiColorHexes, multiColorD
 
   const isLongitudinal = multiColorDirection === "longitudinal";
   if (isLongitudinal) {
+    // Longitudinal multi-color spools are shown as separate swatches because the
+    // stripe order matters more than the combined spool silhouette.
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         {colors.map((hex, index) => (

--- a/client/src/components/colorHexPreview.tsx
+++ b/client/src/components/colorHexPreview.tsx
@@ -17,7 +17,11 @@ const SMALL_TEXT_STYLE = {
 // canonical uppercase #RRGGBB string so chips and labels stay visually consistent.
 const normalizeHex = (value: string) => `#${value.replace("#", "").toUpperCase()}`;
 
-export default function ColorHexPreview({ colorHex, multiColorHexes, multiColorDirection }: Readonly<ColorHexPreviewProps>) {
+export default function ColorHexPreview({
+  colorHex,
+  multiColorHexes,
+  multiColorDirection,
+}: Readonly<ColorHexPreviewProps>) {
   const colors =
     multiColorHexes
       ?.split(",")

--- a/client/src/components/colorHexPreview.tsx
+++ b/client/src/components/colorHexPreview.tsx
@@ -1,4 +1,5 @@
 import { Typography } from "antd";
+import { normalizeHex } from "../utils/colorFormatting";
 import SpoolIcon from "./spoolIcon";
 
 interface ColorHexPreviewProps {
@@ -12,10 +13,6 @@ const SMALL_TEXT_STYLE = {
   color: "rgba(255,255,255,0.45)",
   lineHeight: 1.2,
 };
-
-// Stored color values omit the hash, but every preview path in the UI should render a
-// canonical uppercase #RRGGBB string so chips and labels stay visually consistent.
-const normalizeHex = (value: string) => `#${value.replace("#", "").toUpperCase()}`;
 
 export default function ColorHexPreview({
   colorHex,

--- a/client/src/components/colorHexPreview.tsx
+++ b/client/src/components/colorHexPreview.tsx
@@ -1,0 +1,78 @@
+import { Typography } from "antd";
+import SpoolIcon from "./spoolIcon";
+
+interface ColorHexPreviewProps {
+  colorHex?: string | null;
+  multiColorHexes?: string | null;
+  multiColorDirection?: string | null;
+}
+
+const SMALL_TEXT_STYLE = {
+  fontSize: 12,
+  color: "rgba(255,255,255,0.45)",
+  lineHeight: 1.2,
+};
+
+const normalizeHex = (value: string) => `#${value.replace("#", "").toUpperCase()}`;
+
+export default function ColorHexPreview({ colorHex, multiColorHexes, multiColorDirection }: Readonly<ColorHexPreviewProps>) {
+  const colors =
+    multiColorHexes
+      ?.split(",")
+      .map((hex) => hex.trim())
+      .filter((hex) => hex.length > 0)
+      .map(normalizeHex) ?? [];
+
+  if (colors.length <= 1) {
+    const singleColor = colorHex ? normalizeHex(colorHex) : colors[0];
+    if (!singleColor) return null;
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <SpoolIcon color={singleColor} size="large" no_margin />
+        <Typography.Text style={SMALL_TEXT_STYLE}>{singleColor}</Typography.Text>
+      </div>
+    );
+  }
+
+  const isLongitudinal = multiColorDirection === "longitudinal";
+  if (isLongitudinal) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {colors.map((hex, index) => (
+          <div key={`${hex}-${index}`} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+            <div
+              style={{
+                width: 56,
+                height: 22,
+                borderRadius: 5,
+                border: "1px solid rgba(255,255,255,0.22)",
+                background: hex,
+              }}
+            />
+            <Typography.Text style={SMALL_TEXT_STYLE}>{hex}</Typography.Text>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", gap: 0 }}>
+      {colors.map((hex, index) => (
+        <div
+          key={`${hex}-${index}`}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            width: 64,
+            gap: 4,
+          }}
+        >
+          <SpoolIcon color={hex} size="large" no_margin />
+          <Typography.Text style={{ ...SMALL_TEXT_STYLE, textAlign: "center" }}>{hex}</Typography.Text>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/multiColorPicker.tsx
+++ b/client/src/components/multiColorPicker.tsx
@@ -26,46 +26,184 @@ export function MultiColorPicker(props: {
   onChange?: (value: string | null | undefined) => void;
   min?: number;
   max?: number;
+  layout?: "horizontal" | "vertical";
+  showHex?: boolean;
+  hexPosition?: "right" | "bottom";
+  swatchWidth?: number;
+  swatchHeight?: number;
 }) {
   const values = props.value ? props.value.split(",") : generateInitialColors(props.min ?? 0);
   if (!props.value && props.onChange) {
     // Update value immediately
     props.onChange(values.join(","));
   }
-  const pickers = values.map((value, idx) => (
-    <Badge
-      key={idx}
-      count={
-        values.length > (props.min ?? 0) ? (
-          <span className="ant-badge-count">
-            <CloseOutlined
+  const layout = props.layout ?? "horizontal";
+  const showHex = props.showHex ?? false;
+  const hexPosition = props.hexPosition ?? "bottom";
+  const swatchWidth = props.swatchWidth ?? 38;
+  const swatchHeight = props.swatchHeight ?? 38;
+  const hexTextStyle = {
+    fontSize: 12,
+    color: "rgba(255, 255, 255, 0.5)",
+    lineHeight: 1.2,
+    textTransform: "uppercase" as const,
+    fontFamily: "monospace",
+  };
+
+  const pickers = values.map((value, idx) => {
+    const formattedHex = `#${value.replace("#", "").toUpperCase()}`;
+    return (
+      <Badge
+        key={idx}
+        count={
+          values.length > (props.min ?? 0) ? (
+            <span className="ant-badge-count">
+              <CloseOutlined
+                onClick={() => {
+                  if (props.onChange) {
+                    props.onChange(values.filter((v, i) => i !== idx).join(","));
+                  }
+                }}
+              />
+            </span>
+          ) : (
+            <></>
+          )
+        }
+      >
+        <div
+          style={{
+            display: "flex",
+            flexDirection: showHex ? (hexPosition === "right" ? "row" : "column") : "column",
+            alignItems: showHex && hexPosition === "right" ? "center" : "flex-start",
+            gap: showHex ? 8 : 0,
+          }}
+        >
+          <ColorPicker
+            value={value}
+            onChange={(clr) => {
+              if (props.onChange) {
+                props.onChange(values.map((v, i) => (i === idx ? clr.toHex() : v)).join(","));
+              }
+            }}
+          >
+            <div
+              style={{
+                width: swatchWidth,
+                height: swatchHeight,
+                borderRadius: 8,
+                border: "1px solid rgba(255,255,255,0.2)",
+                backgroundColor: `#${value.replace("#", "")}`,
+              }}
+            />
+          </ColorPicker>
+          {showHex && <span style={hexTextStyle}>{formattedHex}</span>}
+        </div>
+      </Badge>
+    );
+  });
+
+  const isVerticalWithRightHex = layout === "vertical" && showHex && hexPosition === "right";
+  if (isVerticalWithRightHex) {
+    const canRemove = values.length > (props.min ?? 0);
+    const canAdd = values.length < (props.max ?? Infinity);
+    const actionSize = Math.max(20, Math.min(28, swatchHeight));
+    const rowGap = 12;
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 10,
+          marginTop: "1em",
+        }}
+      >
+        <Space direction="vertical" size={rowGap}>
+          {values.map((_, idx) => (
+            <Button
+              key={`remove-${idx}`}
+              danger
+              shape="circle"
+              icon={<CloseOutlined />}
+              disabled={!canRemove}
+              style={{
+                width: actionSize,
+                minWidth: actionSize,
+                height: actionSize,
+                padding: 0,
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
               onClick={() => {
-                // Remove this picker
+                if (!canRemove) return;
                 if (props.onChange) {
                   props.onChange(values.filter((v, i) => i !== idx).join(","));
                 }
               }}
             />
-          </span>
-        ) : (
-          <></>
-        )
-      }
-    >
-      <ColorPicker
-        value={value}
-        onChange={(clr) => {
-          if (props.onChange) {
-            props.onChange(values.map((v, i) => (i === idx ? clr.toHex() : v)).join(","));
-          }
-        }}
-      />
-    </Badge>
-  ));
+          ))}
+          <Button
+            key="add"
+            shape="circle"
+            icon={<PlusOutlined />}
+            disabled={!canAdd}
+            style={{
+              width: actionSize,
+              minWidth: actionSize,
+              height: actionSize,
+              padding: 0,
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+            onClick={() => {
+              if (!canAdd) return;
+              if (props.onChange) {
+                props.onChange(values.concat(generateRandomColor()).join(","));
+              }
+            }}
+          />
+        </Space>
+        <Space direction="vertical" size={rowGap} style={{ paddingLeft: 10 }}>
+          {values.map((value, idx) => (
+            <div
+              key={`${value}-${idx}`}
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
+              <ColorPicker
+                value={value}
+                onChange={(clr) => {
+                  if (props.onChange) {
+                    props.onChange(values.map((v, i) => (i === idx ? clr.toHex() : v)).join(","));
+                  }
+                }}
+              >
+                <div
+                  style={{
+                    width: swatchWidth,
+                    height: swatchHeight,
+                    borderRadius: 8,
+                    border: "1px solid rgba(255,255,255,0.2)",
+                    backgroundColor: `#${value.replace("#", "")}`,
+                  }}
+                />
+              </ColorPicker>
+              <span style={hexTextStyle}>{`#${value.replace("#", "").toUpperCase()}`}</span>
+            </div>
+          ))}
+        </Space>
+      </div>
+    );
+  }
 
   return (
     <>
-      <Space direction="horizontal" size="middle" style={{ marginTop: "1em" }}>
+      <Space direction={layout === "vertical" ? "vertical" : "horizontal"} size="middle" style={{ marginTop: "1em" }}>
         {pickers}
         {values.length < (props.max ?? Infinity) && (
           <Button

--- a/client/src/components/multiColorPicker.tsx
+++ b/client/src/components/multiColorPicker.tsx
@@ -1,5 +1,6 @@
 import { CloseOutlined, PlusOutlined } from "@ant-design/icons";
 import { Badge, Button, ColorPicker, Space } from "antd";
+import { normalizeHex } from "../utils/colorFormatting";
 
 function generateRandomColor() {
   return "000000".replace(/0/g, function () {
@@ -50,9 +51,13 @@ export function MultiColorPicker(props: {
     textTransform: "uppercase" as const,
     fontFamily: "monospace",
   };
+  const swatchStyle = {
+    borderRadius: 8,
+    border: "1px solid rgba(255,255,255,0.2)",
+  } as const;
 
   const pickers = values.map((value, idx) => {
-    const formattedHex = `#${value.replace("#", "").toUpperCase()}`;
+    const formattedHex = normalizeHex(value);
     return (
       <Badge
         key={idx}
@@ -90,10 +95,9 @@ export function MultiColorPicker(props: {
           >
             <div
               style={{
+                ...swatchStyle,
                 width: swatchWidth,
                 height: swatchHeight,
-                borderRadius: 8,
-                border: "1px solid rgba(255,255,255,0.2)",
                 backgroundColor: `#${value.replace("#", "")}`,
               }}
             />
@@ -188,15 +192,14 @@ export function MultiColorPicker(props: {
               >
                 <div
                   style={{
+                    ...swatchStyle,
                     width: swatchWidth,
                     height: swatchHeight,
-                    borderRadius: 8,
-                    border: "1px solid rgba(255,255,255,0.2)",
                     backgroundColor: `#${value.replace("#", "")}`,
                   }}
                 />
               </ColorPicker>
-              <span style={hexTextStyle}>{`#${value.replace("#", "").toUpperCase()}`}</span>
+              <span style={hexTextStyle}>{normalizeHex(value)}</span>
             </div>
           ))}
         </Space>

--- a/client/src/components/multiColorPicker.tsx
+++ b/client/src/components/multiColorPicker.tsx
@@ -34,7 +34,8 @@ export function MultiColorPicker(props: {
 }) {
   const values = props.value ? props.value.split(",") : generateInitialColors(props.min ?? 0);
   if (!props.value && props.onChange) {
-    // Update value immediately
+    // Seed the form value immediately so a newly toggled multi-color field persists a
+    // valid minimum color set instead of rendering transient placeholder swatches only.
     props.onChange(values.join(","));
   }
   const layout = props.layout ?? "horizontal";
@@ -107,6 +108,8 @@ export function MultiColorPicker(props: {
   if (isVerticalWithRightHex) {
     const canRemove = values.length > (props.min ?? 0);
     const canAdd = values.length < (props.max ?? Infinity);
+    // Longitudinal filaments read more naturally as stacked rows with the swatch and
+    // hex side by side, so switch to explicit row controls instead of the generic Badge layout.
     const actionSize = Math.max(20, Math.min(28, swatchHeight));
     const rowGap = 12;
     return (

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -67,6 +67,7 @@ export const FilamentEdit = () => {
   formProps.onFinish = (allValues: IFilamentParsedExtras) => {
     if (allValues !== undefined && allValues !== null) {
       if (colorType == "single") {
+        // Clear the hidden multi-color payload so switching modes does not submit stale comma-separated values.
         allValues.multi_color_hexes = "";
       }
       // Lot of stupidity here to make types work

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -217,6 +217,8 @@ export const FilamentEdit = () => {
             ]}
           >
             <MultiColorPicker
+              // Match the editor layout to the final preview so the user is editing
+              // colors in the same visual orientation they will later see on show pages.
               min={2}
               max={14}
               layout={watchedMultiColorDirection === "longitudinal" ? "vertical" : "horizontal"}

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -42,6 +42,8 @@ export const FilamentEdit = () => {
     optionLabel: "name",
     pagination: { mode: "off" },
   });
+  const watchedColorHex = Form.useWatch(["color_hex"], formProps.form);
+  const watchedMultiColorDirection = Form.useWatch(["multi_color_direction"], formProps.form);
 
   // Add the vendor_id field to the form
   if (formProps.initialValues) {
@@ -170,8 +172,23 @@ export const FilamentEdit = () => {
               return e?.toHex();
             }}
           >
-            <ColorPicker />
+            <ColorPicker>
+              <div
+                style={{
+                  width: 74,
+                  height: 74,
+                  borderRadius: 10,
+                  border: "1px solid rgba(255,255,255,0.2)",
+                  backgroundColor: `#${(watchedColorHex ?? "000000").replace("#", "")}`,
+                }}
+              />
+            </ColorPicker>
           </Form.Item>
+        )}
+        {colorType == "single" && watchedColorHex && (
+          <Typography.Text type="secondary" style={{ display: "block", marginTop: -12, marginBottom: 12 }}>
+            #{`${watchedColorHex}`.replace("#", "").toUpperCase()}
+          </Typography.Text>
         )}
         {colorType == "multi" && (
           <Form.Item
@@ -199,7 +216,15 @@ export const FilamentEdit = () => {
               },
             ]}
           >
-            <MultiColorPicker min={2} max={14} />
+            <MultiColorPicker
+              min={2}
+              max={14}
+              layout={watchedMultiColorDirection === "longitudinal" ? "vertical" : "horizontal"}
+              showHex
+              hexPosition={watchedMultiColorDirection === "longitudinal" ? "right" : "bottom"}
+              swatchWidth={watchedMultiColorDirection === "longitudinal" ? 66 : 74}
+              swatchHeight={watchedMultiColorDirection === "longitudinal" ? 24 : 74}
+            />
           </Form.Item>
         )}
         <Form.Item

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -26,6 +26,7 @@ export const FilamentShow = () => {
   const { data, isLoading } = query;
 
   const record = data?.data;
+  // Show the direction alongside the preview so identical color sets still read differently to the user.
   const multiColorLabel =
     record?.multi_color_hexes && record.multi_color_direction === "longitudinal"
       ? `${t("filament.fields.longitudinal")} ${t("filament.fields.multi_color")}`

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -5,15 +5,15 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useNavigate } from "react-router";
 import { ExtraFieldDisplay } from "../../components/extraFields";
+import ColorHexPreview from "../../components/colorHexPreview";
 import { NumberFieldUnit } from "../../components/numberField";
-import SpoolIcon from "../../components/spoolIcon";
 import { enrichText } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { useCurrencyFormatter } from "../../utils/settings";
 import { IFilament } from "./model";
 dayjs.extend(utc);
 
-const { Title } = Typography;
+const { Text, Title } = Typography;
 
 export const FilamentShow = () => {
   const t = useTranslate();
@@ -26,6 +26,12 @@ export const FilamentShow = () => {
   const { data, isLoading } = query;
 
   const record = data?.data;
+  const multiColorLabel =
+    record?.multi_color_hexes && record.multi_color_direction === "longitudinal"
+      ? `${t("filament.fields.longitudinal")} ${t("filament.fields.multi_color")}`
+      : record?.multi_color_hexes
+        ? `${t("filament.fields.coaxial")} ${t("filament.fields.multi_color")}`
+        : null;
 
   const formatTitle = (item: IFilament) => {
     let vendorPrefix = "";
@@ -48,13 +54,6 @@ export const FilamentShow = () => {
     const URL = `/spool#filters=[{"field":"filament.id","operator":"in","value":[${record?.id}]}]`;
     navigate(URL);
   };
-
-  const colorObj = record?.multi_color_hexes
-    ? {
-        colors: record.multi_color_hexes.split(","),
-        vertical: record.multi_color_direction === "longitudinal",
-      }
-    : record?.color_hex;
 
   return (
     <Show
@@ -87,8 +86,16 @@ export const FilamentShow = () => {
       <Title level={5}>{t("filament.fields.name")}</Title>
       <TextField value={record?.name} />
       <Title level={5}>{t("filament.fields.color_hex")}</Title>
-      {colorObj && <SpoolIcon color={colorObj} size="large" no_margin />}
-      {record?.color_hex && <TextField value={`#${record?.color_hex}`} />}
+      {multiColorLabel && (
+        <Text type="secondary" style={{ display: "block", marginTop: -10, marginBottom: 8 }}>
+          {multiColorLabel}
+        </Text>
+      )}
+      <ColorHexPreview
+        colorHex={record?.color_hex}
+        multiColorHexes={record?.multi_color_hexes}
+        multiColorDirection={record?.multi_color_direction}
+      />
       <Title level={5}>{t("filament.fields.material")}</Title>
       <TextField value={record?.material} />
       <Title level={5}>{t("filament.fields.price")}</Title>

--- a/client/src/pages/spools/show.tsx
+++ b/client/src/pages/spools/show.tsx
@@ -5,8 +5,8 @@ import { Button, Modal, Typography } from "antd";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { ExtraFieldDisplay } from "../../components/extraFields";
+import ColorHexPreview from "../../components/colorHexPreview";
 import { NumberFieldUnit } from "../../components/numberField";
-import SpoolIcon from "../../components/spoolIcon";
 import { enrichText } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { useCurrencyFormatter } from "../../utils/settings";
@@ -17,7 +17,7 @@ import { ISpool } from "./model";
 
 dayjs.extend(utc);
 
-const { Title } = Typography;
+const { Text, Title } = Typography;
 const { confirm } = Modal;
 
 export const SpoolShow = () => {
@@ -32,6 +32,12 @@ export const SpoolShow = () => {
   const { data, isLoading } = query;
 
   const record = data?.data;
+  const multiColorLabel =
+    record?.filament.multi_color_hexes && record.filament.multi_color_direction === "longitudinal"
+      ? `${t("filament.fields.longitudinal")} ${t("filament.fields.multi_color")}`
+      : record?.filament.multi_color_hexes
+        ? `${t("filament.fields.coaxial")} ${t("filament.fields.multi_color")}`
+        : null;
 
   const spoolPrice = (item?: ISpool) => {
     const price = item?.price ?? item?.filament.price;
@@ -104,13 +110,6 @@ export const SpoolShow = () => {
     });
   };
 
-  const colorObj = record?.filament.multi_color_hexes
-    ? {
-        colors: record.filament.multi_color_hexes.split(","),
-        vertical: record.filament.multi_color_direction === "longitudinal",
-      }
-    : record?.filament.color_hex;
-
   return (
     <Show
       isLoading={isLoading}
@@ -151,7 +150,16 @@ export const SpoolShow = () => {
       <Title level={5}>{t("spool.fields.id")}</Title>
       <NumberField value={record?.id ?? ""} />
       <Title level={5}>{t("spool.fields.filament")}</Title>
-      {colorObj && <SpoolIcon color={colorObj} size="large" no_margin />}
+      {multiColorLabel && (
+        <Text type="secondary" style={{ display: "block", marginTop: -10, marginBottom: 8 }}>
+          {multiColorLabel}
+        </Text>
+      )}
+      <ColorHexPreview
+        colorHex={record?.filament.color_hex}
+        multiColorHexes={record?.filament.multi_color_hexes}
+        multiColorDirection={record?.filament.multi_color_direction}
+      />
       <TextField value={record ? filamentURL(record?.filament) : ""} />
       <Title level={5}>{t("spool.fields.price")}</Title>
       <TextField value={spoolPrice(record)} />

--- a/client/src/pages/spools/show.tsx
+++ b/client/src/pages/spools/show.tsx
@@ -32,6 +32,7 @@ export const SpoolShow = () => {
   const { data, isLoading } = query;
 
   const record = data?.data;
+  // Mirror the filament show-page wording so spool detail pages preserve the same color-direction context.
   const multiColorLabel =
     record?.filament.multi_color_hexes && record.filament.multi_color_direction === "longitudinal"
       ? `${t("filament.fields.longitudinal")} ${t("filament.fields.multi_color")}`

--- a/client/src/utils/colorFormatting.ts
+++ b/client/src/utils/colorFormatting.ts
@@ -1,0 +1,14 @@
+/**
+ * Normalize hex color values to canonical #RRGGBB format (uppercase, with hash).
+ * Strips existing hash if present, then adds one back.
+ * @param value - Hex string with or without leading hash
+ * @returns Canonical color string: #RRGGBB uppercase
+ */
+/**
+ * Normalize hex color values to canonical format.
+ * Stored color values omit the hash, but every preview path in the UI should render
+ * canonical uppercase #RRGGBB string so chips and labels stay visually consistent.
+ */
+export function normalizeHex(value: string): string {
+  return `#${value.replace("#", "").toUpperCase()}`;
+}


### PR DESCRIPTION
## Summary
Improve filament and spool color previews, make multi-color hex values easier to read while editing, and carry forward the shared malformed-saved-state recovery that was dropped during restacking.

  <img src="https://github.com/user-attachments/assets/eadb08d5-d040-4ad8-be7e-a61d69e53a2e" width="10%">
  <img src="https://github.com/user-attachments/assets/e7b9f33a-db73-487c-b440-9f1b46d77e61" width="33%">
  <img src="https://github.com/user-attachments/assets/ffa6bb53-cb0a-4fa9-b35b-a2662641a06a" width="33%">

## What Changed
- Added a reusable `ColorHexPreview` so filament and spool show pages render color chips and canonical uppercase hex values the same way.
- Updated filament editing to show readable single-color hex text, per-swatch multi-color hex labels, and a longitudinal layout that matches the final preview.
- Carried forward the shared `useSavedState` guard in `client/src/utils/saveload.ts` so malformed `savedStates-*` entries fall back cleanly instead of crashing the page.

## Screenshots
# Filament edit: single-color + multi-color modes
  
<img width="244" height="531" alt="image" src="https://github.com/user-attachments/assets/40254b2a-cc4d-41cf-9bf9-dd18d2b817ef"/>
<img width="345" height="591" alt="image" src="https://github.com/user-attachments/assets/d6443648-09d4-467d-a785-0f2e46b7b256"/>
<img width="287" height="576" alt="image" src="https://github.com/user-attachments/assets/c73dbd35-95a8-4559-8165-8a97bac10be8"/>

# Filament show: color/hex preview
 
<img width="356" height="401" alt="image" src="https://github.com/user-attachments/assets/e8b292c4-2106-49eb-a31f-9ffff1821d29"/>
<img width="532" height="415" alt="image" src="https://github.com/user-attachments/assets/b92a07f6-18c7-4178-ab78-3fa8f6306407"/>
<img width="514" height="424" alt="image" src="https://github.com/user-attachments/assets/bf9a33f2-d901-4a66-b894-95b1b7d9b143"/>

# Spool show: color/hex preview
<img width="379" height="203" alt="image" src="https://github.com/user-attachments/assets/feab0af9-9a45-4dd8-9cf6-1466a6961921"/>
<img width="523" height="263" alt="image" src="https://github.com/user-attachments/assets/b86442bc-9250-4454-b60d-a354e720a84d"/>
<img width="526" height="286" alt="image" src="https://github.com/user-attachments/assets/b1800e6d-1ba7-455e-9370-308e353c64bc"/>

## Testing Performed
- `cd client && ./node_modules/.bin/eslint src/components/colorHexPreview.tsx src/components/multiColorPicker.tsx src/pages/filaments/edit.tsx src/pages/filaments/show.tsx src/pages/spools/show.tsx src/utils/colorFormatting.ts src/utils/saveload.ts`
- `client/node_modules/.bin/prettier --check client/src/components/colorHexPreview.tsx client/src/components/multiColorPicker.tsx client/src/pages/filaments/edit.tsx client/src/pages/filaments/show.tsx client/src/pages/spools/show.tsx client/src/utils/colorFormatting.ts client/src/utils/saveload.ts`
- `cd client && VITE_APIURL=/api/v1 npm run build`
- `PATH=.venv/bin:$PATH SPOOLMAN_DIR_DATA=/tmp/spoolman_pr_863_data uv run uvicorn spoolman.main:app --host 0.0.0.0 --port 9863`
- Playwright against `http://localhost:9863` with local seeded vendor/filament/spool data:
- Verified filament edit shows uppercase single-color hex text.
- Verified multi-color edit shows per-swatch hex labels.
- Verified longitudinal multi-color edit uses stacked rows with right-side hex labels.
- Verified edit-to-show flow persists the updated multi-color state.
- Verified filament show renders the shared longitudinal multi-color preview and labels.
- Verified spool show renders the same shared preview for the linked filament.
- Set `localStorage["savedStates-spoolList-showArchived"] = "{bad json"` and reloaded `/spool`; the page still rendered and the saved value recovered to `false`.

## Test Checklist
- [x] Single-color filament edit shows uppercase hex text under the swatch
- [x] Multi-color filament edit shows per-swatch hex labels
- [x] Longitudinal multi-color edit uses stacked rows with right-side hex labels
- [x] Edit-to-show flow persists the updated multi-color state
- [x] Filament show renders the shared color/hex preview for a longitudinal multi-color filament
- [x] Spool show renders the shared color/hex preview for the linked filament
- [x] Malformed persisted saved state on `/spool` no longer white-screens the page
