### PR TITLE
feat(filaments): add spool-count column with sort/filter support

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -217,6 +217,7 @@
         "filament": "Filaments",
         "fields": {
             "id": "ID",
+            "spool_count": "Spool Count",
             "vendor_name": "Manufacturer",
             "vendor": "Manufacturer",
             "name": "Name",

--- a/client/src/components/column.tsx
+++ b/client/src/components/column.tsx
@@ -188,6 +188,7 @@ export function RichColumn<Obj extends Entity>(
 interface FilteredQueryColumnProps<Obj extends Entity> extends BaseColumnProps<Obj> {
   filterValueQuery: UseQueryResult<string[] | ColumnFilterItem[], unknown>;
   allowMultipleFilters?: boolean;
+  includeEmptyOption?: boolean;
 }
 
 export function FilteredQueryColumn<Obj extends Entity>(props: FilteredQueryColumnProps<Obj>) {
@@ -205,10 +206,12 @@ export function FilteredQueryColumn<Obj extends Entity>(props: FilteredQueryColu
       return item;
     });
   }
-  filters.push({
-    text: "<empty>",
-    value: "<empty>",
-  });
+  if (props.includeEmptyOption ?? true) {
+    filters.push({
+      text: "<empty>",
+      value: "<empty>",
+    });
+  }
 
   const typedFilters = typeFilters<Obj>(props.tableState.filters);
   const filteredValue = getFiltersForField(typedFilters, props.dataId ?? (props.id as keyof Obj));

--- a/client/src/components/column.tsx
+++ b/client/src/components/column.tsx
@@ -60,6 +60,7 @@ interface FilteredColumnProps {
   filters?: ColumnFilterItem[];
   filteredValue?: string[];
   allowMultipleFilters?: boolean;
+  includeEmptyFilter?: boolean;
   onFilterDropdownOpen?: () => void;
   loadingFilters?: boolean;
 }

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -269,7 +269,7 @@ export const FilamentList = () => {
             ...commonProps,
             id: "spool_count",
             dataId: "spool_count",
-            title: "Spool Count",
+            title: t("filament.fields.spool_count"),
             filterValueQuery: querySpoolCounts,
             // Spool count is always a computed number, so an <empty> bucket would be
             // misleading noise rather than a real "missing value" state.

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -1,7 +1,9 @@
 import { EditOutlined, EyeOutlined, FileOutlined, FilterOutlined, PlusSquareOutlined } from "@ant-design/icons";
 import { List, useTable } from "@refinedev/antd";
 import { useInvalidate, useNavigation, useTranslate } from "@refinedev/core";
+import { useQuery } from "@tanstack/react-query";
 import { Button, Dropdown, Table } from "antd";
+import { ColumnFilterItem } from "antd/es/table/interface";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useMemo, useState } from "react";
@@ -27,6 +29,7 @@ import { removeUndefined } from "../../utils/filtering";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { TableState, useInitialTableState, useStoreInitialState } from "../../utils/saveload";
 import { useCurrencyFormatter } from "../../utils/settings";
+import { getAPIURL } from "../../utils/url";
 import { IFilament } from "./model";
 
 dayjs.extend(utc);
@@ -50,10 +53,19 @@ function translateColumnI18nKey(columnName: string): string {
   return `filament.fields.${columnName}`;
 }
 
+function getColumnLabel(t: (key: string, options?: unknown) => string, columnName: string): string {
+  if (columnName === "spool_count") {
+    return t("filament.fields.spool_count", { defaultValue: "Spool Count" });
+  }
+
+  return t(translateColumnI18nKey(columnName));
+}
+
 const namespace = "filamentList-v2";
 
 const allColumns: (keyof IFilamentCollapsed & string)[] = [
   "id",
+  "spool_count",
   "vendor.name",
   "name",
   "material",
@@ -72,12 +84,35 @@ const defaultColumns = allColumns.filter(
   (column_id) => ["registered", "density", "diameter", "spool_weight"].indexOf(column_id) === -1,
 );
 
+function useSpoolmanSpoolCounts(enabled: boolean = false) {
+  return useQuery<number[], unknown, ColumnFilterItem[]>({
+    enabled,
+    queryKey: ["filamentSpoolCounts"],
+    queryFn: async () => {
+      const response = await fetch(getAPIURL() + "/filament/spool-count");
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      return response.json();
+    },
+    select: (data) => {
+      return data
+        .sort((a, b) => a - b)
+        .map((count) => ({
+          text: String(count),
+          value: String(count),
+        }));
+    },
+  });
+}
+
 export const FilamentList = () => {
   const t = useTranslate();
   const invalidate = useInvalidate();
   const navigate = useNavigate();
   const extraFields = useGetFields(EntityType.filament);
   const currencyFormatter = useCurrencyFormatter();
+  const querySpoolCounts = useSpoolmanSpoolCounts(true);
 
   const allColumnsWithExtraFields = [...allColumns, ...(extraFields.data?.map((field) => "extra." + field.key) ?? [])];
 
@@ -194,7 +229,7 @@ export const FilamentList = () => {
 
                 return {
                   key: column_id,
-                  label: t(translateColumnI18nKey(column_id)),
+                  label: getColumnLabel(t, column_id),
                 };
               }),
               selectedKeys: showColumns,
@@ -229,6 +264,15 @@ export const FilamentList = () => {
             id: "id",
             i18ncat: "filament",
             width: 70,
+          }),
+          FilteredQueryColumn({
+            ...commonProps,
+            id: "spool_count",
+            dataId: "spool_count",
+            title: "Spool Count",
+            filterValueQuery: querySpoolCounts,
+            width: 120,
+            transform: (value) => value ?? 0,
           }),
           FilteredQueryColumn({
             ...commonProps,

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -271,6 +271,7 @@ export const FilamentList = () => {
             dataId: "spool_count",
             title: "Spool Count",
             filterValueQuery: querySpoolCounts,
+            includeEmptyOption: false,
             width: 120,
             transform: (value) => value ?? 0,
           }),

--- a/client/src/pages/filaments/list.tsx
+++ b/client/src/pages/filaments/list.tsx
@@ -271,6 +271,8 @@ export const FilamentList = () => {
             dataId: "spool_count",
             title: "Spool Count",
             filterValueQuery: querySpoolCounts,
+            // Spool count is always a computed number, so an <empty> bucket would be
+            // misleading noise rather than a real "missing value" state.
             includeEmptyOption: false,
             width: 120,
             transform: (value) => value ?? 0,

--- a/client/src/pages/filaments/model.tsx
+++ b/client/src/pages/filaments/model.tsx
@@ -11,6 +11,7 @@ export interface IFilament {
   diameter: number;
   weight?: number;
   spool_weight?: number;
+  spool_count?: number;
   article_number?: string;
   comment?: string;
   settings_extruder_temp?: number;

--- a/migrations/versions/2026_02_20_1605-b5f9c2e31a1b_add_index_on_spool_filament_id.py
+++ b/migrations/versions/2026_02_20_1605-b5f9c2e31a1b_add_index_on_spool_filament_id.py
@@ -1,0 +1,33 @@
+"""add index on spool.filament_id.
+
+Revision ID: b5f9c2e31a1b
+Revises: 415a8f855e14
+Create Date: 2026-02-20 16:05:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b5f9c2e31a1b"
+down_revision = "415a8f855e14"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Perform the upgrade."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    index_names = {index["name"] for index in inspector.get_indexes("spool")}
+    if "ix_spool_filament_id" not in index_names:
+        op.create_index("ix_spool_filament_id", "spool", ["filament_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Perform the downgrade."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    index_names = {index["name"] for index in inspector.get_indexes("spool")}
+    if "ix_spool_filament_id" in index_names:
+        op.drop_index("ix_spool_filament_id", table_name="spool")

--- a/migrations/versions/2026_02_20_1605-b5f9c2e31a1b_add_index_on_spool_filament_id.py
+++ b/migrations/versions/2026_02_20_1605-b5f9c2e31a1b_add_index_on_spool_filament_id.py
@@ -19,6 +19,8 @@ def upgrade() -> None:
     """Perform the upgrade."""
     conn = op.get_bind()
     inspector = sa.inspect(conn)
+    # Keep the migration idempotent so local PR containers can be rebuilt against the
+    # same SQLite file without failing on an index that already exists.
     index_names = {index["name"] for index in inspector.get_indexes("spool")}
     if "ix_spool_filament_id" not in index_names:
         op.create_index("ix_spool_filament_id", "spool", ["filament_id"], unique=False)

--- a/spoolman/api/v1/filament.py
+++ b/spoolman/api/v1/filament.py
@@ -304,6 +304,15 @@ async def find(
             examples=["polymaker_pla_polysonicblack_1000_175"],
         ),
     ] = None,
+    spool_count: Annotated[
+        str | None,
+        Query(
+            title="Spool Count",
+            description="Match filaments with an exact spool count. Separate multiple counts with a comma.",
+            pattern=r"^\d+(,\d+)*$",
+            examples=["0", "1,2,3"],
+        ),
+    ] = None,
     sort: Annotated[
         str | None,
         Query(
@@ -331,6 +340,10 @@ async def find(
         vendor_ids = [int(vendor_id_item) for vendor_id_item in vendor_id.split(",")]
     else:
         vendor_ids = None
+    if spool_count is not None:
+        spool_counts = [int(spool_count_item) for spool_count_item in spool_count.split(",")]
+    else:
+        spool_counts = None
 
     if color_hex is not None:
         matched_filaments = await filament.find_by_color(
@@ -354,6 +367,7 @@ async def find(
         sort_by=sort_by,
         limit=limit,
         offset=offset,
+        spool_count=spool_counts,
     )
 
     # Set x-total-count header for pagination
@@ -364,6 +378,19 @@ async def find(
         ),
         headers={"x-total-count": str(total_count)},
     )
+
+
+@router.get(
+    "/spool-count",
+    name="Find filament spool counts",
+    description="Get distinct spool-count values across filaments.",
+    response_model_exclude_none=True,
+)
+async def find_spool_counts(
+    *,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> list[int]:
+    return await filament.find_spool_counts(db=db)
 
 
 @router.websocket(

--- a/spoolman/api/v1/models.py
+++ b/spoolman/api/v1/models.py
@@ -134,6 +134,12 @@ class Filament(BaseModel):
         examples=[1000],
     )
     spool_weight: float | None = Field(None, ge=0, description="The empty spool weight, in grams.", examples=[140])
+    spool_count: int | None = Field(
+        None,
+        ge=0,
+        description="Number of spools associated with this filament.",
+        examples=[3],
+    )
     article_number: str | None = Field(
         None,
         max_length=64,
@@ -212,6 +218,7 @@ class Filament(BaseModel):
             diameter=item.diameter,
             weight=item.weight,
             spool_weight=item.spool_weight,
+            spool_count=getattr(item, "spool_count", None),
             article_number=item.article_number,
             comment=item.comment,
             settings_extruder_temp=item.settings_extruder_temp,

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -105,6 +105,7 @@ async def find(
     sort_by: dict[str, SortOrder] | None = None,
     limit: int | None = None,
     offset: int = 0,
+    spool_count: int | Sequence[int] | None = None,
 ) -> tuple[list[models.Filament], int]:
     """Find a list of filament objects by search criteria.
 
@@ -113,6 +114,13 @@ async def find(
 
     Returns a tuple containing the list of items and the total count of matching items.
     """
+    spool_count_expr = func.coalesce(
+        select(func.count(models.Spool.id))
+        .where(models.Spool.filament_id == models.Filament.id)
+        .scalar_subquery(),
+        0,
+    )
+
     stmt = (
         select(models.Filament)
         .options(contains_eager(models.Filament.vendor))
@@ -126,6 +134,10 @@ async def find(
     stmt = add_where_clause_str_opt(stmt, models.Filament.material, material)
     stmt = add_where_clause_str_opt(stmt, models.Filament.article_number, article_number)
     stmt = add_where_clause_str_opt(stmt, models.Filament.external_id, external_id)
+    if spool_count is not None:
+        if isinstance(spool_count, int):
+            spool_count = [spool_count]
+        stmt = stmt.where(spool_count_expr.in_(spool_count))
 
     total_count = None
 
@@ -134,6 +146,16 @@ async def find(
         total_count = (await db.execute(total_count_stmt)).scalar()
 
         stmt = stmt.offset(offset).limit(limit)
+
+    spool_count_sort_order = None
+    if sort_by is not None and "spool_count" in sort_by:
+        spool_count_sort_order = sort_by["spool_count"]
+        sort_by = {field: order for field, order in sort_by.items() if field != "spool_count"}
+
+    if spool_count_sort_order == SortOrder.ASC:
+        stmt = stmt.order_by(spool_count_expr.asc())
+    elif spool_count_sort_order == SortOrder.DESC:
+        stmt = stmt.order_by(spool_count_expr.desc())
 
     if sort_by is not None:
         for fieldstr, order in sort_by.items():
@@ -148,6 +170,19 @@ async def find(
         execution_options={"populate_existing": True},
     )
     result = list(rows.unique().scalars().all())
+
+    spool_count_map: dict[int, int] = {}
+    if result:
+        spool_count_stmt = (
+            select(models.Spool.filament_id, func.count(models.Spool.id))
+            .where(models.Spool.filament_id.in_([item.id for item in result]))
+            .group_by(models.Spool.filament_id)
+        )
+        spool_count_rows = await db.execute(spool_count_stmt)
+        spool_count_map = {int(filament_id): int(count) for filament_id, count in spool_count_rows.all()}
+    for item in result:
+        setattr(item, "spool_count", spool_count_map.get(item.id, 0))
+
     if total_count is None:
         total_count = len(result)
 
@@ -219,6 +254,27 @@ async def find_article_numbers(
     stmt = select(models.Filament.article_number).distinct()
     rows = await db.execute(stmt)
     return [row[0] for row in rows.all() if row[0] is not None]
+
+
+async def find_spool_counts(
+    *,
+    db: AsyncSession,
+) -> list[int]:
+    """Find distinct spool counts per filament."""
+    spool_counts_stmt = select(func.count(models.Spool.id)).group_by(models.Spool.filament_id)
+    spool_count_rows = await db.execute(spool_counts_stmt)
+    spool_counts = {int(row[0]) for row in spool_count_rows.all()}
+
+    filament_without_spool_exists_stmt = (
+        select(models.Filament.id)
+        .where(~select(models.Spool.id).where(models.Spool.filament_id == models.Filament.id).exists())
+        .limit(1)
+    )
+    filament_without_spool_exists = (await db.execute(filament_without_spool_exists_stmt)).scalar() is not None
+    if filament_without_spool_exists:
+        spool_counts.add(0)
+
+    return sorted(spool_counts)
 
 
 async def find_by_color(

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -43,7 +43,7 @@ async def set_spool_counts(
     spool_count_map = {int(filament_id): int(count) for filament_id, count in spool_count_rows.all()}
 
     for item in filaments:
-        setattr(item, "spool_count", spool_count_map.get(item.id, 0))
+        item.spool_count = spool_count_map.get(item.id, 0)
 
 
 async def create(
@@ -115,7 +115,7 @@ async def get_by_id(db: AsyncSession, filament_id: int) -> models.Filament:
     return filament
 
 
-async def find(
+async def find(  # noqa: C901
     *,
     db: AsyncSession,
     ids: list[int] | None = None,
@@ -138,9 +138,7 @@ async def find(
     Returns a tuple containing the list of items and the total count of matching items.
     """
     spool_count_expr = func.coalesce(
-        select(func.count(models.Spool.id))
-        .where(models.Spool.filament_id == models.Filament.id)
-        .scalar_subquery(),
+        select(func.count(models.Spool.id)).where(models.Spool.filament_id == models.Filament.id).scalar_subquery(),
         0,
     )
     # Reuse the same scalar count expression for filtering and sorting so the list can

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -25,6 +25,27 @@ from spoolman.math import delta_e, hex_to_rgb, rgb_to_lab
 from spoolman.ws import websocket_manager
 
 
+async def set_spool_counts(
+    db: AsyncSession,
+    filaments: Sequence[models.Filament],
+) -> None:
+    """Populate spool_count on filament models."""
+    if not filaments:
+        return
+
+    filament_ids = [item.id for item in filaments]
+    spool_count_stmt = (
+        select(models.Spool.filament_id, func.count(models.Spool.id))
+        .where(models.Spool.filament_id.in_(filament_ids))
+        .group_by(models.Spool.filament_id)
+    )
+    spool_count_rows = await db.execute(spool_count_stmt)
+    spool_count_map = {int(filament_id): int(count) for filament_id, count in spool_count_rows.all()}
+
+    for item in filaments:
+        setattr(item, "spool_count", spool_count_map.get(item.id, 0))
+
+
 async def create(
     *,
     db: AsyncSession,
@@ -76,6 +97,7 @@ async def create(
     )
     db.add(filament)
     await db.commit()
+    await set_spool_counts(db, [filament])
     await filament_changed(filament, EventType.ADDED)
     return filament
 
@@ -89,6 +111,7 @@ async def get_by_id(db: AsyncSession, filament_id: int) -> models.Filament:
     )
     if filament is None:
         raise ItemNotFoundError(f"No filament with ID {filament_id} found.")
+    await set_spool_counts(db, [filament])
     return filament
 
 
@@ -172,18 +195,7 @@ async def find(
         execution_options={"populate_existing": True},
     )
     result = list(rows.unique().scalars().all())
-
-    spool_count_map: dict[int, int] = {}
-    if result:
-        spool_count_stmt = (
-            select(models.Spool.filament_id, func.count(models.Spool.id))
-            .where(models.Spool.filament_id.in_([item.id for item in result]))
-            .group_by(models.Spool.filament_id)
-        )
-        spool_count_rows = await db.execute(spool_count_stmt)
-        spool_count_map = {int(filament_id): int(count) for filament_id, count in spool_count_rows.all()}
-    for item in result:
-        setattr(item, "spool_count", spool_count_map.get(item.id, 0))
+    await set_spool_counts(db, result)
 
     if total_count is None:
         total_count = len(result)
@@ -212,6 +224,7 @@ async def update(
         else:
             setattr(filament, k, v)
     await db.commit()
+    await set_spool_counts(db, [filament])
     await filament_changed(filament, EventType.UPDATED)
     return filament
 
@@ -263,19 +276,14 @@ async def find_spool_counts(
     db: AsyncSession,
 ) -> list[int]:
     """Find distinct spool counts per filament."""
-    spool_counts_stmt = select(func.count(models.Spool.id)).group_by(models.Spool.filament_id)
+    spool_counts_stmt = (
+        select(func.count(models.Spool.id))
+        .select_from(models.Filament)
+        .join(models.Spool, models.Spool.filament_id == models.Filament.id, isouter=True)
+        .group_by(models.Filament.id)
+    )
     spool_count_rows = await db.execute(spool_counts_stmt)
     spool_counts = {int(row[0]) for row in spool_count_rows.all()}
-
-    filament_without_spool_exists_stmt = (
-        select(models.Filament.id)
-        .where(~select(models.Spool.id).where(models.Spool.filament_id == models.Filament.id).exists())
-        .limit(1)
-    )
-    filament_without_spool_exists = (await db.execute(filament_without_spool_exists_stmt)).scalar() is not None
-    if filament_without_spool_exists:
-        spool_counts.add(0)
-
     return sorted(spool_counts)
 
 

--- a/spoolman/database/filament.py
+++ b/spoolman/database/filament.py
@@ -120,6 +120,8 @@ async def find(
         .scalar_subquery(),
         0,
     )
+    # Reuse the same scalar count expression for filtering and sorting so the list can
+    # stay server-driven without materializing every filament first.
 
     stmt = (
         select(models.Filament)

--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -33,6 +33,13 @@ def utc_timezone_naive(dt: datetime) -> datetime:
     return dt.astimezone(tz=timezone.utc).replace(tzinfo=None)
 
 
+async def notify_filament_count_changed(db: AsyncSession, filament_ids: set[int]) -> None:
+    """Send updated filament events for spool-count changes."""
+    for filament_id in filament_ids:
+        filament_item = await filament.get_by_id(db, filament_id)
+        await filament.filament_changed(filament_item, EventType.UPDATED)
+
+
 async def create(
     *,
     db: AsyncSession,
@@ -96,6 +103,7 @@ async def create(
     db.add(spool)
     await db.commit()
     await spool_changed(spool, EventType.ADDED)
+    await notify_filament_count_changed(db, {spool.filament_id})
     return spool
 
 
@@ -216,6 +224,7 @@ async def update(
 ) -> models.Spool:
     """Update the fields of a spool object."""
     spool = await get_by_id(db, spool_id)
+    previous_filament_id = spool.filament_id
     for k, v in data.items():
         if k == "filament_id":
             spool.filament = await filament.get_by_id(db, v)
@@ -236,14 +245,19 @@ async def update(
             setattr(spool, k, v)
     await db.commit()
     await spool_changed(spool, EventType.UPDATED)
+    if spool.filament_id != previous_filament_id:
+        await notify_filament_count_changed(db, {previous_filament_id, spool.filament_id})
     return spool
 
 
 async def delete(db: AsyncSession, spool_id: int) -> None:
     """Delete a spool object."""
     spool = await get_by_id(db, spool_id)
-    await spool_changed(spool, EventType.DELETED)
+    filament_id = spool.filament_id
     await db.delete(spool)
+    await db.flush()
+    await spool_changed(spool, EventType.DELETED)
+    await notify_filament_count_changed(db, {filament_id})
 
 
 async def clear_extra_field(db: AsyncSession, key: str) -> None:

--- a/tests_integration/tests/filament/test_find.py
+++ b/tests_integration/tests/filament/test_find.py
@@ -15,6 +15,24 @@ class Fixture:
     filaments: list[dict[str, Any]]
 
 
+def add_spool(filament_id: int) -> dict[str, Any]:
+    """Create a spool for a filament."""
+    result = httpx.post(
+        f"{URL}/api/v1/spool",
+        json={
+            "filament_id": filament_id,
+            "used_weight": 0,
+        },
+    )
+    result.raise_for_status()
+    return result.json()
+
+
+def delete_spool(spool: dict[str, Any]) -> None:
+    """Delete a spool created by a test."""
+    httpx.delete(f"{URL}/api/v1/spool/{spool['id']}").raise_for_status()
+
+
 @pytest.fixture(scope="module")
 def filaments(random_vendor_mod: dict[str, Any], random_empty_vendor_mod: dict[str, Any]) -> Iterable[Fixture]:
     """Add some filaments to the database."""
@@ -139,6 +157,71 @@ def test_find_all_filaments_sort_desc(filaments: Fixture):
     filaments_result = result.json()
     assert len(filaments_result) == len(filaments.filaments)
     assert filaments_result[-1] == filaments.filaments[0]
+
+
+def test_find_filaments_by_spool_count(filaments: Fixture):
+    spools = [
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[1]["id"]),
+    ]
+
+    try:
+        result = httpx.get(f"{URL}/api/v1/filament", params={"spool_count": "0", "sort": "id:asc"})
+        result.raise_for_status()
+
+        filaments_result = result.json()
+        assert [item["id"] for item in filaments_result] == [
+            filaments.filaments[2]["id"],
+            filaments.filaments[3]["id"],
+            filaments.filaments[4]["id"],
+        ]
+        assert [item["spool_count"] for item in filaments_result] == [0, 0, 0]
+    finally:
+        for spool in spools:
+            delete_spool(spool)
+
+
+def test_find_filaments_sort_by_spool_count(filaments: Fixture):
+    spools = [
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[1]["id"]),
+    ]
+
+    try:
+        result = httpx.get(f"{URL}/api/v1/filament?sort=spool_count:desc,id:asc")
+        result.raise_for_status()
+
+        filaments_result = result.json()
+        assert [item["id"] for item in filaments_result] == [
+            filaments.filaments[0]["id"],
+            filaments.filaments[1]["id"],
+            filaments.filaments[2]["id"],
+            filaments.filaments[3]["id"],
+            filaments.filaments[4]["id"],
+        ]
+        assert [item["spool_count"] for item in filaments_result] == [2, 1, 0, 0, 0]
+    finally:
+        for spool in spools:
+            delete_spool(spool)
+
+
+def test_find_distinct_spool_counts(filaments: Fixture):
+    spools = [
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[0]["id"]),
+        add_spool(filaments.filaments[1]["id"]),
+    ]
+
+    try:
+        result = httpx.get(f"{URL}/api/v1/filament/spool-count")
+        result.raise_for_status()
+
+        assert result.json() == [0, 1, 2]
+    finally:
+        for spool in spools:
+            delete_spool(spool)
 
 
 def test_find_all_filaments_sort_multiple(filaments: Fixture):

--- a/tests_integration/tests/filament/test_get.py
+++ b/tests_integration/tests/filament/test_get.py
@@ -89,3 +89,25 @@ def test_get_filament_not_found():
     assert "filament" in message
     assert "id" in message
     assert "123456789" in message
+
+
+def test_get_filament_spool_count(random_filament: dict[str, Any]):
+    """Test that spool_count is returned for a filament."""
+    spool_result = httpx.post(
+        f"{URL}/api/v1/spool",
+        json={
+            "filament_id": random_filament["id"],
+            "used_weight": 0,
+        },
+    )
+    spool_result.raise_for_status()
+    spool = spool_result.json()
+
+    try:
+        result = httpx.get(f"{URL}/api/v1/filament/{random_filament['id']}")
+        result.raise_for_status()
+
+        filament = result.json()
+        assert filament["spool_count"] == 1
+    finally:
+        httpx.delete(f"{URL}/api/v1/spool/{spool['id']}").raise_for_status()


### PR DESCRIPTION
## Summary
This PR hardens filament `spool_count` support so the filaments list can use it as a reliable inventory signal instead of a one-off display field.

## Why
The useful part of `spool_count` is not just rendering a number. It needs to stay coherent across list queries, numeric filter semantics, spool relationship changes, and adjacent PRs that touch the same query plumbing.

## Hardening In This PR
### Backend
- Filament list queries treat `spool_count` as a first-class sortable and filterable field.
- Filament payload hydration now keeps `spool_count` populated on list, get, and update paths instead of leaving event payloads to drift to `null` or an implied `0`.
- Distinct spool-count lookup stays numeric, including `0`, without needing empty-string semantics.
- Spool relationship changes that affect counts are wired to refresh the related filament event path.
- The `spool.filament_id` index migration remains in scope to keep count lookups responsive.

### Frontend
- The filament list exposes `spool_count` as a sortable, filterable numeric column.
- The filter path treats `0` as the real empty-state count rather than surfacing the generic `""` option.
- The column display still normalizes missing values to `0` for safety, but the backend hydration path is now intended to keep that fallback from masking stale data.

## Screenshots
### Filament list with new `Spool Count` column visible. UI enabled to Hide/Show `Spool Count` column.
<img width="629" height="340" alt="image" src="https://github.com/user-attachments/assets/ac5187d4-402e-44a1-a486-2bded343f7af" />

### Sort by `Spool Count` (asc/desc).
<img width="292" height="242" alt="image" src="https://github.com/user-attachments/assets/d568a059-9430-43a2-8c0b-124f0dac13bd" />

### Filter dropdown for `Spool Count` values (without `"<empty>"`)
<img width="179" height="228" alt="image" src="https://github.com/user-attachments/assets/131e6732-e0b8-46ba-bebc-232b29cefcd0" />

## Testing Status
Targeted integration coverage was added for:
- filament get returning `spool_count`
- filament find filtering by `spool_count=0`
- filament find sorting by `spool_count`
- distinct values from `GET /api/v1/filament/spool-count`

## Testing TODO
- [ ] Run the new filament integration slice covering `spool_count` get/find/filter/sort/distinct-value cases.
- [ ] Run the frontend build.
- [ ] Manually smoke-test the filament list column, numeric filter values, and clear-filters path.

## Scope Boundary
This PR stays limited to spool-count correctness, query behavior, and integration hardening for the filament list path.
Manufacturer-level count columns and other list-query UX work remain out of scope.

## Issues
- Fixes #201
- Fixes #207
- Fixes #539
- Fixes #688
- Fixes #742

## Merge Notes
This branch still shares nearby query-plumbing touchpoints with adjacent filament-list PRs such as `#858` and `#862`, so rebase/conflict cleanup may still be needed depending on merge order.