### PR TITLE
UI: rename Hide Columns button to Columns (English only)

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -28,7 +28,7 @@
         "hideArchived": "Hide Archived",
         "showArchived": "Show Archived",
         "notAccessTitle": "You don't have permission to access",
-        "hideColumns": "Hide Columns",
+        "hideColumns": "Columns",
         "clearFilters": "Clear Filters"
     },
     "warnWhenUnsavedChanges": "Are you sure you want to leave? You have unsaved changes.",


### PR DESCRIPTION
Replacement for 867 due fork branch protection rules preventing force-push/history rewrite.\n\nThis PR contains only the English locale change for the button label and is based on the latest master.