### PR TITLE
UI: responsive show-page header wrapping

### DIFF
--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -59,14 +59,20 @@ export const FilamentShow = () => {
   return (
     <Show
       isLoading={isLoading}
-      title={record ? formatTitle(record) : ""}
+      title={
+        record ? (
+          <span style={{ whiteSpace: "normal", overflowWrap: "anywhere", lineHeight: 1.2 }}>{formatTitle(record)}</span>
+        ) : (
+          ""
+        )
+      }
       headerButtons={({ defaultButtons }) => (
-        <>
+        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", gap: 8 }}>
           <Button type="primary" onClick={gotoSpools}>
             {t("filament.fields.spools")}
           </Button>
           {defaultButtons}
-        </>
+        </div>
       )}
     >
       <Title level={5}>{t("filament.fields.id")}</Title>

--- a/client/src/pages/spools/show.tsx
+++ b/client/src/pages/spools/show.tsx
@@ -114,9 +114,15 @@ export const SpoolShow = () => {
   return (
     <Show
       isLoading={isLoading}
-      title={record ? formatTitle(record) : ""}
+      title={
+        record ? (
+          <span style={{ whiteSpace: "normal", overflowWrap: "anywhere", lineHeight: 1.2 }}>{formatTitle(record)}</span>
+        ) : (
+          ""
+        )
+      }
       headerButtons={({ defaultButtons }) => (
-        <>
+        <div style={{ display: "flex", flexWrap: "wrap", justifyContent: "flex-end", gap: 8 }}>
           <Button type="primary" icon={<ToolOutlined />} onClick={() => record && openSpoolAdjustModal(record)}>
             {t("spool.titles.adjust")}
           </Button>
@@ -145,7 +151,7 @@ export const SpoolShow = () => {
 
           {defaultButtons}
           {spoolAdjustModal}
-        </>
+        </div>
       )}
     >
       <Title level={5}>{t("spool.fields.id")}</Title>

--- a/client/src/pages/vendors/show.tsx
+++ b/client/src/pages/vendors/show.tsx
@@ -28,7 +28,16 @@ export const VendorShow = () => {
   };
 
   return (
-    <Show isLoading={isLoading} title={record ? formatTitle(record) : ""}>
+    <Show
+      isLoading={isLoading}
+      title={
+        record ? (
+          <span style={{ whiteSpace: "normal", overflowWrap: "anywhere", lineHeight: 1.2 }}>{formatTitle(record)}</span>
+        ) : (
+          ""
+        )
+      }
+    >
       <Title level={5}>{t("vendor.fields.id")}</Title>
       <NumberField value={record?.id ?? ""} />
       <Title level={5}>{t("vendor.fields.registered")}</Title>


### PR DESCRIPTION
## Summary
- keep long show-page titles readable instead of letting them collide with the header action area
- let filament and spool show-page actions wrap cleanly when horizontal space is tight

## What Changed
- render wrapped title nodes in the filament, spool, and manufacturer show pages
- wrap the custom filament and spool header action groups so multi-button layouts stay usable at narrower widths
- keep the PR scoped to the three affected show pages only

## Visual Impact
- Word wrap working for long titles
<img width="1760" height="168" alt="image" src="https://github.com/user-attachments/assets/3650c45b-5ee7-4ad4-a002-44898d64ad21" />

- Compared to existing issue where the title could be blocked by buttons
<img width="1496" height="208" alt="image" src="https://github.com/user-attachments/assets/249c6171-10c3-4b30-804c-d37f6cee7c31" />

## Testing Performed
- `cd client && ./node_modules/.bin/eslint src/pages/filaments/show.tsx src/pages/spools/show.tsx src/pages/vendors/show.tsx`
- `./client/node_modules/.bin/prettier --check client/src/pages/filaments/show.tsx client/src/pages/spools/show.tsx client/src/pages/vendors/show.tsx`
- `cd client && VITE_APIURL=/api/v1 npm run build`
- restarted the local backend with `SPOOLMAN_DIR_DATA=/tmp/spoolman_pr_868_data` on `http://localhost:9868`
- Playwright validation on `http://localhost:9868` using fresh local data created for this pass:
  - created a manufacturer with a long wrapped name
  - created a filament with a very long unbroken name
  - created a spool using that filament to exercise the busiest action-row layout
  - verified `vendor/show/1` title wrapping at desktop (`1406px`) and mobile (`375px`)
  - verified `filament/show/1` title wrapping at desktop (`1406px`) and mobile (`375px`)
  - verified `spool/show/1` title readability at desktop (`1406px`) and button wrapping/usability at mobile (`375px`)

## Test Checklist
- [x] Vendor show-page title wraps at desktop width
- [x] Vendor show-page title wraps at `375px`
- [x] Filament show-page title wraps at desktop width
- [x] Filament show-page title wraps at `375px`
- [x] Spool show-page title remains readable with the full action set at desktop width
- [x] Spool show-page action buttons wrap at `375px`
- [x] ESLint run on touched frontend files
- [x] Prettier check run on touched frontend files
- [x] Frontend production build run with `VITE_APIURL=/api/v1`
- [ ] Locale-specific long translated strings
- [ ] Full keyboard-only traversal of every show-page header action
