### PR TITLE
fix: handle comma decimal inputs

### DIFF
--- a/client/src/components/extraFields.tsx
+++ b/client/src/components/extraFields.tsx
@@ -3,7 +3,7 @@ import { Checkbox, Form, Input, InputNumber, Select, Typography } from "antd";
 import { FormItemProps, Rule } from "antd/es/form";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
-import { enrichText } from "../utils/parsing";
+import { enrichText, formatNumberOnUserInput, numberParserAllowEmpty } from "../utils/parsing";
 import { Field, FieldType } from "../utils/queryFields";
 import { DateTimePicker } from "./dateTimePicker";
 import { InputNumberRange } from "./inputNumberRange";
@@ -113,7 +113,14 @@ export function ExtraFieldFormItem(props: { field: Field; setDefaultValue?: bool
       type: "integer",
     });
   } else if (field.field_type === FieldType.float) {
-    inputNode = <InputNumber addonAfter={field.unit} precision={3} />;
+    inputNode = (
+      <InputNumber
+        addonAfter={field.unit}
+        precision={3}
+        formatter={formatNumberOnUserInput}
+        parser={numberParserAllowEmpty}
+      />
+    );
     rules.push({
       type: "number",
     });

--- a/client/src/components/inputNumberRange.tsx
+++ b/client/src/components/inputNumberRange.tsx
@@ -1,4 +1,5 @@
 import { InputNumber } from "antd";
+import { formatNumberOnUserInput, numberParserAllowEmpty } from "../utils/parsing";
 
 function parseValue(value?: (number | null)[]): [number | null, number | null] {
   if (value === undefined) {
@@ -12,6 +13,10 @@ function parseValue(value?: (number | null)[]): [number | null, number | null] {
   const [min, max] = value;
 
   return [min, max];
+}
+
+function parseInputNumberValue(value: string | number | null): number | null {
+  return typeof value === "number" ? value : null;
 }
 
 /**
@@ -33,10 +38,12 @@ export function InputNumberRange(props: {
         value={min}
         precision={props.precision ?? 0}
         addonAfter={props.unit}
+        formatter={formatNumberOnUserInput}
+        parser={numberParserAllowEmpty}
         style={{ maxWidth: 110 }}
         onChange={(value) => {
           if (props.onChange) {
-            props.onChange([value, max]);
+            props.onChange([parseInputNumberValue(value), max]);
           }
         }}
       />
@@ -45,10 +52,12 @@ export function InputNumberRange(props: {
         value={max}
         precision={props.precision ?? 0}
         addonAfter={props.unit}
+        formatter={formatNumberOnUserInput}
+        parser={numberParserAllowEmpty}
         style={{ maxWidth: 110 }}
         onChange={(value) => {
           if (props.onChange) {
-            props.onChange([min, value]);
+            props.onChange([min, parseInputNumberValue(value)]);
           }
         }}
       />

--- a/client/src/pages/filaments/create.tsx
+++ b/client/src/pages/filaments/create.tsx
@@ -295,7 +295,12 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Form.Item
           label={t("filament.fields.spool_weight")}
@@ -309,7 +314,12 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Form.Item
           label={t("filament.fields.settings_extruder_temp")}

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -273,7 +273,12 @@ export const FilamentEdit = () => {
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Form.Item
           label={t("filament.fields.spool_weight")}
@@ -287,7 +292,12 @@ export const FilamentEdit = () => {
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Form.Item
           label={t("filament.fields.settings_extruder_temp")}

--- a/client/src/pages/printing/printingDialog.tsx
+++ b/client/src/pages/printing/printingDialog.tsx
@@ -17,6 +17,7 @@ import {
 import * as htmlToImage from "html-to-image";
 import { ReactElement, useRef } from "react";
 import { useReactToPrint } from "react-to-print";
+import { formatNumberOnUserInput, numberParser } from "../../utils/parsing";
 import { useSavedState } from "../../utils/saveload";
 import { PrintSettings } from "./printing";
 
@@ -368,6 +369,8 @@ const PrintingDialog = ({
                     step={0.01}
                     style={{ margin: "0 16px" }}
                     value={previewScale}
+                    formatter={formatNumberOnUserInput}
+                    parser={numberParser}
                     onChange={(value) => {
                       setPreviewScale(value ?? 0.1);
                     }}
@@ -415,6 +418,8 @@ const PrintingDialog = ({
                         value={customPaperSize.width}
                         min={0.1}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           customPaperSize.width = value ?? 0;
                           printSettings.customPaperSize = customPaperSize;
@@ -430,6 +435,8 @@ const PrintingDialog = ({
                         value={customPaperSize.height}
                         min={0.1}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           customPaperSize.height = value ?? 0;
                           printSettings.customPaperSize = customPaperSize;
@@ -515,6 +522,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={margin.left}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           margin.left = value ?? 0;
                           printSettings.margin = margin;
@@ -546,6 +555,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={margin.top}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           margin.top = value ?? 0;
                           printSettings.margin = margin;
@@ -577,6 +588,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={margin.right}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           margin.right = value ?? 0;
                           printSettings.margin = margin;
@@ -608,6 +621,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={margin.bottom}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           margin.bottom = value ?? 0;
                           printSettings.margin = margin;
@@ -641,6 +656,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={printerMargin.left}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           printerMargin.left = value ?? 0;
                           printSettings.printerMargin = printerMargin;
@@ -672,6 +689,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={printerMargin.top}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           printerMargin.top = value ?? 0;
                           printSettings.printerMargin = printerMargin;
@@ -703,6 +722,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={printerMargin.right}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           printerMargin.right = value ?? 0;
                           printSettings.printerMargin = printerMargin;
@@ -734,6 +755,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={printerMargin.bottom}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           printerMargin.bottom = value ?? 0;
                           printSettings.printerMargin = printerMargin;
@@ -766,6 +789,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={spacing.horizontal}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           spacing.horizontal = value ?? 0;
                           printSettings.spacing = spacing;
@@ -797,6 +822,8 @@ const PrintingDialog = ({
                         style={{ margin: "0 16px" }}
                         value={spacing.vertical}
                         addonAfter="mm"
+                        formatter={formatNumberOnUserInput}
+                        parser={numberParser}
                         onChange={(value) => {
                           spacing.vertical = value ?? 0;
                           printSettings.spacing = spacing;

--- a/client/src/pages/printing/qrCodePrintingDialog.tsx
+++ b/client/src/pages/printing/qrCodePrintingDialog.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from "@refinedev/core";
 import { Col, Form, InputNumber, QRCode, Radio, RadioChangeEvent, Row, Slider, Switch, Typography } from "antd";
 import { ReactElement } from "react";
+import { formatNumberOnUserInput, numberParser } from "../../utils/parsing";
 import { getBasePath } from "../../utils/url";
 import { QRCodePrintSettings } from "./printing";
 import PrintingDialog from "./printingDialog";
@@ -147,6 +148,8 @@ const QRCodePrintingDialog = ({
                   style={{ margin: "0 16px" }}
                   value={textSize}
                   addonAfter="mm"
+                  formatter={formatNumberOnUserInput}
+                  parser={numberParser}
                   onChange={(value) => {
                     printSettings.textSize = value ?? 5;
                     setPrintSettings(printSettings);

--- a/client/src/pages/settings/extraFieldsSettings.tsx
+++ b/client/src/pages/settings/extraFieldsSettings.tsx
@@ -25,6 +25,7 @@ import { Trans } from "react-i18next";
 import { useParams } from "react-router";
 import { DateTimePicker } from "../../components/dateTimePicker";
 import { InputNumberRange } from "../../components/inputNumberRange";
+import { formatNumberOnUserInput, numberParserAllowEmpty } from "../../utils/parsing";
 import { EntityType, Field, FieldType, useDeleteField, useGetFields, useSetField } from "../../utils/queryFields";
 
 dayjs.extend(utc);
@@ -190,7 +191,7 @@ const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps
         type: "integer",
       });
     } else if (fieldType === FieldType.float) {
-      inputNode = <InputNumber />;
+      inputNode = <InputNumber formatter={formatNumberOnUserInput} parser={numberParserAllowEmpty} />;
       rules.push({
         type: "number",
       });

--- a/client/src/pages/spools/create.tsx
+++ b/client/src/pages/spools/create.tsx
@@ -353,7 +353,12 @@ export const SpoolCreate = (props: IResourceComponentsProps & CreateOrCloneProps
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
 
         <Form.Item
@@ -368,7 +373,12 @@ export const SpoolCreate = (props: IResourceComponentsProps & CreateOrCloneProps
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
 
         <Form.Item hidden={true} name={["used_weight"]} initialValue={0}>

--- a/client/src/pages/spools/edit.tsx
+++ b/client/src/pages/spools/edit.tsx
@@ -336,7 +336,12 @@ export const SpoolEdit = () => {
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
 
         <Form.Item
@@ -351,7 +356,12 @@ export const SpoolEdit = () => {
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
 
         <Form.Item hidden={true} name={["used_weight"]} initialValue={0}>

--- a/client/src/pages/spools/functions.tsx
+++ b/client/src/pages/spools/functions.tsx
@@ -4,7 +4,7 @@ import { Form, InputNumber, Modal, Radio } from "antd";
 import { useForm } from "antd/es/form/Form";
 import type { InputNumberRef } from "rc-input-number";
 import { useCallback, useMemo, useRef, useState } from "react";
-import { formatLength, formatWeight } from "../../utils/parsing";
+import { formatLength, formatNumberOnUserInput, formatWeight, numberParser } from "../../utils/parsing";
 import { SpoolType, useGetExternalDBFilaments } from "../../utils/queryExternalDB";
 import { getAPIURL } from "../../utils/url";
 import { IFilament } from "../filaments/model";
@@ -252,7 +252,13 @@ export function useSpoolAdjustModal() {
             </Radio.Group>
           </Form.Item>
           <Form.Item label={t("spool.form.adjust_filament_value")} name="filament_value">
-            <InputNumber ref={inputNumberRef} precision={1} addonAfter={measurementType === "length" ? "mm" : "g"} />
+            <InputNumber
+              ref={inputNumberRef}
+              precision={1}
+              addonAfter={measurementType === "length" ? "mm" : "g"}
+              formatter={formatNumberOnUserInput}
+              parser={numberParser}
+            />
           </Form.Item>
         </Form>
       </Modal>

--- a/client/src/pages/vendors/create.tsx
+++ b/client/src/pages/vendors/create.tsx
@@ -6,6 +6,7 @@ import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import { useEffect } from "react";
 import { ExtraFieldFormItem, ParsedExtras, StringifiedExtras } from "../../components/extraFields";
+import { formatNumberOnUserInput, numberParserAllowEmpty } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { IVendor, IVendorParsedExtras } from "./model";
 
@@ -102,7 +103,12 @@ export const VendorCreate = (props: IResourceComponentsProps & CreateOrCloneProp
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Typography.Title level={5}>{t("settings.extra_fields.tab")}</Typography.Title>
         {extraFields.data?.map((field, index) => (

--- a/client/src/pages/vendors/edit.tsx
+++ b/client/src/pages/vendors/edit.tsx
@@ -5,6 +5,7 @@ import TextArea from "antd/es/input/TextArea";
 import dayjs from "dayjs";
 import { useState } from "react";
 import { ExtraFieldFormItem, ParsedExtras, StringifiedExtras } from "../../components/extraFields";
+import { formatNumberOnUserInput, numberParserAllowEmpty } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
 import { IVendor, IVendorParsedExtras } from "./model";
 
@@ -111,7 +112,12 @@ export const VendorEdit = () => {
             },
           ]}
         >
-          <InputNumber addonAfter="g" precision={1} />
+          <InputNumber
+            addonAfter="g"
+            precision={1}
+            formatter={formatNumberOnUserInput}
+            parser={numberParserAllowEmpty}
+          />
         </Form.Item>
         <Form.Item
           label={t("vendor.fields.external_id")}


### PR DESCRIPTION
Fixes #554.

This updates the remaining decimal `InputNumber` fields to use the existing comma-aware parser and input formatter, so values such as `0,3` are accepted consistently across filament, spool, vendor, extra-field, adjustment, and print/QR settings forms. Integer-only fields are left unchanged.

Validation:

```bash
cd client
npm run build
```

Passed:

```text
> spoolman-ui@0.23.1 build
> tsc && refine build

vite v7.3.1 building client environment for production...
✓ 6363 modules transformed.
✓ built
```

```bash
node - <<'NODE'
const fs = require('fs');
const assert = require('assert');
const dialog = fs.readFileSync('client/src/pages/printing/printingDialog.tsx', 'utf8');
assert(dialog.includes('value={previewScale}'));
assert(dialog.includes('formatter={formatNumberOnUserInput}'));
assert(dialog.includes('parser={numberParser}'));
function numberParser(value) {
  value = value?.replace(',', '.');
  value = value?.replace(/[^\d.-]/g, '');
  return parseFloat(value || '0');
}
assert.strictEqual(numberParser('0,3'), 0.3);
console.log('OK: printing preview scale InputNumber uses shared numberParser; numberParser("0,3") =>', numberParser('0,3'));
NODE
```

Passed:

```text
OK: printing preview scale InputNumber uses shared numberParser; numberParser("0,3") => 0.3
```
