### PR TITLE
fix(dev): add opt-in loopback cache reset for local review

### DIFF
--- a/client/README.MD
+++ b/client/README.MD
@@ -1,3 +1,7 @@
 # Spoolman UI
 
 A simple [refine](https://github.com/refinedev/refine) based UI for manipulating the data in the Spoolman database.
+
+## Local Review Cache Reset
+
+Set `VITE_BYPASS_LOOPBACK_PWA_CACHE=true` when you want loopback URLs such as `localhost`, `127.0.0.1`, or `::1` to clear existing service workers and browser caches before the app boots. This is intended for local review and debugging when stale PWA assets are masking the current frontend bundle.

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -5,6 +5,32 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./i18n";
 
+const shouldBypassLoopbackPwaCache = import.meta.env["VITE_BYPASS_LOOPBACK_PWA_CACHE"] === "true";
+const normalizedHostname = window.location.hostname.replace(/^\[|\]$/g, "");
+const isLoopbackHost =
+  normalizedHostname === "localhost" ||
+  normalizedHostname === "::1" ||
+  /^127(?:\.\d{1,3}){3}$/.test(normalizedHostname);
+
+if (shouldBypassLoopbackPwaCache && isLoopbackHost) {
+  // Opt-in local review builds can clear loopback-host PWA state before boot so stale assets
+  // from earlier test runs do not mask the current bundle.
+  if ("serviceWorker" in navigator) {
+    void navigator.serviceWorker.getRegistrations().then((registrations) => {
+      registrations.forEach((registration) => {
+        void registration.unregister();
+      });
+    });
+  }
+  if ("caches" in window) {
+    void caches.keys().then((keys) => {
+      keys.forEach((key) => {
+        void caches.delete(key);
+      });
+    });
+  }
+}
+
 const container = document.getElementById("root") as HTMLElement;
 const root = createRoot(container);
 


### PR DESCRIPTION
## Summary
This PR adds an opt-in way to clear stale frontend service workers and caches on loopback hosts during local review.

## Background
Spoolman already supports PWA behavior via `vite-plugin-pwa`, introduced in upstream PR #762. That is useful background for why stale local frontend assets can happen, but this PR does not depend on #762 as part of a stack.

## Problem
Today, you can open the app locally, refresh the page, and still be looking at an older frontend bundle because the browser is serving assets from an existing service worker or cache.

That makes local review and debugging unreliable. You can think you are testing the current branch when the browser is still showing UI from an earlier run.

This PR fixes that by adding an opt-in local-review flag: `VITE_BYPASS_LOOPBACK_PWA_CACHE=true`. When that flag is enabled, loopback hosts such as `localhost`, IPv4 `127.x.x.x`, and IPv6 `::1` clear existing service workers and Cache Storage before the app boots. If the flag is not enabled, behavior stays exactly as it is today.

## Why This Shape
The stale-cache problem is real, but automatically clearing caches for every localhost-style user would be too broad.

This PR keeps the workaround available for development and review while avoiding behavior changes for normal localhost users unless they explicitly opt in.

## How To Use It
Build or run the frontend with:
- `VITE_BYPASS_LOOPBACK_PWA_CACHE=true`

When that flag is enabled on a loopback host, the app clears service workers and Cache Storage before boot.

## Implementation
- read `VITE_BYPASS_LOOPBACK_PWA_CACHE` from `import.meta.env`
- normalize the browser hostname before evaluation
- treat `localhost`, `::1`, and `127.x.x.x` addresses as loopback hosts
- clear service workers and Cache Storage only when both conditions are true:
  - the opt-in flag is enabled
  - the current hostname is a loopback host

## Alternatives Considered
1. Do nothing
This leaves local review vulnerable to stale frontend assets.

2. Document a manual workaround only
This helps contributors, but it does not make the behavior predictable or easy to reproduce consistently.

3. Always clear caches on localhost-style hosts
This fixes the stale-cache problem, but it changes behavior for all localhost users, not just reviewers and developers.

4. Disable PWA behavior in dev entirely
This may be a valid future direction, but it is a broader behavioral decision. This PR is narrower and keeps existing dev PWA capability available.

## Validation
Commands:
- `./node_modules/.bin/eslint src/index.tsx`
- `./node_modules/.bin/prettier --check src/index.tsx README.MD`
- `VITE_APIURL=/api/v1 VITE_BYPASS_LOOPBACK_PWA_CACHE=true npm run build`

## Test Checklist
- [x] Loopback cache reset is opt-in via `VITE_BYPASS_LOOPBACK_PWA_CACHE=true`
- [x] IPv4 and IPv6 loopback hosts are both covered when the flag is enabled
- [x] Non-loopback app bootstrap remains unchanged
- [x] File-scoped ESLint passes for `client/src/index.tsx`
- [x] Prettier check passes for `client/src/index.tsx` and `client/README.MD`
- [x] Frontend build passes with the opt-in flag enabled
