### PR TITLE
feat(printing/ui): Spool Print selection page UX Improvement

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -127,12 +127,17 @@
         },
         "spoolSelect": {
             "title": "Select Spools",
-            "description": "Select spools to print labels for.",
+            "description": "Search for and select spool labels to print:",
+            "searchPlaceholder": "Search by spool ID, filament, material, location, or lot number",
             "showArchived": "Show Archived",
             "noSpoolsSelected": "You have not selected any spools.",
             "selectAll": "Select/Unselect All",
             "selectedTotal_one": "{{count}} spool selected",
             "selectedTotal_other": "{{count}} spools selected"
+        },
+        "filamentSelect": {
+            "description": "Search for and select filament labels to print:",
+            "searchPlaceholder": "Search by filament ID, vendor, name, material, or color"
         }
     },
     "scanner": {

--- a/client/src/pages/printing/index.tsx
+++ b/client/src/pages/printing/index.tsx
@@ -51,11 +51,11 @@ export const Printing = () => {
             <SpoolSelectModal
               description={t("printing.spoolSelect.description")}
               searchPlaceholder={t("printing.spoolSelect.searchPlaceholder")}
-              onContinue={(spools) => {
+              onPrint={(selectedIds) => {
                 setSearchParams((prev) => {
                   const newParams = new URLSearchParams(prev);
                   newParams.delete("spools");
-                  spools.forEach((spool) => newParams.append("spools", spool.id.toString()));
+                  selectedIds.forEach((id) => newParams.append("spools", id.toString()));
                   newParams.set("return", "/spool/print");
                   return newParams;
                 });

--- a/client/src/pages/printing/index.tsx
+++ b/client/src/pages/printing/index.tsx
@@ -56,6 +56,8 @@ export const Printing = () => {
                   const newParams = new URLSearchParams(prev);
                   newParams.delete("spools");
                   selectedIds.forEach((id) => newParams.append("spools", id.toString()));
+                  // Keep the selector route as the explicit return target so back/cancel
+                  // returns to the selection step instead of the originating show page.
                   newParams.set("return", "/spool/print");
                   return newParams;
                 });

--- a/client/src/pages/printing/index.tsx
+++ b/client/src/pages/printing/index.tsx
@@ -50,6 +50,7 @@ export const Printing = () => {
           {step === 0 && (
             <SpoolSelectModal
               description={t("printing.spoolSelect.description")}
+              searchPlaceholder={t("printing.spoolSelect.searchPlaceholder")}
               onContinue={(spools) => {
                 setSearchParams((prev) => {
                   const newParams = new URLSearchParams(prev);

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -271,9 +271,7 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
               onChange={(event) => {
                 const value = event.target.value;
                 setSearchValue(value);
-                if (value === "") {
-                  applySearchFilter("");
-                }
+                applySearchFilter(value);
               }}
               onSearch={(value) => {
                 setSearchValue(value);

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -1,17 +1,23 @@
 import { RightOutlined } from "@ant-design/icons";
 import { useTable } from "@refinedev/antd";
-import { Button, Checkbox, Col, message, Row, Space, Table } from "antd";
+import { Button, Checkbox, Col, Input, message, Pagination, Row, Space, Table } from "antd";
 import { t } from "i18next";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { FilteredQueryColumn, SortedColumn, SpoolIconColumn } from "../../components/column";
-import { useSpoolmanFilamentFilter, useSpoolmanMaterials } from "../../components/otherModels";
+import {
+  useSpoolmanFilamentFilter,
+  useSpoolmanLocations,
+  useSpoolmanLotNumbers,
+  useSpoolmanMaterials,
+} from "../../components/otherModels";
 import { removeUndefined } from "../../utils/filtering";
 import { TableState } from "../../utils/saveload";
 import { ISpool } from "../spools/model";
 
 interface Props {
   description?: string;
+  searchPlaceholder?: string;
   onContinue: (selectedSpools: ISpool[]) => void;
 }
 
@@ -36,73 +42,172 @@ function collapseSpool(element: ISpool): ISpoolCollapsed {
   };
 }
 
-const SpoolSelectModal = ({ description, onContinue }: Props) => {
+function matchesSearch(spool: ISpoolCollapsed, searchTerm: string): boolean {
+  const needle = searchTerm.trim().toLowerCase();
+  if (needle.length === 0) {
+    return true;
+  }
+
+  const haystacks = [
+    String(spool.id),
+    spool["filament.combined_name"] ?? "",
+    spool["filament.material"] ?? "",
+    spool.location ?? "",
+    spool.lot_nr ?? "",
+  ];
+
+  return haystacks.some((value) => value.toLowerCase().includes(needle));
+}
+
+const SpoolSelectModal = ({ description, searchPlaceholder, onContinue }: Props) => {
+  const MIN_TABLE_SCROLL_Y = 180;
+  const TABLE_BOTTOM_GAP = 16;
   const [selectedItems, setSelectedItems] = useState<number[]>([]);
   const [showArchived, setShowArchived] = useState(false);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
+  const [searchValue, setSearchValue] = useState("");
+  const [serverSearchValue, setServerSearchValue] = useState("");
+  const [selectedArchivedMap, setSelectedArchivedMap] = useState<Record<number, boolean>>({});
+  const [tableScrollY, setTableScrollY] = useState<number>(300);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const tableContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const { tableProps, sorters, filters, currentPage, pageSize } = useTable<ISpoolCollapsed>({
-    resource: "spool",
-    meta: {
-      queryParams: {
-        ["allow_archived"]: showArchived,
+  const { tableProps, sorters, filters, setFilters, currentPage, pageSize, setCurrentPage, setPageSize } =
+    useTable<ISpoolCollapsed>({
+      resource: "spool",
+      meta: {
+        queryParams: {
+          ["allow_archived"]: showArchived,
+          ...(serverSearchValue.trim().length > 0 ? { search: serverSearchValue.trim() } : {}),
+        },
       },
-    },
-    syncWithLocation: false,
-    pagination: {
-      mode: "off",
-      currentPage: 1,
-      pageSize: 10,
-    },
-    sorters: {
-      mode: "server",
-    },
-    filters: {
-      mode: "server",
-    },
-    queryOptions: {
-      select(data) {
-        return {
-          total: data.total,
-          data: data.data.map(collapseSpool),
-        };
+      syncWithLocation: false,
+      pagination: {
+        mode: "server",
+        currentPage: 1,
+        pageSize: 50,
       },
-    },
-  });
+      sorters: {
+        mode: "server",
+      },
+      filters: {
+        mode: "server",
+      },
+      queryOptions: {
+        select(data) {
+          return {
+            total: data.total,
+            data: data.data.map(collapseSpool),
+          };
+        },
+      },
+    });
 
-  // Store state in local storage
   const tableState: TableState = {
     sorters,
     filters,
     pagination: { currentPage: currentPage, pageSize },
   };
 
-  // Collapse the dataSource to a mutable list and add a filament_name field
   const dataSource: ISpoolCollapsed[] = useMemo(
     () => (tableProps.dataSource || []).map((record) => ({ ...record })),
     [tableProps.dataSource],
   );
+  const visibleDataSource = useMemo(
+    () => dataSource.filter((spool) => matchesSearch(spool, searchValue)),
+    [dataSource, searchValue],
+  );
+  const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
 
-  // Function to add/remove all filtered items from selected items
+  useEffect(() => {
+    if (dataSource.length === 0) {
+      return;
+    }
+    setSelectedArchivedMap((prev) => {
+      const next = { ...prev };
+      dataSource.forEach((spool) => {
+        next[spool.id] = spool.archived === true;
+      });
+      return next;
+    });
+  }, [dataSource]);
+
+  useEffect(() => {
+    const computeScrollHeight = () => {
+      if (!tableContainerRef.current) {
+        return;
+      }
+      const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
+      const tableTop = tableContainerRef.current.getBoundingClientRect().top;
+      const availableHeight = Math.floor(viewportHeight - tableTop - TABLE_BOTTOM_GAP);
+      setTableScrollY(Math.max(MIN_TABLE_SCROLL_Y, availableHeight));
+    };
+
+    computeScrollHeight();
+
+    const onViewportResize = () => computeScrollHeight();
+    window.addEventListener("resize", onViewportResize);
+    window.addEventListener("orientationchange", onViewportResize);
+    window.visualViewport?.addEventListener("resize", onViewportResize);
+    window.visualViewport?.addEventListener("scroll", onViewportResize);
+
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined" ? new ResizeObserver(() => computeScrollHeight()) : undefined;
+    if (resizeObserver && rootRef.current) {
+      resizeObserver.observe(rootRef.current);
+    }
+
+    return () => {
+      window.removeEventListener("resize", onViewportResize);
+      window.removeEventListener("orientationchange", onViewportResize);
+      window.visualViewport?.removeEventListener("resize", onViewportResize);
+      window.visualViewport?.removeEventListener("scroll", onViewportResize);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  const paginationTotal = tableProps.pagination ? tableProps.pagination.total ?? 0 : 0;
+  const handlePageChange = (page: number, nextPageSize?: number) => {
+    if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
+      setPageSize(nextPageSize);
+    }
+    setCurrentPage(page);
+  };
+  const handlePageSizeChange = (_current: number, size: number) => {
+    setPageSize(size);
+    setCurrentPage(1);
+  };
+
+  const applySearchFilter = (nextSearch: string) => {
+    setServerSearchValue(nextSearch.trim());
+    setCurrentPage(1);
+  };
+
   const selectUnselectFiltered = (select: boolean) => {
     setSelectedItems((prevSelected) => {
-      const filtered = dataSource.map((spool) => spool.id).filter((spool) => !prevSelected.includes(spool));
-      return select ? [...prevSelected, ...filtered] : filtered;
+      const nextSelected = new Set(prevSelected);
+      visibleDataSource.forEach((spool) => {
+        if (select) {
+          nextSelected.add(spool.id);
+        } else {
+          nextSelected.delete(spool.id);
+        }
+      });
+      return Array.from(nextSelected);
     });
   };
 
-  // Handler for selecting/unselecting individual items
   const handleSelectItem = (item: number) => {
     setSelectedItems((prevSelected) =>
       prevSelected.includes(item) ? prevSelected.filter((selected) => selected !== item) : [...prevSelected, item],
     );
   };
 
-  // State for the select/unselect all checkbox
-  const isAllFilteredSelected = dataSource.every((spool) => selectedItems.includes(spool.id));
+  const isAllFilteredSelected =
+    visibleDataSource.length > 0 && visibleDataSource.every((spool) => selectedSet.has(spool.id));
   const isSomeButNotAllFilteredSelected =
-    dataSource.some((spool) => selectedItems.includes(spool.id)) && !isAllFilteredSelected;
+    visibleDataSource.some((spool) => selectedSet.has(spool.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -114,106 +219,195 @@ const SpoolSelectModal = ({ description, onContinue }: Props) => {
     tableState,
     sorter: true,
   };
+  const resolvedDescription =
+    description ??
+    t("printing.spoolSelect.description", {
+      defaultValue: "Search for and select spool labels to print:",
+    });
+  const resolvedSearchPlaceholder =
+    searchPlaceholder ??
+    t("printing.spoolSelect.searchPlaceholder", {
+      defaultValue: "Search by spool ID, filament, material, location, or lot number",
+    });
 
   return (
     <>
       {contextHolder}
-      <Space direction="vertical" style={{ width: "100%" }}>
-        {description && <div>{description}</div>}
-        <Table
-          {...tableProps}
-          rowKey="id"
-          tableLayout="auto"
-          dataSource={dataSource}
-          pagination={false}
-          scroll={{ y: 200 }}
-          columns={removeUndefined([
-            {
-              width: 50,
-              render: (_, item: ISpool) => (
-                <Checkbox checked={selectedItems.includes(item.id)} onChange={() => handleSelectItem(item.id)} />
-              ),
-            },
-            SortedColumn({
-              ...commonProps,
-              id: "id",
-              i18ncat: "spool",
-              width: 80,
-            }),
-            SpoolIconColumn({
-              ...commonProps,
-              id: "filament.combined_name",
-              dataId: "filament.combined_name",
-              i18nkey: "spool.fields.filament_name",
-              color: (record: ISpoolCollapsed) => record.filament.color_hex,
-              filterValueQuery: useSpoolmanFilamentFilter(),
-            }),
-            FilteredQueryColumn({
-              ...commonProps,
-              id: "filament.material",
-              i18nkey: "spool.fields.material",
-              filterValueQuery: useSpoolmanMaterials(),
-            }),
-          ])}
-        />
-        <Row gutter={[10, 10]}>
-          <Col span={12}>
-            <Checkbox
-              checked={isAllFilteredSelected}
-              indeterminate={isSomeButNotAllFilteredSelected}
-              onChange={(e) => {
-                selectUnselectFiltered(e.target.checked);
-              }}
-            >
-              {t("printing.spoolSelect.selectAll")}
-            </Checkbox>
-          </Col>
-          <Col span={12}>
-            <div style={{ float: "right" }}>
-              {t("printing.spoolSelect.selectedTotal", {
-                count: selectedItems.length,
-              })}
-            </div>
-          </Col>
-          <Col span={12}>
-            <Checkbox
-              checked={showArchived}
-              onChange={(e) => {
-                setShowArchived(e.target.checked);
-                if (!e.target.checked) {
-                  // Remove archived spools from selected items
-                  setSelectedItems((prevSelected) =>
-                    prevSelected.filter(
-                      (selected) => dataSource.find((spool) => spool.id === selected)?.archived !== true,
-                    ),
-                  );
+      <div ref={rootRef} style={{ width: "100%", display: "flex", flexDirection: "column", height: "100%" }}>
+        {(resolvedDescription || tableProps.pagination) && (
+          <Row gutter={[12, 8]} align="middle" style={{ marginBottom: 8 }}>
+            <Col flex="auto">{resolvedDescription && <div style={{ margin: 0 }}>{resolvedDescription}</div>}</Col>
+            {tableProps.pagination && (
+              <Col flex="none">
+                <Pagination
+                  size="small"
+                  current={currentPage}
+                  pageSize={pageSize}
+                  total={paginationTotal}
+                  showSizeChanger
+                  pageSizeOptions={["25", "50", "100", "200"]}
+                  showQuickJumper
+                  onChange={handlePageChange}
+                  onShowSizeChange={handlePageSizeChange}
+                />
+              </Col>
+            )}
+          </Row>
+        )}
+        <Row gutter={[12, 8]} style={{ marginBottom: 8 }}>
+          <Col xs={24} md={12}>
+            <Input.Search
+              placeholder={resolvedSearchPlaceholder}
+              value={searchValue}
+              allowClear
+              enterButton
+              onChange={(event) => {
+                const value = event.target.value;
+                setSearchValue(value);
+                if (value === "") {
+                  applySearchFilter("");
                 }
               }}
-            >
-              {t("printing.spoolSelect.showArchived")}
-            </Checkbox>
-          </Col>
-          <Col span={24}>
-            <Button
-              type="primary"
-              icon={<RightOutlined />}
-              iconPosition="end"
-              onClick={() => {
-                if (selectedItems.length === 0) {
-                  messageApi.open({
-                    type: "error",
-                    content: t("printing.spoolSelect.noSpoolsSelected"),
-                  });
-                  return;
-                }
-                onContinue(dataSource.filter((spool) => selectedItems.includes(spool.id)));
+              onSearch={(value) => {
+                setSearchValue(value);
+                applySearchFilter(value);
               }}
-            >
-              {t("buttons.continue")}
-            </Button>
+            />
           </Col>
         </Row>
-      </Space>
+        <Row gutter={[12, 12]} align="middle" style={{ marginBottom: 8 }}>
+          <Col flex="none">
+            <Button
+              onClick={() => {
+                setSearchValue("");
+                setServerSearchValue("");
+                setFilters([], "replace");
+                setCurrentPage(1);
+              }}
+            >
+              {t("buttons.clearFilters")}
+            </Button>
+          </Col>
+          <Col flex="auto">
+            <div
+              style={{
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "center",
+                gap: 12,
+                flexWrap: "wrap",
+              }}
+            >
+              <Checkbox
+                checked={isAllFilteredSelected}
+                indeterminate={isSomeButNotAllFilteredSelected}
+                onChange={(e) => {
+                  selectUnselectFiltered(e.target.checked);
+                }}
+              >
+                {t("printing.spoolSelect.selectAll")}
+              </Checkbox>
+              <Checkbox
+                checked={showArchived}
+                onChange={(e) => {
+                  setShowArchived(e.target.checked);
+                  if (!e.target.checked) {
+                    setSelectedItems((prevSelected) =>
+                      prevSelected.filter((selected) => selectedArchivedMap[selected] !== true),
+                    );
+                  }
+                }}
+              >
+                {t("printing.spoolSelect.showArchived")}
+              </Checkbox>
+              <div style={{ minWidth: 140, textAlign: "right" }}>
+                {t("printing.spoolSelect.selectedTotal", {
+                  count: selectedItems.length,
+                })}
+              </div>
+              <Space>
+                <Button
+                  type="primary"
+                  icon={<RightOutlined />}
+                  iconPosition="end"
+                  onClick={() => {
+                    if (selectedItems.length === 0) {
+                      messageApi.open({
+                        type: "error",
+                        content: t("printing.spoolSelect.noSpoolsSelected"),
+                      });
+                      return;
+                    }
+                    onContinue(selectedItems.map((id) => ({ id }) as ISpool));
+                  }}
+                >
+                  {t("buttons.continue")}
+                </Button>
+              </Space>
+            </div>
+          </Col>
+        </Row>
+        <div ref={tableContainerRef} style={{ flex: 1, minHeight: 0 }}>
+          <Table
+            {...tableProps}
+            rowKey="id"
+            tableLayout="fixed"
+            pagination={false}
+            dataSource={visibleDataSource}
+            scroll={{ y: tableScrollY, x: "max-content" }}
+            columns={removeUndefined([
+              {
+                width: 48,
+                render: (_, item: ISpool) => (
+                  <Checkbox checked={selectedSet.has(item.id)} onChange={() => handleSelectItem(item.id)} />
+                ),
+              },
+              SortedColumn({
+                ...commonProps,
+                id: "id",
+                i18ncat: "spool",
+                width: 70,
+              }),
+              SpoolIconColumn({
+                ...commonProps,
+                id: "filament.combined_name",
+                dataId: "filament.combined_name",
+                i18nkey: "spool.fields.filament_name",
+                width: 360,
+                color: (record: ISpoolCollapsed) =>
+                  record.filament.multi_color_hexes
+                    ? {
+                        colors: record.filament.multi_color_hexes.split(","),
+                        vertical: record.filament.multi_color_direction === "longitudinal",
+                      }
+                    : record.filament.color_hex,
+                filterValueQuery: useSpoolmanFilamentFilter(),
+              }),
+              FilteredQueryColumn({
+                ...commonProps,
+                id: "filament.material",
+                i18nkey: "spool.fields.material",
+                filterValueQuery: useSpoolmanMaterials(),
+                width: 140,
+              }),
+              FilteredQueryColumn({
+                ...commonProps,
+                id: "location",
+                i18ncat: "spool",
+                filterValueQuery: useSpoolmanLocations(),
+                width: 160,
+              }),
+              FilteredQueryColumn({
+                ...commonProps,
+                id: "lot_nr",
+                i18ncat: "spool",
+                filterValueQuery: useSpoolmanLotNumbers(),
+                width: 160,
+              }),
+            ])}
+          />
+        </div>
+      </div>
     </>
   );
 };

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -1,4 +1,3 @@
-import { RightOutlined } from "@ant-design/icons";
 import { useTable } from "@refinedev/antd";
 import { Button, Checkbox, Col, Input, message, Pagination, Row, Space, Table } from "antd";
 import { t } from "i18next";
@@ -17,8 +16,10 @@ import { ISpool } from "../spools/model";
 
 interface Props {
   description?: string;
+  initialSelectedIds?: number[];
+  onExport?: (selectedIds: number[]) => void;
+  onPrint?: (selectedIds: number[]) => void;
   searchPlaceholder?: string;
-  onContinue: (selectedSpools: ISpool[]) => void;
 }
 
 interface ISpoolCollapsed extends ISpool {
@@ -59,10 +60,10 @@ function matchesSearch(spool: ISpoolCollapsed, searchTerm: string): boolean {
   return haystacks.some((value) => value.toLowerCase().includes(needle));
 }
 
-const SpoolSelectModal = ({ description, searchPlaceholder, onContinue }: Props) => {
+const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, searchPlaceholder }: Props) => {
   const MIN_TABLE_SCROLL_Y = 180;
   const TABLE_BOTTOM_GAP = 16;
-  const [selectedItems, setSelectedItems] = useState<number[]>([]);
+  const [selectedItems, setSelectedItems] = useState<number[]>(initialSelectedIds ?? []);
   const [showArchived, setShowArchived] = useState(false);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
@@ -326,23 +327,40 @@ const SpoolSelectModal = ({ description, searchPlaceholder, onContinue }: Props)
                 })}
               </div>
               <Space>
-                <Button
-                  type="primary"
-                  icon={<RightOutlined />}
-                  iconPosition="end"
-                  onClick={() => {
-                    if (selectedItems.length === 0) {
-                      messageApi.open({
-                        type: "error",
-                        content: t("printing.spoolSelect.noSpoolsSelected"),
-                      });
-                      return;
-                    }
-                    onContinue(selectedItems.map((id) => ({ id }) as ISpool));
-                  }}
-                >
-                  {t("buttons.continue")}
-                </Button>
+                {onPrint && (
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      if (selectedItems.length === 0) {
+                        messageApi.open({
+                          type: "error",
+                          content: t("printing.spoolSelect.noSpoolsSelected"),
+                        });
+                        return;
+                      }
+                      onPrint(selectedItems);
+                    }}
+                  >
+                    {t("printing.qrcode.button")}
+                  </Button>
+                )}
+                {onExport && (
+                  <Button
+                    type="primary"
+                    onClick={() => {
+                      if (selectedItems.length === 0) {
+                        messageApi.open({
+                          type: "error",
+                          content: t("printing.spoolSelect.noSpoolsSelected"),
+                        });
+                        return;
+                      }
+                      onExport(selectedItems);
+                    }}
+                  >
+                    {t("printing.qrcode.exportButton")}
+                  </Button>
+                )}
               </Space>
             </div>
           </Col>

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -246,7 +246,7 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
                   pageSize={pageSize}
                   total={paginationTotal}
                   showSizeChanger
-                  pageSizeOptions={["25", "50", "100", "200"]}
+                  pageSizeOptions={["10", "20", "50", "100"]}
                   showQuickJumper
                   onChange={handlePageChange}
                   onShowSizeChange={handlePageSizeChange}

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -115,6 +115,8 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
     () => (tableProps.dataSource || []).map((record) => ({ ...record })),
     [tableProps.dataSource],
   );
+  // Keep the UI responsive even without backend search support by letting the text box
+  // instantly narrow whatever page of rows is already loaded.
   const visibleDataSource = useMemo(
     () => dataSource.filter((spool) => matchesSearch(spool, searchValue)),
     [dataSource, searchValue],
@@ -181,11 +183,15 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
   };
 
   const applySearchFilter = (nextSearch: string) => {
+    // The server-side search hook is optional; on plain master this still resets paging
+    // while the local narrowed view continues to work on the current page.
     setServerSearchValue(nextSearch.trim());
     setCurrentPage(1);
   };
 
   const selectUnselectFiltered = (select: boolean) => {
+    // Bulk selection intentionally follows the visible narrowed rows so "Select All"
+    // acts on what the user can currently see, not on hidden rows on other pages.
     setSelectedItems((prevSelected) => {
       const nextSelected = new Set(prevSelected);
       visibleDataSource.forEach((spool) => {

--- a/client/src/pages/printing/spoolSelectModal.tsx
+++ b/client/src/pages/printing/spoolSelectModal.tsx
@@ -1,7 +1,7 @@
 import { useTable } from "@refinedev/antd";
 import { Button, Checkbox, Col, Input, message, Pagination, Row, Space, Table } from "antd";
 import { t } from "i18next";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router";
 import { FilteredQueryColumn, SortedColumn, SpoolIconColumn } from "../../components/column";
 import {
@@ -43,23 +43,6 @@ function collapseSpool(element: ISpool): ISpoolCollapsed {
   };
 }
 
-function matchesSearch(spool: ISpoolCollapsed, searchTerm: string): boolean {
-  const needle = searchTerm.trim().toLowerCase();
-  if (needle.length === 0) {
-    return true;
-  }
-
-  const haystacks = [
-    String(spool.id),
-    spool["filament.combined_name"] ?? "",
-    spool["filament.material"] ?? "",
-    spool.location ?? "",
-    spool.lot_nr ?? "",
-  ];
-
-  return haystacks.some((value) => value.toLowerCase().includes(needle));
-}
-
 const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, searchPlaceholder }: Props) => {
   const MIN_TABLE_SCROLL_Y = 180;
   const TABLE_BOTTOM_GAP = 16;
@@ -67,8 +50,8 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
   const [showArchived, setShowArchived] = useState(false);
   const [messageApi, contextHolder] = message.useMessage();
   const navigate = useNavigate();
-  const [searchValue, setSearchValue] = useState("");
-  const [serverSearchValue, setServerSearchValue] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [selectedArchivedMap, setSelectedArchivedMap] = useState<Record<number, boolean>>({});
   const [tableScrollY, setTableScrollY] = useState<number>(300);
   const rootRef = useRef<HTMLDivElement | null>(null);
@@ -80,7 +63,7 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
       meta: {
         queryParams: {
           ["allow_archived"]: showArchived,
-          ...(serverSearchValue.trim().length > 0 ? { search: serverSearchValue.trim() } : {}),
+          ...(debouncedSearch.length > 0 ? { search: debouncedSearch } : {}),
         },
       },
       syncWithLocation: false,
@@ -114,12 +97,6 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
   const dataSource: ISpoolCollapsed[] = useMemo(
     () => (tableProps.dataSource || []).map((record) => ({ ...record })),
     [tableProps.dataSource],
-  );
-  // Keep the UI responsive even without backend search support by letting the text box
-  // instantly narrow whatever page of rows is already loaded.
-  const visibleDataSource = useMemo(
-    () => dataSource.filter((spool) => matchesSearch(spool, searchValue)),
-    [dataSource, searchValue],
   );
   const selectedSet = useMemo(() => new Set(selectedItems), [selectedItems]);
 
@@ -170,51 +147,59 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
     };
   }, []);
 
-  const paginationTotal = tableProps.pagination ? tableProps.pagination.total ?? 0 : 0;
-  const handlePageChange = (page: number, nextPageSize?: number) => {
-    if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
-      setPageSize(nextPageSize);
-    }
-    setCurrentPage(page);
-  };
-  const handlePageSizeChange = (_current: number, size: number) => {
-    setPageSize(size);
-    setCurrentPage(1);
-  };
+  // Debounce search input to avoid excessive API calls while typing
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedSearch(searchTerm.trim());
+      setCurrentPage(1);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchTerm, setCurrentPage]);
 
-  const applySearchFilter = (nextSearch: string) => {
-    // The server-side search hook is optional; on plain master this still resets paging
-    // while the local narrowed view continues to work on the current page.
-    setServerSearchValue(nextSearch.trim());
-    setCurrentPage(1);
-  };
+  const paginationTotal = tableProps.pagination ? (tableProps.pagination.total ?? 0) : 0;
+  const handlePageChange = useCallback(
+    (page: number, nextPageSize?: number) => {
+      if (typeof nextPageSize === "number" && nextPageSize !== pageSize) {
+        setPageSize(nextPageSize);
+      }
+      setCurrentPage(page);
+    },
+    [pageSize, setPageSize, setCurrentPage],
+  );
+  const handlePageSizeChange = useCallback(
+    (_current: number, size: number) => {
+      setPageSize(size);
+      setCurrentPage(1);
+    },
+    [setPageSize, setCurrentPage],
+  );
 
-  const selectUnselectFiltered = (select: boolean) => {
-    // Bulk selection intentionally follows the visible narrowed rows so "Select All"
-    // acts on what the user can currently see, not on hidden rows on other pages.
-    setSelectedItems((prevSelected) => {
-      const nextSelected = new Set(prevSelected);
-      visibleDataSource.forEach((spool) => {
-        if (select) {
-          nextSelected.add(spool.id);
-        } else {
-          nextSelected.delete(spool.id);
-        }
+  const selectUnselectFiltered = useCallback(
+    (select: boolean) => {
+      setSelectedItems((prevSelected) => {
+        const nextSelected = new Set(prevSelected);
+        dataSource.forEach((spool) => {
+          if (select) {
+            nextSelected.add(spool.id);
+          } else {
+            nextSelected.delete(spool.id);
+          }
+        });
+        return Array.from(nextSelected);
       });
-      return Array.from(nextSelected);
-    });
-  };
+    },
+    [dataSource],
+  );
 
-  const handleSelectItem = (item: number) => {
+  const handleSelectItem = useCallback((item: number) => {
     setSelectedItems((prevSelected) =>
       prevSelected.includes(item) ? prevSelected.filter((selected) => selected !== item) : [...prevSelected, item],
     );
-  };
+  }, []);
 
-  const isAllFilteredSelected =
-    visibleDataSource.length > 0 && visibleDataSource.every((spool) => selectedSet.has(spool.id));
+  const isAllFilteredSelected = dataSource.length > 0 && dataSource.every((spool) => selectedSet.has(spool.id));
   const isSomeButNotAllFilteredSelected =
-    visibleDataSource.some((spool) => selectedSet.has(spool.id)) && !isAllFilteredSelected;
+    dataSource.some((spool) => selectedSet.has(spool.id)) && !isAllFilteredSelected;
 
   const commonProps = {
     t,
@@ -265,17 +250,14 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
           <Col xs={24} md={12}>
             <Input.Search
               placeholder={resolvedSearchPlaceholder}
-              value={searchValue}
+              value={searchTerm}
               allowClear
               enterButton
               onChange={(event) => {
-                const value = event.target.value;
-                setSearchValue(value);
-                applySearchFilter(value);
+                setSearchTerm(event.target.value);
               }}
               onSearch={(value) => {
-                setSearchValue(value);
-                applySearchFilter(value);
+                setSearchTerm(value);
               }}
             />
           </Col>
@@ -284,8 +266,8 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
           <Col flex="none">
             <Button
               onClick={() => {
-                setSearchValue("");
-                setServerSearchValue("");
+                setSearchTerm("");
+                setDebouncedSearch("");
                 setFilters([], "replace");
                 setCurrentPage(1);
               }}
@@ -375,7 +357,7 @@ const SpoolSelectModal = ({ description, initialSelectedIds, onExport, onPrint, 
             rowKey="id"
             tableLayout="fixed"
             pagination={false}
-            dataSource={visibleDataSource}
+            dataSource={dataSource}
             scroll={{ y: tableScrollY, x: "max-content" }}
             columns={removeUndefined([
               {

--- a/spoolman/api/v1/spool.py
+++ b/spoolman/api/v1/spool.py
@@ -128,6 +128,17 @@ class SpoolMeasureParameters(BaseModel):
 async def find(
     *,
     db: Annotated[AsyncSession, Depends(get_db_session)],
+    search: Annotated[
+        str | None,
+        Query(
+            title="Search",
+            description=(
+                "Partial case-insensitive search term applied across spool ID, filament vendor name, filament name, "
+                "material, location, and lot number. Separate multiple terms with a comma. Surround a term with "
+                "quotes to search for the exact term."
+            ),
+        ),
+    ] = None,
     filament_name_old: Annotated[
         str | None,
         Query(alias="filament_name", title="Filament Name", description="See filament.name.", deprecated=True),
@@ -287,6 +298,7 @@ async def find(
 
     db_items, total_count = await spool.find(
         db=db,
+        search=search,
         filament_name=filament_name if filament_name is not None else filament_name_old,
         filament_id=filament_ids,
         filament_material=filament_material if filament_material is not None else filament_material_old,

--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -111,7 +111,7 @@ async def get_by_id(db: AsyncSession, spool_id: int) -> models.Spool:
     return spool
 
 
-async def find(  # noqa: C901, PLR0912
+async def find(  # noqa: C901, PLR0912, PLR0915
     *,
     db: AsyncSession,
     search: str | None = None,

--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -114,6 +114,7 @@ async def get_by_id(db: AsyncSession, spool_id: int) -> models.Spool:
 async def find(  # noqa: C901, PLR0912
     *,
     db: AsyncSession,
+    search: str | None = None,
     filament_name: str | None = None,
     filament_id: int | Sequence[int] | None = None,
     filament_material: str | None = None,
@@ -147,6 +148,40 @@ async def find(  # noqa: C901, PLR0912
     stmt = add_where_clause_str_opt(stmt, models.Filament.material, filament_material)
     stmt = add_where_clause_str_opt(stmt, models.Spool.location, location)
     stmt = add_where_clause_str_opt(stmt, models.Spool.lot_nr, lot_nr)
+    if search is not None:
+        search_conditions = []
+        for value_part in search.split(","):
+            if len(value_part) == 0:
+                continue
+
+            if value_part[0] == '"' and value_part[-1] == '"':
+                exact_value = value_part[1:-1]
+                search_conditions.extend(
+                    [
+                        models.Vendor.name == exact_value,
+                        models.Filament.name == exact_value,
+                        models.Filament.material == exact_value,
+                        models.Spool.location == exact_value,
+                        models.Spool.lot_nr == exact_value,
+                    ],
+                )
+                if exact_value.lstrip("-").isdigit():
+                    search_conditions.append(models.Spool.id == int(exact_value))
+            else:
+                fuzzy_value = f"%{value_part}%"
+                search_conditions.extend(
+                    [
+                        models.Vendor.name.ilike(fuzzy_value),
+                        models.Filament.name.ilike(fuzzy_value),
+                        models.Filament.material.ilike(fuzzy_value),
+                        models.Spool.location.ilike(fuzzy_value),
+                        models.Spool.lot_nr.ilike(fuzzy_value),
+                        sqlalchemy.cast(models.Spool.id, sqlalchemy.String).ilike(fuzzy_value),
+                    ],
+                )
+
+        if search_conditions:
+            stmt = stmt.where(sqlalchemy.or_(*search_conditions))
 
     if not allow_archived:
         # Since the archived field is nullable, and default is false, we need to check for both false or null


### PR DESCRIPTION
## Summary
Improves the spool pre-print selection step for larger datasets while keeping PR869 independent from the filament-printing stack.

## What Changed
- Added debounced full-dataset spool search via the existing spool `?search=` API.
- Kept the selection table viewport-filling with visible server pagination controls.
- Kept bulk selection scoped to the currently visible rows.
- Added `Location` and `Lot Nr` columns and preserved multi-color filament preview handling.
- Carried forward shared saved-state hardening so malformed `savedStates-*` and malformed spool table hash/localStorage state recover instead of crashing.
- Removed unrelated filament-selector locale spillover from this PR.

## Screenshots
New Selection Page Layout:
<img width="1104" height="665" alt="image" src="https://github.com/user-attachments/assets/278268b0-2198-472e-bbd0-e0ea389438a7"/>

Simple Text Search Field:
<img width="1099" height="385" alt="image" src="https://github.com/user-attachments/assets/040f7612-21cb-4c12-8f82-5362d021e810"/>

## Testing Performed
- `cd client && ./node_modules/.bin/eslint src/pages/printing/spoolSelectModal.tsx src/utils/saveload.ts src/pages/printing/index.tsx`
- `uv run ruff check spoolman/api/v1/spool.py spoolman/database/spool.py`
- `/bin/bash -lc "cd /Users/dfinch/Code/Spoolman_Labels/worktrees/pr869/client && npm ci && VITE_APIURL=/api/v1 npm run build"`
- `PATH=.venv/bin:$PATH SPOOLMAN_DIR_DATA=/tmp/spoolman_pr_869_data uv run uvicorn spoolman.main:app --host 0.0.0.0 --port 9869`
- Playwright on `http://localhost:9869`:
  - `/spool/print`: visible pagination rendered, page 2 navigation worked, and the first row on page 2 was spool `52`
  - `/spool/print`: searching `Rack Alpha` narrowed visible results to `30` and `Select/Unselect All` updated the counter to `30 spools selected`
  - `/spool/print`: enabling archived rows and searching `LOT-12` surfaced archived spool `12`
  - `/spool/print`: table scroll height adjusted from `332px` at a `620px` viewport to `612px` at a `900px` viewport
  - `/spool/print?spools=1&return=%2Fspool%2Fprint`: selected spool `1` advanced into the print dialog
  - Malformed persisted state recovery:
    - bad `savedStates-selectedPreset` and `savedStates-print-previewScale` no longer crash the print dialog
    - bad `spool-*` localStorage values and bad `#sorters/#filters/#pagination` hash state no longer crash `/spool`

## Test Checklist
- [x] Search narrows the full spool dataset via the backend `?search=` parameter
- [x] Bulk select only affects the currently visible rows
- [x] Pagination controls render and page navigation works
- [x] Table height responds to viewport size
- [x] `Location` and `Lot Nr` columns render in the selector
- [x] Print flow advances from selector to dialog with selected spool IDs
- [x] Malformed saved state recovers without crashing
- [ ] Multi-color preview was visually inspected in the browser
- [ ] No console errors on nested routes

## Notes
- Direct nested-route loads still log an existing service-worker registration 404 for `/spool/sw.js`. That showed up during validation but is outside this PR's diff.
