### PR TITLE
Add pyserial dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "httpx~=0.28",
     "hishel~=0.1",
     "aiomysql[rsa]~=0.3",
+    "pyserial>=3.5", 
 ]
 requires-python = ">=3.10"
 


### PR DESCRIPTION
Users with pyserial v3.5 constantly being downgraded - likely because of aiomysql -> pymysql -> pyserial constrains. This downgrade causes issues on my software, so users upgrade pyserial again to v3.5 and everything (also spoolman) is working. 

Added pyserial to the dependencies to avoid this.