### PR TITLE
docs: add MCP server to integrations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Spoolman is a self-hosted web service designed to help you efficiently manage yo
   * [OctoPrint](https://github.com/mdziekon/octoprint-spoolman)
   * [OctoEverywhere](https://octoeverywhere.com/spoolman?source=github_spoolman)
   * [Home Assistant](https://github.com/Disane87/spoolman-homeassistant)
+  * [MCP Server](https://github.com/Disane87/spoolman-mcp) - Manage your filament inventory through AI assistants like Claude using the Model Context Protocol
 
 **Web client preview:**
 ![image](https://github.com/Donkie/Spoolman/assets/2332094/33928d5e-440f-4445-aca9-456c4370ad0d)


### PR DESCRIPTION
## What's this about?

Hey! I built an MCP (Model Context Protocol) server for Spoolman that lets you manage your entire filament inventory through AI assistants like Claude, things like adding spools, tracking usage, looking up filaments, exporting data, and more. All through natural language instead of clicking through the UI.

It covers pretty much everything the API offers: vendors, filaments, spools, settings, custom fields, lookups, exports, and system stuff like health checks and backups.

I thought it'd be nice to have it listed alongside the other integrations in the README so people can find it more easily.

**The change:** Added [spoolman-mcp](https://github.com/Disane87/spoolman-mcp) to the "Spoolman integrates with" section.

(I'm also the author of the [Home Assistant integration](https://github.com/Disane87/spoolman-homeassistant) that's already listed there.)