### PR TITLE
Vibe coded PR: Reload page on 401 to recover from forward-auth session expiry

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -2,6 +2,7 @@ import "@ant-design/v5-patch-for-react-19";
 import React from "react";
 import { createRoot } from "react-dom/client";
 
+import "./utils/authReloadHandler";
 import App from "./App";
 import "./i18n";
 

--- a/client/src/utils/authReloadHandler.ts
+++ b/client/src/utils/authReloadHandler.ts
@@ -1,0 +1,48 @@
+import { axiosInstance } from "@refinedev/simple-rest";
+
+const RELOAD_FLAG_KEY = "spoolmanAuthReloadedAt";
+const RELOAD_COOLDOWN_MS = 30_000;
+
+/**
+ * Reloads the page on 401 so a forward-auth proxy can redirect through its
+ * login portal and back. Cooldown bounds reload loops if recovery fails. The
+ * PWA service worker's NavigationRoute would otherwise serve the precached
+ * index.html and prevent the reload from reaching the proxy, so unregister it.
+ */
+async function reloadOnAuthFailure(): Promise<void> {
+  let last = 0;
+  try {
+    last = Number(localStorage.getItem(RELOAD_FLAG_KEY) || "0");
+  } catch {
+    /* storage unavailable */
+  }
+  if (Date.now() - last < RELOAD_COOLDOWN_MS) return;
+  try {
+    localStorage.setItem(RELOAD_FLAG_KEY, String(Date.now()));
+  } catch {
+    /* storage unavailable */
+  }
+  if ("serviceWorker" in navigator) {
+    try {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(registrations.map((r) => r.unregister()));
+    } catch {
+      /* fall through to reload anyway */
+    }
+  }
+  window.location.reload();
+}
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error?.response?.status === 401) {
+      // Auto-reload only on idempotent requests so unsaved form data on
+      // POST/PUT/PATCH/DELETE is preserved — mutation 401s surface through
+      // the Refine notification provider instead.
+      const method = String(error.config?.method ?? "get").toLowerCase();
+      if (method === "get" || method === "head") void reloadOnAuthFailure();
+    }
+    return Promise.reject(error);
+  },
+);


### PR DESCRIPTION
Fixes #923

## Problem

Behind a forward-auth proxy (Authelia, oauth2-proxy, Authentik, etc.), the proxy returns 401 Unauthorized to XHR once the user's session expires. The SPA shell renders fine, but every backend call fails and a "Loading…" indicator hangs in the corner indefinitely. Recovery today requires manually logging into the auth portal in another tab.

## Fix

Axios response interceptor triggers `window.location.reload()` on 401. The reload is a top-level GET, so the proxy returns its 302 to the login portal with `?rd=` set, and the user lands back on the original URL after auth.

- Auto-reload fires only on GET/HEAD. Mutation 401s pass through to the existing notification provider so unsaved form data isn't destroyed.
- The service worker is unregistered first because vite-plugin-pwa's default `NavigationRoute` serves the precached `index.html` and would prevent the reload from reaching the proxy. vite-plugin-pwa re-registers via `registerType: "autoUpdate"` on next load.
- 30s `localStorage` cooldown bounds the loop if recovery fails.

## Scope

Two files (~45 lines). No behavior change for users without forward-auth: Spoolman v0.23.1 emits no 401s natively, so the interceptor stays dormant.

If/when native auth lands (#229, #852), the future login endpoint should be excluded here so a wrong-password 401 doesn't reload-loop — one-line guard, left for whoever ships that feature.
