### PR TITLE
Allow archived spool export

### DIFF
--- a/spoolman/api/v1/export.py
+++ b/spoolman/api/v1/export.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from enum import Enum
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Response
+from fastapi import APIRouter, Depends, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from spoolman.database import filament, spool, vendor
@@ -34,8 +34,12 @@ async def export_spools(
     *,
     db: Annotated[AsyncSession, Depends(get_db_session)],
     fmt: ExportFormat,
+    allow_archived: Annotated[
+        bool,
+        Query(description="Whether to include archived spools in the export."),
+    ] = False,
 ) -> Response:
-    all_spools, _ = await spool.find(db=db)
+    all_spools, _ = await spool.find(db=db, allow_archived=allow_archived)
     return await _export(all_spools, fmt)
 
 


### PR DESCRIPTION
## Changes

### Allow archived spools in export
Adds an optional `allow_archived` query parameter (default: `false`) to the
spool export endpoint. When set to `true`, archived spools are included in the
exported data alongside active ones.

Previously archived spools were silently excluded from all exports, making it
impossible to do a full data backup or migration that preserves archived items.

## API change

`GET /api/v1/export` gains a new optional query parameter:

| Parameter        | Type    | Default | Description                              |
|------------------|---------|---------|------------------------------------------|
| `allow_archived` | boolean | `false` | Include archived spools in the export    |
