### PR TITLE
fix(ui): theme dark-mode scrollbars globally

### DIFF
--- a/client/src/contexts/color-mode/index.tsx
+++ b/client/src/contexts/color-mode/index.tsx
@@ -28,22 +28,31 @@ export const ColorModeContextProvider = ({ children }: PropsWithChildren) => {
   };
 
   const { darkAlgorithm, defaultAlgorithm } = theme;
+  // Apply the scrollbar theme globally in dark mode because many scroll containers come from
+  // nested Ant components/popup portals, so local component-level overrides miss large parts of
+  // the UI. The light theme keeps native scrollbars unchanged.
   const darkScrollbarCss = `
-    body, body * {
+    html, body, body * {
       scrollbar-width: thin;
       scrollbar-color: rgba(255, 255, 255, 0.22) rgba(255, 255, 255, 0.06);
     }
 
+    html::-webkit-scrollbar,
+    body::-webkit-scrollbar,
     body *::-webkit-scrollbar {
       width: 10px;
       height: 10px;
     }
 
+    html::-webkit-scrollbar-track,
+    body::-webkit-scrollbar-track,
     body *::-webkit-scrollbar-track {
       background: rgba(255, 255, 255, 0.06);
       border-radius: 999px;
     }
 
+    html::-webkit-scrollbar-thumb,
+    body::-webkit-scrollbar-thumb,
     body *::-webkit-scrollbar-thumb {
       background: rgba(255, 255, 255, 0.22);
       border-radius: 999px;
@@ -51,6 +60,8 @@ export const ColorModeContextProvider = ({ children }: PropsWithChildren) => {
       background-clip: padding-box;
     }
 
+    html::-webkit-scrollbar-thumb:hover,
+    body::-webkit-scrollbar-thumb:hover,
     body *::-webkit-scrollbar-thumb:hover {
       background: rgba(255, 255, 255, 0.3);
       background-clip: padding-box;

--- a/client/src/contexts/color-mode/index.tsx
+++ b/client/src/contexts/color-mode/index.tsx
@@ -28,6 +28,34 @@ export const ColorModeContextProvider = ({ children }: PropsWithChildren) => {
   };
 
   const { darkAlgorithm, defaultAlgorithm } = theme;
+  const darkScrollbarCss = `
+    body, body * {
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255, 255, 255, 0.22) rgba(255, 255, 255, 0.06);
+    }
+
+    body *::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+    }
+
+    body *::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 999px;
+    }
+
+    body *::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.22);
+      border-radius: 999px;
+      border: 2px solid rgba(0, 0, 0, 0);
+      background-clip: padding-box;
+    }
+
+    body *::-webkit-scrollbar-thumb:hover {
+      background: rgba(255, 255, 255, 0.3);
+      background-clip: padding-box;
+    }
+  `;
 
   return (
     <ColorModeContext.Provider
@@ -36,6 +64,7 @@ export const ColorModeContextProvider = ({ children }: PropsWithChildren) => {
         mode,
       }}
     >
+      {mode === "dark" && <style>{darkScrollbarCss}</style>}
       <ConfigProvider
         // you can change the theme colors here. example: ...RefineThemes.Magenta,
         theme={{


### PR DESCRIPTION
## Summary
Applies the dark scrollbar theme to the page scrollbar as well as nested scroll areas in dark mode.

## What Changed
- Extended the global dark-mode scrollbar selectors in the color mode context to cover `html` and `body`.
- Kept light mode on native scrollbar styling by only injecting the custom rules in dark mode.

## Testing Performed
- `./node_modules/.bin/eslint src/contexts/color-mode/index.tsx`
- `VITE_APIURL=/api/v1 npm run build`
- Playwright check on `http://127.0.0.1:9875`: toggled dark mode on the home page and verified page-level and nested scrollbar styling is applied
- Playwright check on `http://127.0.0.1:9875`: toggled back to light mode and verified the custom scrollbar styling is removed

## Test Checklist
- [x] Dark mode applies themed scrollbars to page-level and nested scroll areas
- [x] Light mode restores native scrollbar styling
