### PR TITLE
Add OrcaCloud integration: link filaments to synced OrcaSlicer profiles

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -265,7 +265,13 @@
         "form": {
             "filament_updated": "This filament has been updated by someone/something else since you opened this page. Saving will overwrite those changes!",
             "import_external": "Import from External",
-            "import_external_description": "Select a filament in the list to automatically populate its details in the filament creation form. This will overwrite any data you have entered in the form.<br><br>A Manufacturer object will be created automatically when you click Ok, if necessary."
+            "import_external_description": "Select a filament in the list to automatically populate its details in the filament creation form. This will overwrite any data you have entered in the form.<br><br>A Manufacturer object will be created automatically when you click Ok, if necessary.",
+            "link_orca_profile": "Link OrcaCloud Profile",
+            "link_orca_profile_description": "Select a synced OrcaCloud filament profile to fill in its Orca Filament ID and Orca Setting ID, plus any other extra field below whose key matches a field in that profile. Nothing else on this form is changed.",
+            "link_orca_profile_not_connected": "Not connected to OrcaCloud yet. Sign in from Settings → OrcaCloud first.",
+            "link_orca_profile_missing_fields": "Define the \"orca_filament_id\" and/or \"orca_setting_id\" extra fields (Settings → Extra Fields → Filament) before linking an OrcaCloud profile.",
+            "link_orca_profile_no_matches": "That profile didn't match any of this filament's extra fields — nothing was filled in. Define extra fields whose keys match OrcaSlicer profile fields (e.g. orca_filament_id, orca_setting_id) in Settings → Extra Fields → Filament.",
+            "linked_orca_profile": "Linked to OrcaCloud profile:"
         },
         "buttons": {
             "add_spool": "Add Spool"

--- a/client/src/components/orcaLinkedProfileBadge.tsx
+++ b/client/src/components/orcaLinkedProfileBadge.tsx
@@ -1,0 +1,26 @@
+import { CloudOutlined } from "@ant-design/icons";
+import { useTranslate } from "@refinedev/core";
+import { Typography } from "antd";
+
+const { Text } = Typography;
+
+/**
+ * Shows which OrcaCloud profile a filament is linked to, if any. Prefers orca_setting_id since
+ * that's already OrcaSlicer's human-readable preset name (e.g. "Generic PLA @Bambu Lab X1
+ * Carbon"); falls back to the less-readable orca_filament_id. Renders nothing if neither extra
+ * field is set on this filament — deliberately no live OrcaCloud lookup here, so it works
+ * offline/without a connection.
+ */
+export function OrcaLinkedProfileBadge(props: { settingId?: string | null; filamentId?: string | null }) {
+  const t = useTranslate();
+  const label = props.settingId || props.filamentId;
+  if (!label) {
+    return null;
+  }
+  return (
+    <Text type="secondary">
+      <CloudOutlined style={{ marginRight: 6 }} />
+      {t("filament.form.linked_orca_profile")} <Text strong>{label}</Text>
+    </Text>
+  );
+}

--- a/client/src/components/orcaProfilePickerModal.tsx
+++ b/client/src/components/orcaProfilePickerModal.tsx
@@ -1,0 +1,148 @@
+import { useTranslate } from "@refinedev/core";
+import { Alert, Form, Modal, Select } from "antd";
+import { searchMatches } from "../utils/filtering";
+import { Field, FieldType } from "../utils/queryFields";
+import { OrcaFilamentProfileSummary, useOrcaConnectionStatus, useOrcaFilamentProfiles } from "../utils/queryOrca";
+
+// Mirrors spoolman/orca_cloud.py's _first_str/_first_float/_first_int/encode_profile_value —
+// OrcaSlicer profile values are typically single-element arrays (its per-layer-override format).
+function firstStr(val: unknown): string | null {
+  if (Array.isArray(val)) return val.length > 0 ? String(val[0]) : null;
+  if (typeof val === "string") return val || null;
+  return null;
+}
+
+function firstFloat(val: unknown): number | null {
+  const s = firstStr(val);
+  if (s === null) return null;
+  const f = Number.parseFloat(s);
+  return Number.isNaN(f) ? null : f;
+}
+
+function firstInt(val: unknown): number | null {
+  const f = firstFloat(val);
+  return f === null ? null : Math.trunc(f);
+}
+
+function encodeProfileValue(rawValue: unknown, fieldType: FieldType): unknown {
+  if (fieldType === FieldType.float || fieldType === FieldType.float_range) {
+    return firstFloat(rawValue);
+  }
+  if (fieldType === FieldType.integer || fieldType === FieldType.integer_range) {
+    return firstInt(rawValue);
+  }
+  if (fieldType === FieldType.boolean) {
+    const s = firstStr(rawValue);
+    return s === null ? null : !(s === "0" || s === "false" || s === "");
+  }
+  // text / choice / datetime (same catch-all as the backend)
+  return firstStr(rawValue);
+}
+
+/**
+ * Extra-field values to apply from a picked OrcaCloud profile: orca_filament_id/orca_setting_id
+ * always come from the profile itself, and any other defined extra field is filled in only if
+ * its key matches a key in the profile's raw content (same matching /orca/import does), so
+ * picking a profile never invents data for fields that don't correspond to anything in Orca.
+ */
+export function getOrcaProfileExtraValues(
+  profile: OrcaFilamentProfileSummary,
+  definedExtraFields: readonly Field[],
+): Record<string, unknown> {
+  const values: Record<string, unknown> = {};
+  for (const field of definedExtraFields) {
+    if (field.key === "orca_filament_id") {
+      if (profile.filament_id) {
+        values[field.key] = profile.filament_id;
+      }
+    } else if (field.key === "orca_setting_id") {
+      if (profile.setting_id) {
+        values[field.key] = profile.setting_id;
+      }
+    } else {
+      const rawVal = profile.content[field.key];
+      if (rawVal === undefined || rawVal === null) continue;
+      const encoded = encodeProfileValue(rawVal, field.field_type);
+      if (encoded !== null) {
+        values[field.key] = encoded;
+      }
+    }
+  }
+  return values;
+}
+
+export function OrcaProfilePickerModal(props: {
+  isOpen: boolean;
+  onSelect: (profile: OrcaFilamentProfileSummary) => void;
+  onClose: () => void;
+}) {
+  const [form] = Form.useForm();
+  const t = useTranslate();
+
+  const connectionStatus = useOrcaConnectionStatus();
+  const profiles = useOrcaFilamentProfiles(props.isOpen && connectionStatus.data?.connected === true);
+
+  const profileOptions =
+    profiles.data?.map((item) => {
+      return {
+        label: [item.vendor, item.material, item.name].filter(Boolean).join(" - "),
+        value: item.orca_id,
+        item: item,
+      };
+    }) ?? [];
+  profileOptions.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: "base" }));
+
+  const notConnected = connectionStatus.data?.connected === false;
+
+  return (
+    <Modal
+      title={t("filament.form.link_orca_profile")}
+      open={props.isOpen}
+      onOk={() => form.submit()}
+      onCancel={() => props.onClose()}
+      okButtonProps={{ disabled: notConnected }}
+      confirmLoading={profiles.isFetching}
+    >
+      <Form
+        layout="vertical"
+        form={form}
+        onFinish={(values) => {
+          const profile = profileOptions.find((item) => item.value === values.profile)?.item;
+          if (!profile) {
+            throw new Error("Profile not found");
+          }
+          props.onSelect(profile);
+          props.onClose();
+          form.resetFields();
+        }}
+      >
+        <p>{t("filament.form.link_orca_profile_description")}</p>
+        {notConnected && (
+          <Alert
+            type="warning"
+            showIcon
+            message={t("filament.form.link_orca_profile_not_connected")}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        {profiles.isError && (
+          <Alert
+            type="error"
+            showIcon
+            message={profiles.error instanceof Error ? profiles.error.message : String(profiles.error)}
+            style={{ marginBottom: 16 }}
+          />
+        )}
+        <Form.Item name="profile" rules={[{ required: true }]}>
+          <Select
+            options={profileOptions}
+            showSearch
+            loading={profiles.isFetching}
+            disabled={notConnected}
+            filterOption={(input, option) => typeof option?.label === "string" && searchMatches(input, option?.label)}
+          />
+        </Form.Item>
+      </Form>
+    </Modal>
+  );
+}

--- a/client/src/pages/filaments/create.tsx
+++ b/client/src/pages/filaments/create.tsx
@@ -1,6 +1,6 @@
 import { Create, useForm, useSelect } from "@refinedev/antd";
 import { HttpError, IResourceComponentsProps, useInvalidate, useTranslate } from "@refinedev/core";
-import { Button, ColorPicker, Form, Input, InputNumber, Radio, Select, Typography } from "antd";
+import { Button, ColorPicker, Form, Input, InputNumber, message, Radio, Select, Typography } from "antd";
 import TextArea from "antd/es/input/TextArea";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
@@ -8,9 +8,12 @@ import { useEffect, useState } from "react";
 import { ExtraFieldFormItem, ParsedExtras, StringifiedExtras } from "../../components/extraFields";
 import { FilamentImportModal } from "../../components/filamentImportModal";
 import { MultiColorPicker } from "../../components/multiColorPicker";
+import { OrcaLinkedProfileBadge } from "../../components/orcaLinkedProfileBadge";
+import { getOrcaProfileExtraValues, OrcaProfilePickerModal } from "../../components/orcaProfilePickerModal";
 import { formatNumberOnUserInput, numberParser, numberParserAllowEmpty } from "../../utils/parsing";
 import { ExternalFilament } from "../../utils/queryExternalDB";
 import { EntityType, useGetFields } from "../../utils/queryFields";
+import { OrcaFilamentProfileSummary } from "../../utils/queryOrca";
 import { getCurrencySymbol, useCurrency } from "../../utils/settings";
 import { getOrCreateVendorFromExternal } from "../vendors/functions";
 import { IVendor } from "../vendors/model";
@@ -28,9 +31,11 @@ type IFilamentRequest = Omit<IFilamentParsedExtras, "id" | "registered"> & {
 
 export const FilamentCreate = (props: IResourceComponentsProps & CreateOrCloneProps) => {
   const t = useTranslate();
+  const [messageApi, contextHolder] = message.useMessage();
   const extraFields = useGetFields(EntityType.filament);
   const currency = useCurrency();
   const [isImportExtOpen, setIsImportExtOpen] = useState(false);
+  const [isOrcaPickerOpen, setIsOrcaPickerOpen] = useState(false);
   const invalidate = useInvalidate();
   const [colorType, setColorType] = useState<"single" | "multi">("single");
 
@@ -44,6 +49,9 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
   if (!formProps.initialValues) {
     formProps.initialValues = {};
   }
+
+  const linkedSettingId = Form.useWatch(["extra", "orca_setting_id"], form) as string | undefined;
+  const linkedFilamentId = Form.useWatch(["extra", "orca_filament_id"], form) as string | undefined;
 
   if (props.mode === "clone") {
     // Fix the vendor_id
@@ -92,6 +100,17 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
     });
   };
 
+  const handleOrcaProfileSelect = (profile: OrcaFilamentProfileSummary) => {
+    // Values are heterogeneous (string/number/boolean) depending on each extra field's type,
+    // which antd's Store typing (RecursivePartial over `unknown`) can't express cleanly.
+    const extraValues = getOrcaProfileExtraValues(profile, extraFields.data ?? []);
+    if (Object.keys(extraValues).length === 0) {
+      messageApi.warning(t("filament.form.link_orca_profile_no_matches"));
+      return;
+    }
+    form.setFieldsValue({ extra: extraValues as unknown as { [key: string]: string } });
+  };
+
   // Use useEffect to update the form's initialValues when the extra fields are loaded
   // This is necessary because the form is rendered before the extra fields are loaded
   useEffect(() => {
@@ -112,6 +131,7 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
           <Button type="primary" onClick={() => setIsImportExtOpen(true)}>
             {t("filament.form.import_external")}
           </Button>
+          <Button onClick={() => setIsOrcaPickerOpen(true)}>{t("filament.form.link_orca_profile")}</Button>
         </>
       )}
       footerButtons={() => (
@@ -125,6 +145,7 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
         </>
       )}
     >
+      {contextHolder}
       <FilamentImportModal
         isOpen={isImportExtOpen}
         onImport={(value) => {
@@ -132,6 +153,11 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
           importFilament(value);
         }}
         onClose={() => setIsImportExtOpen(false)}
+      />
+      <OrcaProfilePickerModal
+        isOpen={isOrcaPickerOpen}
+        onSelect={handleOrcaProfileSelect}
+        onClose={() => setIsOrcaPickerOpen(false)}
       />
       <Form {...formProps} layout="vertical">
         <Form.Item
@@ -361,6 +387,7 @@ export const FilamentCreate = (props: IResourceComponentsProps & CreateOrClonePr
           <TextArea maxLength={1024} />
         </Form.Item>
         <Typography.Title level={5}>{t("settings.extra_fields.tab")}</Typography.Title>
+        <OrcaLinkedProfileBadge settingId={linkedSettingId} filamentId={linkedFilamentId} />
         {extraFields.data?.map((field, index) => (
           <ExtraFieldFormItem key={index} field={field} />
         ))}

--- a/client/src/pages/filaments/edit.tsx
+++ b/client/src/pages/filaments/edit.tsx
@@ -1,13 +1,28 @@
 import { Edit, useForm, useSelect } from "@refinedev/antd";
 import { HttpError, useTranslate } from "@refinedev/core";
-import { Alert, ColorPicker, DatePicker, Form, Input, InputNumber, message, Radio, Select, Typography } from "antd";
+import {
+  Alert,
+  Button,
+  ColorPicker,
+  DatePicker,
+  Form,
+  Input,
+  InputNumber,
+  message,
+  Radio,
+  Select,
+  Typography,
+} from "antd";
 import TextArea from "antd/es/input/TextArea";
 import dayjs from "dayjs";
 import { useEffect, useState } from "react";
 import { ExtraFieldFormItem, ParsedExtras, StringifiedExtras } from "../../components/extraFields";
 import { MultiColorPicker } from "../../components/multiColorPicker";
+import { OrcaLinkedProfileBadge } from "../../components/orcaLinkedProfileBadge";
+import { getOrcaProfileExtraValues, OrcaProfilePickerModal } from "../../components/orcaProfilePickerModal";
 import { formatNumberOnUserInput, numberParser, numberParserAllowEmpty } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
+import { OrcaFilamentProfileSummary } from "../../utils/queryOrca";
 import { getCurrencySymbol, useCurrency } from "../../utils/settings";
 import { IVendor } from "../vendors/model";
 import { IFilament, IFilamentParsedExtras } from "./model";
@@ -26,8 +41,9 @@ export const FilamentEdit = () => {
   const extraFields = useGetFields(EntityType.filament);
   const currency = useCurrency();
   const [colorType, setColorType] = useState<"single" | "multi">("single");
+  const [isOrcaPickerOpen, setIsOrcaPickerOpen] = useState(false);
 
-  const { formProps, saveButtonProps } = useForm<IFilament, HttpError, IFilament, IFilament>({
+  const { form, formProps, saveButtonProps } = useForm<IFilament, HttpError, IFilament, IFilament>({
     liveMode: "manual",
     onLiveEvent() {
       // Warn the user if the filament has been updated since the form was opened
@@ -43,6 +59,9 @@ export const FilamentEdit = () => {
     pagination: { mode: "off" },
   });
 
+  const linkedSettingId = Form.useWatch(["extra", "orca_setting_id"], form) as string | undefined;
+  const linkedFilamentId = Form.useWatch(["extra", "orca_filament_id"], form) as string | undefined;
+
   // Add the vendor_id field to the form
   if (formProps.initialValues) {
     formProps.initialValues["vendor_id"] = formProps.initialValues["vendor"]?.id;
@@ -50,6 +69,17 @@ export const FilamentEdit = () => {
     // Parse the extra fields from string values into real types
     formProps.initialValues = ParsedExtras(formProps.initialValues);
   }
+
+  const handleOrcaProfileSelect = (profile: OrcaFilamentProfileSummary) => {
+    // Values are heterogeneous (string/number/boolean) depending on each extra field's type,
+    // which antd's Store typing (RecursivePartial over `unknown`) can't express cleanly.
+    const extraValues = getOrcaProfileExtraValues(profile, extraFields.data ?? []);
+    if (Object.keys(extraValues).length === 0) {
+      messageApi.warning(t("filament.form.link_orca_profile_no_matches"));
+      return;
+    }
+    form.setFieldsValue({ extra: extraValues as unknown as { [key: string]: string } });
+  };
 
   // Update colorType state
   useEffect(() => {
@@ -77,8 +107,21 @@ export const FilamentEdit = () => {
   };
 
   return (
-    <Edit saveButtonProps={saveButtonProps}>
+    <Edit
+      saveButtonProps={saveButtonProps}
+      headerButtons={({ defaultButtons }) => (
+        <>
+          {defaultButtons}
+          <Button onClick={() => setIsOrcaPickerOpen(true)}>{t("filament.form.link_orca_profile")}</Button>
+        </>
+      )}
+    >
       {contextHolder}
+      <OrcaProfilePickerModal
+        isOpen={isOrcaPickerOpen}
+        onSelect={handleOrcaProfileSelect}
+        onClose={() => setIsOrcaPickerOpen(false)}
+      />
       <Form {...formProps} layout="vertical">
         <Form.Item
           label={t("filament.fields.id")}
@@ -350,6 +393,7 @@ export const FilamentEdit = () => {
           <TextArea maxLength={1024} />
         </Form.Item>
         <Typography.Title level={5}>{t("settings.extra_fields.tab")}</Typography.Title>
+        <OrcaLinkedProfileBadge settingId={linkedSettingId} filamentId={linkedFilamentId} />
         {extraFields.data?.map((field, index) => (
           <ExtraFieldFormItem key={index} field={field} />
         ))}

--- a/client/src/pages/filaments/show.tsx
+++ b/client/src/pages/filaments/show.tsx
@@ -6,6 +6,7 @@ import utc from "dayjs/plugin/utc";
 import { useNavigate } from "react-router";
 import { ExtraFieldDisplay } from "../../components/extraFields";
 import { NumberFieldUnit } from "../../components/numberField";
+import { OrcaLinkedProfileBadge } from "../../components/orcaLinkedProfileBadge";
 import SpoolIcon from "../../components/spoolIcon";
 import { enrichText } from "../../utils/parsing";
 import { EntityType, useGetFields } from "../../utils/queryFields";
@@ -49,6 +50,17 @@ export const FilamentShow = () => {
     navigate(URL);
   };
 
+  const parseExtra = (key: string): string | undefined => {
+    const raw = record?.extra?.[key];
+    if (raw === undefined) return undefined;
+    try {
+      const parsed = JSON.parse(raw);
+      return typeof parsed === "string" ? parsed : undefined;
+    } catch {
+      return undefined;
+    }
+  };
+
   const colorObj = record?.multi_color_hexes
     ? {
         colors: record.multi_color_hexes.split(","),
@@ -86,6 +98,7 @@ export const FilamentShow = () => {
       />
       <Title level={5}>{t("filament.fields.name")}</Title>
       <TextField value={record?.name} />
+      <OrcaLinkedProfileBadge settingId={parseExtra("orca_setting_id")} filamentId={parseExtra("orca_filament_id")} />
       <Title level={5}>{t("filament.fields.color_hex")}</Title>
       {colorObj && <SpoolIcon color={colorObj} size="large" no_margin />}
       {record?.color_hex && <TextField value={`#${record?.color_hex}`} />}

--- a/client/src/pages/settings/extraFieldsSettings.tsx
+++ b/client/src/pages/settings/extraFieldsSettings.tsx
@@ -12,6 +12,7 @@ import {
   Select,
   Space,
   Table,
+  Typography,
   message,
 } from "antd";
 import { FormItemProps, Rule } from "antd/es/form";
@@ -26,6 +27,7 @@ import { useParams } from "react-router";
 import { DateTimePicker } from "../../components/dateTimePicker";
 import { InputNumberRange } from "../../components/inputNumberRange";
 import { EntityType, Field, FieldType, useDeleteField, useGetFields, useSetField } from "../../utils/queryFields";
+import { useOrcaProfileFields } from "../../utils/queryOrca";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -40,6 +42,7 @@ interface EditableCellProps extends React.HTMLAttributes<HTMLElement> {
   dataIndex: string;
   form: FormInstance;
   children: React.ReactNode;
+  entityType?: EntityType;
 }
 
 interface FieldHolder {
@@ -55,8 +58,9 @@ const canEditField = (dataIndex: string, isNew: boolean) => {
   return dataIndex !== "key" && dataIndex !== "field_type" && dataIndex !== "multi_choice";
 };
 
-const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps }: EditableCellProps) => {
+const EditableCell = ({ record, editing, dataIndex, children, form, entityType, ...restProps }: EditableCellProps) => {
   const t = useTranslate();
+  const orcaFields = useOrcaProfileFields();
 
   if (!editing || !canEditField(dataIndex, record.is_new)) {
     return (
@@ -77,10 +81,44 @@ const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps
   const title = t(`settings.extra_fields.params.${dataIndex}`);
 
   let inputNode;
+  let extraCellContent: React.ReactNode = null;
   const rules: Rule[] = [];
   const formItemProps: FormItemProps = {};
   if (dataIndex === "key") {
+    const orcaPicker =
+      record.is_new && entityType === EntityType.filament && orcaFields.data && orcaFields.data.length > 0 ? (
+        <div style={{ marginTop: 4 }}>
+          <Typography.Text type="secondary" style={{ fontSize: 11 }}>
+            From OrcaSlicer:
+          </Typography.Text>
+          <Select
+            size="small"
+            style={{ width: "100%", marginTop: 2 }}
+            placeholder="Pick a profile field…"
+            showSearch
+            allowClear
+            optionFilterProp="label"
+            options={orcaFields.data.map((f) => ({
+              label: `${f.name}  (${f.key})`,
+              value: f.key,
+            }))}
+            onChange={(value: string | undefined) => {
+              if (!value) return;
+              const picked = orcaFields.data?.find((f) => f.key === value);
+              if (!picked) return;
+              form.setFieldsValue({
+                key: picked.key,
+                name: picked.name,
+                field_type: picked.field_type as FieldType,
+                unit: picked.unit ?? "",
+              });
+            }}
+          />
+        </div>
+      ) : null;
+
     inputNode = <Input />;
+    extraCellContent = orcaPicker;
     rules.push({
       required: true,
       min: 1,
@@ -280,7 +318,12 @@ const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps
     </Form.Item>
   ) : null;
 
-  return <td {...restProps}>{formItem}</td>;
+  return (
+    <td {...restProps}>
+      {formItem}
+      {extraCellContent}
+    </td>
+  );
 };
 
 export function ExtraFieldsSettings() {
@@ -579,6 +622,7 @@ export function ExtraFieldsSettings() {
           editing: isEditing(record),
           dataIndex: (col.dataIndex?.toString() || "").split(",").pop() || "",
           form: form,
+          entityType: entityType as EntityType,
           children: [],
         };
       },

--- a/client/src/pages/settings/index.tsx
+++ b/client/src/pages/settings/index.tsx
@@ -1,4 +1,11 @@
-import { FileOutlined, HighlightOutlined, SolutionOutlined, ToolOutlined, UserOutlined } from "@ant-design/icons";
+import {
+  CloudOutlined,
+  FileOutlined,
+  HighlightOutlined,
+  SolutionOutlined,
+  ToolOutlined,
+  UserOutlined,
+} from "@ant-design/icons";
 import { useTranslate } from "@refinedev/core";
 import { Menu, theme } from "antd";
 import { Content } from "antd/es/layout/layout";
@@ -7,6 +14,7 @@ import utc from "dayjs/plugin/utc";
 import { Route, Routes, useNavigate } from "react-router";
 import { ExtraFieldsSettings } from "./extraFieldsSettings";
 import { GeneralSettings } from "./generalSettings";
+import { OrcaSettings } from "./orcaSettings";
 
 dayjs.extend(utc);
 
@@ -57,6 +65,7 @@ export const Settings = () => {
           }}
           items={[
             { key: "", label: t("settings.general.tab"), icon: <ToolOutlined /> },
+            { key: "orca", label: "OrcaCloud", icon: <CloudOutlined /> },
             {
               key: "extra",
               label: t("settings.extra_fields.tab"),
@@ -87,6 +96,7 @@ export const Settings = () => {
         <main>
           <Routes>
             <Route index element={<GeneralSettings />} />
+            <Route path="/orca" element={<OrcaSettings />} />
             <Route path="/extra/:entityType" element={<ExtraFieldsSettings />} />
           </Routes>
         </main>

--- a/client/src/pages/settings/orcaSettings.tsx
+++ b/client/src/pages/settings/orcaSettings.tsx
@@ -1,0 +1,297 @@
+import {
+  AppleFilled,
+  CheckCircleFilled,
+  CloudDownloadOutlined,
+  CloudOutlined,
+  GoogleOutlined,
+} from "@ant-design/icons";
+import { Alert, Button, Divider, Form, Input, Space, Statistic, Steps, Typography } from "antd";
+import { useState } from "react";
+import { useOrcaConnectionStatus } from "../../utils/queryOrca";
+import { getAPIURL } from "../../utils/url";
+
+const { Title, Paragraph, Text } = Typography;
+
+interface ImportResult {
+  created: number;
+  updated: number;
+  skipped: number;
+}
+
+export function OrcaSettings() {
+  const [callbackForm] = Form.useForm();
+  const [passwordForm] = Form.useForm();
+  const [connecting, setConnecting] = useState(false);
+  const [startingProvider, setStartingProvider] = useState<"google" | "apple" | null>(null);
+  const [passwordLoading, setPasswordLoading] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [result, setResult] = useState<ImportResult | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  const connectionStatus = useOrcaConnectionStatus();
+
+  const startSignIn = async (provider: "google" | "apple") => {
+    setStartingProvider(provider);
+    setConnectError(null);
+    try {
+      const resp = await fetch(`${getAPIURL()}/orca/auth/start?provider=${provider}`, { method: "POST" });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.message ?? "Could not start sign-in");
+      setSessionId(data.session_id as string);
+      window.open(data.auth_url as string, "_blank", "noopener");
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setStartingProvider(null);
+    }
+  };
+
+  const onCallbackFinish = async (values: { callback_url: string }) => {
+    if (!sessionId) return;
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const cbResp = await fetch(`${getAPIURL()}/orca/auth/callback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId, callback_url: values.callback_url.trim() }),
+      });
+      const cbData = await cbResp.json();
+      if (!cbResp.ok) throw new Error(cbData.message ?? "Sign-in failed");
+
+      setSessionId(null);
+      callbackForm.resetFields();
+      await connectionStatus.refetch();
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const onPasswordFinish = async (values: { email: string; password: string }) => {
+    setPasswordLoading(true);
+    setPasswordError(null);
+    try {
+      const resp = await fetch(`${getAPIURL()}/orca/auth/password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(values),
+      });
+      const data = await resp.json();
+      if (!resp.ok) throw new Error(data.message ?? "Sign-in failed");
+
+      passwordForm.resetFields();
+      await connectionStatus.refetch();
+    } catch (err) {
+      setPasswordError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setPasswordLoading(false);
+    }
+  };
+
+  const disconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await fetch(`${getAPIURL()}/orca/auth`, { method: "DELETE" });
+      setResult(null);
+      await connectionStatus.refetch();
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const runBulkImport = async () => {
+    setImporting(true);
+    setImportError(null);
+    setResult(null);
+    try {
+      const importResp = await fetch(`${getAPIURL()}/orca/import`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const importData = await importResp.json();
+      if (!importResp.ok) throw new Error(importData.message ?? "Import failed");
+      setResult(importData as ImportResult);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Network error");
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const resultBlock = result && (
+    <>
+      <Divider />
+      <Alert type="success" message="Import complete" showIcon style={{ maxWidth: 520, marginBottom: 16 }} />
+      <Space size="large">
+        <Statistic title="Created" value={result.created} valueStyle={{ color: "#3f8600" }} />
+        <Statistic title="Updated" value={result.updated} valueStyle={{ color: "#1677ff" }} />
+        <Statistic title="Skipped" value={result.skipped} valueStyle={{ color: "#888" }} />
+      </Space>
+      <Text type="secondary" style={{ display: "block", marginTop: 12 }}>
+        Skipped profiles are non-filament entries (printer configs, process settings, etc.)
+      </Text>
+    </>
+  );
+
+  const connected = connectionStatus.data?.connected === true;
+
+  return (
+    <>
+      <Title level={4}>
+        <CloudOutlined style={{ marginRight: 8 }} />
+        OrcaCloud
+      </Title>
+      <Paragraph type="secondary">
+        Connect Spoolman to your OrcaCloud account. Once connected, use the <Text strong>Link OrcaCloud Profile</Text>{" "}
+        button on a filament&apos;s create/edit page to assign it a synced profile and fill in matching extra fields —
+        nothing is created or changed automatically just by connecting.
+      </Paragraph>
+
+      {connected ? (
+        <Space direction="vertical" style={{ marginBottom: 16 }}>
+          <Space>
+            <CheckCircleFilled style={{ color: "#3f8600" }} />
+            <Text strong>Connected to OrcaCloud</Text>
+            <Button size="small" danger loading={disconnecting} onClick={disconnect}>
+              Disconnect
+            </Button>
+          </Space>
+        </Space>
+      ) : (
+        <>
+          <Steps
+            direction="vertical"
+            size="small"
+            style={{ maxWidth: 620 }}
+            items={[
+              {
+                title: "Sign in with Google or Apple",
+                description: (
+                  <Space style={{ marginTop: 6 }}>
+                    <Button
+                      type="primary"
+                      icon={<GoogleOutlined />}
+                      loading={startingProvider === "google"}
+                      disabled={startingProvider !== null}
+                      onClick={() => startSignIn("google")}
+                    >
+                      Sign in with Google
+                    </Button>
+                    <Button
+                      icon={<AppleFilled />}
+                      loading={startingProvider === "apple"}
+                      disabled={startingProvider !== null}
+                      onClick={() => startSignIn("apple")}
+                    >
+                      Sign in with Apple
+                    </Button>
+                  </Space>
+                ),
+              },
+              {
+                title: "Copy the URL your browser lands on",
+                description: (
+                  <Paragraph type="secondary" style={{ marginTop: 4, marginBottom: 0, maxWidth: 560 }}>
+                    After you finish signing in, the tab will try to open a <Text code>localhost:41172</Text> address
+                    and fail to load — that&apos;s expected, nothing needs to be running there. Copy the{" "}
+                    <Text strong>full URL</Text> from the address bar (it contains an auth code).
+                  </Paragraph>
+                ),
+              },
+              {
+                title: "Paste it here to connect",
+                description: (
+                  <Form form={callbackForm} onFinish={onCallbackFinish} style={{ marginTop: 8, maxWidth: 560 }}>
+                    <Form.Item name="callback_url" rules={[{ required: true, message: "Paste the callback URL" }]}>
+                      <Input
+                        placeholder="http://localhost:41172/callback?code=…"
+                        autoComplete="off"
+                        disabled={!sessionId}
+                      />
+                    </Form.Item>
+                    <Form.Item style={{ marginBottom: 0 }}>
+                      <Button type="primary" htmlType="submit" loading={connecting} disabled={!sessionId}>
+                        {connecting ? "Connecting…" : "Connect"}
+                      </Button>
+                    </Form.Item>
+                  </Form>
+                ),
+              },
+            ]}
+          />
+
+          {connectError && (
+            <Alert
+              type="error"
+              message="Connection failed"
+              description={connectError}
+              showIcon
+              style={{ maxWidth: 520, marginTop: 8 }}
+            />
+          )}
+
+          <Divider>or</Divider>
+
+          <Title level={5}>Sign in with email and password</Title>
+          <Paragraph type="secondary" style={{ maxWidth: 520 }}>
+            No browser redirect needed for this one — just your OrcaCloud account credentials.
+          </Paragraph>
+          <Form form={passwordForm} layout="vertical" onFinish={onPasswordFinish} style={{ maxWidth: 400 }}>
+            <Form.Item name="email" rules={[{ required: true, type: "email", message: "Enter your email" }]}>
+              <Input placeholder="Email" autoComplete="username" />
+            </Form.Item>
+            <Form.Item name="password" rules={[{ required: true, message: "Enter your password" }]}>
+              <Input.Password placeholder="Password" autoComplete="current-password" />
+            </Form.Item>
+            <Form.Item style={{ marginBottom: 0 }}>
+              <Button type="primary" htmlType="submit" loading={passwordLoading}>
+                {passwordLoading ? "Signing in…" : "Sign in"}
+              </Button>
+            </Form.Item>
+          </Form>
+
+          {passwordError && (
+            <Alert
+              type="error"
+              message="Sign-in failed"
+              description={passwordError}
+              showIcon
+              style={{ maxWidth: 520, marginTop: 8 }}
+            />
+          )}
+        </>
+      )}
+
+      <Divider />
+
+      <Title level={5}>Bulk import</Title>
+      <Paragraph type="secondary" style={{ maxWidth: 620 }}>
+        Creates or updates a Spoolman filament for <Text strong>every</Text> synced OrcaCloud profile at once, matched
+        by Orca UUID. This is an all-or-nothing action, separate from linking individual filaments above — most people
+        want the per-filament picker instead.
+      </Paragraph>
+      <Button icon={<CloudDownloadOutlined />} loading={importing} disabled={!connected} onClick={runBulkImport}>
+        {importing ? "Importing…" : "Import all profiles as filaments"}
+      </Button>
+
+      {importError && (
+        <Alert
+          type="error"
+          message="Import failed"
+          description={importError}
+          showIcon
+          style={{ maxWidth: 520, marginTop: 8 }}
+        />
+      )}
+
+      {resultBlock}
+    </>
+  );
+}

--- a/client/src/utils/queryOrca.ts
+++ b/client/src/utils/queryOrca.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAPIURL } from "./url";
+
+export interface OrcaProfileField {
+  key: string;
+  name: string;
+  field_type: string;
+  unit?: string;
+}
+
+export function useOrcaProfileFields() {
+  return useQuery<OrcaProfileField[]>({
+    queryKey: ["orca", "profile-fields"],
+    queryFn: async () => {
+      const response = await fetch(`${getAPIURL()}/orca/profile-fields`);
+      return response.json();
+    },
+    staleTime: Infinity, // static list, never refetch
+  });
+}
+
+export interface OrcaFilamentProfileSummary {
+  // Cloud sync row UUID — identity for the picker's Select, NOT the orca_filament_id value.
+  orca_id: string;
+  filament_id?: string | null;
+  setting_id?: string | null;
+  name: string;
+  vendor?: string | null;
+  material?: string | null;
+  color_hex?: string | null;
+  // Full raw OrcaSlicer profile content, keyed by OrcaSlicer field name (e.g. "flow_ratio"),
+  // for matching against whatever extra fields the user has defined. Values are typically
+  // single-element arrays (OrcaSlicer's per-layer-override format), same as /orca/import uses.
+  content: Record<string, unknown>;
+}
+
+/**
+ * Whether Spoolman has a persisted OrcaCloud sign-in (from a prior Settings -> OrcaCloud
+ * "Sign in with Google" flow) that useOrcaFilamentProfiles can reuse.
+ */
+export function useOrcaConnectionStatus() {
+  return useQuery<{ connected: boolean }>({
+    queryKey: ["orca", "auth-status"],
+    queryFn: async () => {
+      const response = await fetch(`${getAPIURL()}/orca/auth/status`);
+      return response.json();
+    },
+  });
+}
+
+/**
+ * Synced OrcaCloud filament profiles, for a picker UI. Only fetches while `enabled` is true,
+ * since opening the picker is what should trigger the (potentially slow, paginated) cloud fetch.
+ */
+export function useOrcaFilamentProfiles(enabled: boolean) {
+  return useQuery<OrcaFilamentProfileSummary[]>({
+    queryKey: ["orca", "profiles"],
+    queryFn: async () => {
+      const response = await fetch(`${getAPIURL()}/orca/profiles`);
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.message ?? "Failed to fetch OrcaCloud profiles");
+      }
+      return response.json();
+    },
+    enabled,
+    staleTime: 60_000,
+    retry: false,
+  });
+}

--- a/spoolman/api/v1/orca.py
+++ b/spoolman/api/v1/orca.py
@@ -1,0 +1,484 @@
+"""OrcaCloud integration endpoints."""
+
+import json
+import logging
+import secrets
+import time
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from spoolman import orca_cloud
+from spoolman.api.v1.models import Message
+from spoolman.database import filament as filament_db
+from spoolman.database import setting as setting_db
+from spoolman.database import vendor as vendor_db
+from spoolman.database.database import get_db_session
+from spoolman.exceptions import ItemNotFoundError
+from spoolman.extra_fields import EntityType as ExtraEntityType
+from spoolman.extra_fields import get_extra_fields
+from spoolman.settings import SettingDefinition, SettingType
+
+# ruff: noqa: D103
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(
+    prefix="/orca",
+    tags=["orca"],
+)
+
+# ── In-memory OAuth session store ─────────────────────────────────────────────
+# Keys are random session IDs; values hold PKCE state and the resolved tokens.
+# Fine for single-instance home use; sessions are cleaned up after use.
+_sessions: dict[str, dict] = {}
+
+# ── Persisted OrcaCloud sign-in ───────────────────────────────────────────────
+# Deliberately NOT registered via settings.register_setting(): that registry
+# backs the public GET/POST /setting/ endpoints, which would otherwise expose
+# these refresh/access tokens to anyone who can reach the API. Storing it
+# through the same Setting table/DB row mechanism (unregistered key) keeps
+# persistence but stays invisible to that generic surface — setting.py's
+# get/update only need a SettingDefinition, not registry membership, and the
+# /setting/ list/get endpoints silently skip unregistered keys.
+_TOKEN_SETTING = SettingDefinition(key="orca_cloud_tokens", type=SettingType.OBJECT, default=json.dumps({}))
+
+
+async def _load_tokens(db: AsyncSession) -> dict | None:
+    """Return the persisted OrcaCloud tokens, or None if never connected."""
+    try:
+        row = await setting_db.get(db, _TOKEN_SETTING)
+    except ItemNotFoundError:
+        return None
+    data = json.loads(row.value)
+    return data or None
+
+
+async def _save_tokens(db: AsyncSession, access_token: str, refresh_token: str, expires_in: int) -> None:
+    payload = {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "expires_at": time.time() + expires_in,
+    }
+    await setting_db.update(db=db, definition=_TOKEN_SETTING, value=json.dumps(payload))
+    await db.commit()
+
+
+async def _get_valid_access_token(db: AsyncSession) -> str | None:
+    """Return a usable OrcaCloud access token, refreshing it if it's expired.
+
+    Returns None if Spoolman has never completed a sign-in, or if the stored
+    refresh token has itself expired/been revoked (user needs to sign in
+    again via Settings → OrcaCloud).
+    """
+    tokens = await _load_tokens(db)
+    if not tokens:
+        return None
+
+    # Refresh a little early to avoid racing an in-flight request's expiry.
+    if tokens["expires_at"] - 60 > time.time():
+        return tokens["access_token"]
+
+    try:
+        refreshed = await orca_cloud.refresh_access_token(tokens["refresh_token"])
+    except orca_cloud.OrcaAuthError:
+        logger.warning("OrcaCloud token refresh failed — user will need to sign in again")
+        return None
+
+    await _save_tokens(db, refreshed["access_token"], refreshed["refresh_token"], refreshed["expires_in"])
+    return refreshed["access_token"]
+
+
+# ── Request / response models ──────────────────────────────────────────────────
+
+
+class OrcaImportRequest(BaseModel):
+    session_id: str | None = Field(
+        None,
+        description="OAuth session ID returned by /orca/auth/start, after /orca/auth/callback has completed it.",
+    )
+    access_token: str | None = Field(None, description="Raw OrcaCloud access token.")
+    # If neither is given, falls back to the persisted sign-in from a prior /orca/auth/callback.
+
+
+class OrcaImportResponse(BaseModel):
+    created: int = Field(description="Number of new filament profiles created in Spoolman.")
+    updated: int = Field(description="Number of existing filament profiles updated in Spoolman.")
+    skipped: int = Field(description="Number of cloud profiles skipped (not filament profiles).")
+
+
+class OrcaAuthStartResponse(BaseModel):
+    auth_url: str = Field(description="URL to open in the browser for Google sign-in.")
+    session_id: str = Field(description="Session ID to pass to /orca/auth/callback and /orca/import.")
+
+
+class OrcaAuthCallbackRequest(BaseModel):
+    session_id: str = Field(description="Session ID returned by /orca/auth/start.")
+    callback_url: str = Field(
+        description=(
+            "The URL the browser landed on after sign-in completed (it will fail to load — "
+            "that's expected). Copy it from the address bar."
+        ),
+    )
+
+
+class OrcaAuthStatusResponse(BaseModel):
+    status: str = Field(description="'complete' or 'error'.")
+    message: str | None = Field(None, description="Error message if status is 'error'.")
+
+
+class OrcaProfileField(BaseModel):
+    key: str
+    name: str
+    field_type: str
+    unit: str | None = None
+
+
+class OrcaConnectionStatusResponse(BaseModel):
+    connected: bool = Field(description="Whether Spoolman has a stored OrcaCloud sign-in it can reuse.")
+
+
+class OrcaFilamentProfileSummary(BaseModel):
+    orca_id: str = Field(description="Cloud sync row UUID — identity for the picker, NOT the orca_filament_id value.")
+    filament_id: str | None = Field(
+        None,
+        description="Raw filament_id from profile content, for the orca_filament_id extra field.",
+    )
+    setting_id: str | None = Field(None, description="Raw filament_settings_id, for the orca_setting_id extra field.")
+    name: str
+    vendor: str | None = None
+    material: str | None = None
+    color_hex: str | None = None
+    content: dict = Field(
+        default_factory=dict,
+        description=(
+            "Full raw OrcaSlicer profile content, so a client can match it against whatever "
+            "extra fields the user has defined (same key-matching /orca/import uses), without "
+            "Spoolman itself deciding which fields to write."
+        ),
+    )
+
+
+class OrcaPasswordLoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────────
+
+
+@router.get(
+    "/profile-fields",
+    summary="List mappable OrcaSlicer filament profile fields",
+    description=(
+        "Returns a curated list of OrcaSlicer filament profile fields that can be mapped to "
+        "Spoolman extra fields. Once an extra field key matches a profile field key, the import "
+        "endpoint will automatically populate it from the OrcaSlicer profile data."
+    ),
+)
+async def get_profile_fields() -> list[OrcaProfileField]:
+    return [OrcaProfileField(**f) for f in orca_cloud.ORCA_PROFILE_FIELDS]
+
+
+@router.post(
+    "/auth/start",
+    response_model=OrcaAuthStartResponse,
+    responses={400: {"model": Message}},
+    summary="Start Google/Apple OAuth login flow",
+    description=(
+        "Generates PKCE parameters and returns the OrcaCloud sign-in URL for the given provider "
+        "('google' or 'apple', default 'google'). Open the URL in the browser and complete "
+        "sign-in. It will redirect to a localhost:41172 URL that fails to load — that's "
+        "expected, nothing needs to be listening there. Copy that URL from the address bar and "
+        "pass it to /orca/auth/callback."
+    ),
+)
+async def auth_start(provider: str = "google") -> OrcaAuthStartResponse | JSONResponse:
+    if provider not in orca_cloud.OAUTH_PROVIDERS:
+        return JSONResponse(
+            status_code=400,
+            content={"message": f"Unknown provider {provider!r}. Must be one of {orca_cloud.OAUTH_PROVIDERS}."},
+        )
+
+    session_id = secrets.token_hex(16)
+    code_verifier, code_challenge = orca_cloud.generate_pkce()
+
+    _sessions[session_id] = {
+        "code_verifier": code_verifier,
+        "status": "pending",
+        "access_token": None,
+        "error": None,
+    }
+
+    auth_url = orca_cloud.get_oauth_url(provider, code_challenge)
+    return OrcaAuthStartResponse(auth_url=auth_url, session_id=session_id)
+
+
+@router.post(
+    "/auth/callback",
+    response_model=OrcaAuthStatusResponse,
+    responses={400: {"model": Message}, 401: {"model": Message}},
+    summary="Complete Google OAuth login using a pasted callback URL",
+    description=(
+        "Extracts the auth code from the callback URL the user copied out of their browser's "
+        "address bar, and exchanges it for an OrcaCloud access token. On success, the session "
+        "is ready for /orca/import, and the sign-in is also persisted so /orca/profiles can "
+        "reuse it later without going through this flow again."
+    ),
+)
+async def auth_callback(
+    body: OrcaAuthCallbackRequest,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> OrcaAuthStatusResponse | JSONResponse:
+    session = _sessions.get(body.session_id)
+    if session is None:
+        return JSONResponse(status_code=400, content={"message": "Session not found or already used."})
+
+    code, _state = orca_cloud.parse_callback_url(body.callback_url)
+    if not code:
+        return JSONResponse(
+            status_code=400,
+            content={"message": "No auth code found in that URL — make sure you copied the full address."},
+        )
+    # _state is GoTrue's own opaque state value, not one we generated (see
+    # get_oauth_url) — nothing to compare it against.
+
+    try:
+        tokens = await orca_cloud.exchange_pkce_code(code, session["code_verifier"])
+    except orca_cloud.OrcaAuthError as exc:
+        session["status"] = "error"
+        session["error"] = str(exc)
+        return JSONResponse(status_code=401, content={"message": str(exc)})
+
+    session["access_token"] = tokens["access_token"]
+    session["status"] = "complete"
+    await _save_tokens(db, tokens["access_token"], tokens["refresh_token"], tokens["expires_in"])
+    return OrcaAuthStatusResponse(status="complete")
+
+
+@router.post(
+    "/auth/password",
+    response_model=OrcaAuthStatusResponse,
+    responses={401: {"model": Message}},
+    summary="Sign in to OrcaCloud with email and password",
+    description=(
+        "Direct email/password sign-in — unlike Google/Apple, this is a single API call with no "
+        "browser redirect or pasted-URL step. On success, persists the connection the same way "
+        "as /orca/auth/callback."
+    ),
+)
+async def auth_password(
+    body: OrcaPasswordLoginRequest,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> OrcaAuthStatusResponse | JSONResponse:
+    try:
+        tokens = await orca_cloud.exchange_password(body.email, body.password)
+    except orca_cloud.OrcaAuthError as exc:
+        return JSONResponse(status_code=401, content={"message": str(exc)})
+
+    await _save_tokens(db, tokens["access_token"], tokens["refresh_token"], tokens["expires_in"])
+    return OrcaAuthStatusResponse(status="complete")
+
+
+@router.get(
+    "/auth/status",
+    summary="Check whether Spoolman has a stored OrcaCloud sign-in",
+    description=(
+        "Reports whether a previous /orca/auth/callback has left a reusable sign-in persisted, "
+        "so callers (e.g. a profile picker) can tell whether /orca/profiles will work without "
+        "prompting the user to go through Settings → OrcaCloud first."
+    ),
+)
+async def auth_status(db: Annotated[AsyncSession, Depends(get_db_session)]) -> OrcaConnectionStatusResponse:
+    tokens = await _load_tokens(db)
+    return OrcaConnectionStatusResponse(connected=tokens is not None)
+
+
+@router.get(
+    "/profiles",
+    response_model=list[OrcaFilamentProfileSummary],
+    responses={401: {"model": Message}},
+    summary="List synced OrcaCloud filament profiles",
+    description=(
+        "Fetches the user's synced OrcaCloud filament profiles using the persisted sign-in from "
+        "a prior /orca/auth/callback. Intended for a picker UI to fill in a single filament's "
+        "orca_filament_id/orca_setting_id extra fields, as an alternative to the bulk /orca/import."
+    ),
+)
+async def list_profiles(
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> list[OrcaFilamentProfileSummary] | JSONResponse:
+    access_token = await _get_valid_access_token(db)
+    if access_token is None:
+        return JSONResponse(
+            status_code=401,
+            content={"message": "Not connected to OrcaCloud. Sign in from Settings → OrcaCloud first."},
+        )
+
+    raw_profiles = await orca_cloud.fetch_profiles(access_token)
+    summaries: list[OrcaFilamentProfileSummary] = []
+    for raw in raw_profiles:
+        profile = orca_cloud.parse_filament_profile(raw)
+        if profile is None:
+            continue
+        summaries.append(
+            OrcaFilamentProfileSummary(
+                orca_id=profile.orca_id,
+                filament_id=profile.filament_id,
+                setting_id=profile.setting_id,
+                name=profile.name,
+                vendor=profile.vendor,
+                material=profile.material,
+                color_hex=profile.color_hex,
+                content=profile.content,
+            ),
+        )
+    return summaries
+
+
+@router.delete(
+    "/auth",
+    summary="Forget the stored OrcaCloud sign-in",
+    description=(
+        "Clears the persisted access/refresh token. You'll need to sign in again before "
+        "/orca/profiles or /orca/import will work without passing an explicit access_token."
+    ),
+)
+async def auth_disconnect(db: Annotated[AsyncSession, Depends(get_db_session)]) -> Message:
+    try:
+        await setting_db.delete(db=db, definition=_TOKEN_SETTING)
+        await db.commit()
+    except ItemNotFoundError:
+        pass
+    return Message(message="Disconnected from OrcaCloud.")
+
+
+@router.post(
+    "/import",
+    response_model=OrcaImportResponse,
+    responses={400: {"model": Message}, 401: {"model": Message}},
+    summary="Import filament profiles from OrcaCloud",
+    description=(
+        "Fetches all synced filament profiles and imports them into Spoolman, creating or "
+        "updating a filament for EVERY synced profile. This is a bulk, all-or-nothing action — "
+        "for linking one profile to one existing filament, use GET /orca/profiles with a picker "
+        "UI instead. Pass a session_id from a completed /orca/auth/callback, or a raw "
+        "access_token directly; if neither is given, falls back to the persisted sign-in. "
+        "Profiles are matched by their Orca UUID (external_id 'orca:{uuid}') — existing ones are "
+        "updated, new ones created. Any defined filament extra field whose key matches an "
+        "OrcaSlicer profile content key is populated automatically."
+    ),
+)
+async def import_from_orca(
+    body: OrcaImportRequest,
+    db: Annotated[AsyncSession, Depends(get_db_session)],
+) -> OrcaImportResponse | JSONResponse:
+    # Resolve access token from whichever auth method was used
+    if body.access_token:
+        access_token = body.access_token
+    elif body.session_id:
+        session = _sessions.pop(body.session_id, None)
+        if session is None:
+            return JSONResponse(status_code=400, content={"message": "Session not found or already used."})
+        if session["status"] != "complete" or not session["access_token"]:
+            return JSONResponse(status_code=401, content={"message": session.get("error") or "OAuth login incomplete."})
+        access_token = session["access_token"]
+    else:
+        access_token = await _get_valid_access_token(db)
+        if access_token is None:
+            return JSONResponse(
+                status_code=401,
+                content={"message": "Not connected to OrcaCloud. Sign in from Settings → OrcaCloud first."},
+            )
+
+    return await _do_import(access_token, db)
+
+
+def _build_profile_extras(profile: orca_cloud.OrcaFilamentProfile, defined_field_map: dict) -> dict[str, str]:
+    """Build the extra-field values for a profile: its Orca IDs plus defined fields matching profile content."""
+    orca_extras: dict[str, str] = {}
+    if profile.filament_id is not None:
+        orca_extras["orca_filament_id"] = profile.filament_id
+    if profile.setting_id is not None:
+        orca_extras["orca_setting_id"] = profile.setting_id
+
+    for field_key, field_def in defined_field_map.items():
+        if field_key in orca_extras:
+            continue
+        raw_val = profile.content.get(field_key)
+        if raw_val is None:
+            continue
+        encoded = orca_cloud.encode_profile_value(raw_val, field_def.field_type.value)
+        if encoded is not None:
+            orca_extras[field_key] = encoded
+
+    return orca_extras
+
+
+async def _do_import(access_token: str, db: AsyncSession) -> OrcaImportResponse:
+    raw_profiles = await orca_cloud.fetch_profiles(access_token)
+    logger.info("Fetched %d profiles from OrcaCloud", len(raw_profiles))
+
+    defined_fields = await get_extra_fields(db, ExtraEntityType.filament)
+    defined_field_map = {f.key: f for f in defined_fields}
+
+    created = updated = skipped = 0
+
+    for raw in raw_profiles:
+        profile = orca_cloud.parse_filament_profile(raw)
+        if profile is None:
+            skipped += 1
+            continue
+
+        external_id = f"orca:{profile.orca_id}"
+        density = profile.density or 1.24
+        diameter = profile.diameter or 1.75
+        orca_extras = _build_profile_extras(profile, defined_field_map)
+
+        vendor_id: int | None = None
+        if profile.vendor:
+            vendors, _ = await vendor_db.find(db=db, name=profile.vendor)
+            vendor_id = vendors[0].id if vendors else (await vendor_db.create(db=db, name=profile.vendor)).id
+
+        existing, _ = await filament_db.find(db=db, external_id=external_id)
+
+        if existing:
+            merged_extras = {f.key: f.value for f in existing[0].extra}
+            merged_extras.update(orca_extras)
+            await filament_db.update(
+                db=db,
+                filament_id=existing[0].id,
+                data={
+                    "name": profile.name,
+                    "vendor_id": vendor_id,
+                    "material": profile.material,
+                    "density": density,
+                    "diameter": diameter,
+                    "settings_extruder_temp": profile.extruder_temp,
+                    "settings_bed_temp": profile.bed_temp,
+                    "color_hex": profile.color_hex,
+                    "extra": merged_extras,
+                },
+            )
+            updated += 1
+        else:
+            await filament_db.create(
+                db=db,
+                name=profile.name,
+                vendor_id=vendor_id,
+                material=profile.material,
+                density=density,
+                diameter=diameter,
+                settings_extruder_temp=profile.extruder_temp,
+                settings_bed_temp=profile.bed_temp,
+                color_hex=profile.color_hex,
+                external_id=external_id,
+                extra=orca_extras,
+            )
+            created += 1
+
+    logger.info("OrcaCloud import: %d created, %d updated, %d skipped", created, updated, skipped)
+    return OrcaImportResponse(created=created, updated=updated, skipped=skipped)

--- a/spoolman/api/v1/router.py
+++ b/spoolman/api/v1/router.py
@@ -15,7 +15,7 @@ from spoolman.database.database import backup_global_db
 from spoolman.exceptions import ItemNotFoundError
 from spoolman.ws import websocket_manager
 
-from . import export, externaldb, field, filament, models, other, setting, spool, vendor
+from . import export, externaldb, field, filament, models, orca, other, setting, spool, vendor
 
 logger = logging.getLogger(__name__)
 
@@ -112,3 +112,4 @@ app.include_router(field.router)
 app.include_router(other.router)
 app.include_router(externaldb.router)
 app.include_router(export.router)
+app.include_router(orca.router)

--- a/spoolman/orca_cloud.py
+++ b/spoolman/orca_cloud.py
@@ -1,0 +1,330 @@
+"""OrcaCloud API client for fetching synced filament profiles."""
+
+import base64
+import hashlib
+import json
+import logging
+import secrets
+from http import HTTPStatus
+from typing import Any
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+ORCA_AUTH_URL = "https://auth.orcaslicer.com"
+ORCA_API_URL = "https://api.orcaslicer.com"
+# Supabase publishable key embedded in OrcaSlicer source (OrcaCloudServiceAgent.cpp)
+ORCA_API_KEY = "sb_publishable_lvVe_whOi80SU9BPSxM1kA_tbt9AbR_"
+
+# Loopback redirect target. Supabase's redirect_to allowlist on Orca's project
+# only honors http://localhost:* URIs, so we can't point it at Spoolman's own
+# origin. Nothing needs to listen on this port — the browser will fail to load
+# it, and the user copies the resulting URL (which carries ?code=...) out of
+# the address bar instead.
+#
+# 41172 matches auth_constants::LOOPBACK_PORT in OrcaSlicer's own
+# OrcaCloudServiceAgent.cpp (also used by the Bambuddy project's confirmed-
+# working third-party integration) — if the real OrcaSlicer desktop app is
+# running at the same time, its own background listener on this port could in
+# theory intercept our redirect first, but that's a real client conflict
+# rather than an allowlist problem, and 41172 is the one value known to
+# actually be allow-listed.
+ORCA_CALLBACK_PORT = 41172
+ORCA_CALLBACK_PATH = "/callback"
+
+_HEADERS = {"apikey": ORCA_API_KEY, "Content-Type": "application/json"}
+
+
+class OrcaAuthError(Exception):
+    pass
+
+
+# ── PKCE helpers ───────────────────────────────────────────────────────────────
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE OAuth flow."""
+    code_verifier = base64.urlsafe_b64encode(secrets.token_bytes(32)).rstrip(b"=").decode()
+    digest = hashlib.sha256(code_verifier.encode()).digest()
+    code_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return code_verifier, code_challenge
+
+
+OAUTH_PROVIDERS = ("google", "apple")
+
+
+def get_oauth_url(provider: str, code_challenge: str) -> str:
+    """Build the OrcaCloud OAuth authorize URL for the given provider (google or apple).
+
+    Deliberately does NOT send a "state" param: GoTrue uses that query param
+    itself to store its own auth flow bookkeeping (redirect_to, code
+    challenge reference, provider) and reads it back on the callback. A
+    client-supplied state value collides with and corrupts that, and GoTrue
+    rejects the callback with error_code=bad_oauth_state ("OAuth state not
+    found or expired") — confirmed by a Supabase maintainer:
+    https://github.com/supabase/auth/issues/1548#issuecomment-2102402926
+    """
+    params = {
+        "provider": provider,
+        "redirect_to": f"http://localhost:{ORCA_CALLBACK_PORT}{ORCA_CALLBACK_PATH}",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{ORCA_AUTH_URL}/auth/v1/authorize?{urlencode(params)}"
+
+
+def parse_callback_url(callback_url: str) -> tuple[str | None, str | None]:
+    """Extract (code, state) from a callback URL the user pasted back from their browser.
+
+    Checks both the query string and the fragment — Supabase puts the PKCE
+    code in the query string for this flow, but we tolerate a fragment too
+    in case that ever changes.
+    """
+    parsed = urlparse(callback_url.strip())
+    qsd = parse_qs(parsed.query)
+    code = (qsd.get("code") or [None])[0]
+    state = (qsd.get("state") or [None])[0]
+    if not code:
+        frag = parse_qs(parsed.fragment)
+        code = (frag.get("code") or [None])[0]
+        state = state or (frag.get("state") or [None])[0]
+    return code, state
+
+
+async def exchange_pkce_code(auth_code: str, code_verifier: str) -> dict[str, Any]:
+    """Exchange a PKCE auth code for OrcaCloud access/refresh tokens."""
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{ORCA_AUTH_URL}/auth/v1/token",
+            params={"grant_type": "pkce"},
+            headers=_HEADERS,
+            json={"auth_code": auth_code, "code_verifier": code_verifier},
+            timeout=30,
+        )
+    if resp.status_code != HTTPStatus.OK:
+        raise OrcaAuthError(f"Token exchange failed ({resp.status_code}): {resp.text}")
+    data = resp.json()
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", ""),
+        "expires_in": data.get("expires_in", 3600),
+    }
+
+
+async def refresh_access_token(refresh_token: str) -> dict[str, Any]:
+    """Exchange a refresh token for a new OrcaCloud access token.
+
+    Supabase rotates refresh tokens on every use, so the caller must persist
+    the new refresh_token returned here — the old one becomes invalid.
+    """
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{ORCA_AUTH_URL}/auth/v1/token",
+            params={"grant_type": "refresh_token"},
+            headers=_HEADERS,
+            json={"refresh_token": refresh_token},
+            timeout=30,
+        )
+    if resp.status_code != HTTPStatus.OK:
+        raise OrcaAuthError(f"Token refresh failed ({resp.status_code}): {resp.text}")
+    data = resp.json()
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", refresh_token),
+        "expires_in": data.get("expires_in", 3600),
+    }
+
+
+async def exchange_password(email: str, password: str) -> dict[str, Any]:
+    """Exchange an OrcaCloud email/password for access/refresh tokens.
+
+    Unlike the Google/Apple OAuth flow, this is a direct API call — no
+    browser redirect or pasted-URL step needed.
+    """
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            f"{ORCA_AUTH_URL}/auth/v1/token",
+            params={"grant_type": "password"},
+            headers=_HEADERS,
+            json={"email": email, "password": password},
+            timeout=30,
+        )
+    if resp.status_code != HTTPStatus.OK:
+        raise OrcaAuthError(f"Sign-in failed ({resp.status_code}): {resp.text}")
+    data = resp.json()
+    return {
+        "access_token": data["access_token"],
+        "refresh_token": data.get("refresh_token", ""),
+        "expires_in": data.get("expires_in", 3600),
+    }
+
+
+# Curated list of OrcaSlicer filament profile fields that can be mapped to Spoolman extra fields.
+# field_type values match Spoolman's ExtraFieldType enum.
+ORCA_PROFILE_FIELDS: list[dict] = [
+    {"key": "flow_ratio", "name": "Flow Ratio", "field_type": "float", "unit": None},
+    {"key": "fan_min_speed", "name": "Min Fan Speed", "field_type": "integer", "unit": "%"},
+    {"key": "fan_max_speed", "name": "Max Fan Speed", "field_type": "integer", "unit": "%"},
+    {"key": "close_fan_the_first_x_layers", "name": "Close Fan First X Layers", "field_type": "integer", "unit": None},
+    {"key": "full_fan_speed_layer", "name": "Full Fan Speed Layer", "field_type": "integer", "unit": None},
+    {"key": "chamber_temperature", "name": "Chamber Temperature", "field_type": "integer", "unit": "°C"},
+    {"key": "filament_max_volumetric_speed", "name": "Max Volumetric Speed", "field_type": "float", "unit": "mm³/s"},
+    {"key": "filament_cost", "name": "Filament Cost", "field_type": "float", "unit": None},
+    {
+        "key": "filament_minimal_purge_on_wipe_tower",
+        "name": "Min Purge on Wipe Tower",
+        "field_type": "float",
+        "unit": "g",
+    },
+    {"key": "filament_wipe_distance", "name": "Wipe Distance", "field_type": "float", "unit": "mm"},
+    {"key": "filament_retraction_length", "name": "Retraction Length", "field_type": "float", "unit": "mm"},
+    {"key": "filament_retract_speed", "name": "Retraction Speed", "field_type": "float", "unit": "mm/s"},
+    {"key": "filament_deretraction_speed", "name": "Deretraction Speed", "field_type": "float", "unit": "mm/s"},
+]
+
+
+def encode_profile_value(raw_value: object, field_type: str) -> str | None:
+    """Extract a value from a raw OrcaSlicer profile field and JSON-encode it for Spoolman storage."""
+    if field_type in ("float", "float_range"):
+        v = _first_float(raw_value)
+        return json.dumps(v) if v is not None else None
+    if field_type in ("integer", "integer_range"):
+        v = _first_int(raw_value)
+        return json.dumps(v) if v is not None else None
+    if field_type == "boolean":
+        s = _first_str(raw_value)
+        if s is None:
+            return None
+        return json.dumps(s not in ("0", "false", ""))
+    # text / choice
+    s = _first_str(raw_value)
+    return json.dumps(s) if s is not None else None
+
+
+class OrcaFilamentProfile(BaseModel):
+    orca_id: str  # cloud sync row UUID — internal identity, NOT the same as filament_id below
+    name: str
+    filament_id: str | None  # raw filament_id from profile content (e.g. "P6f52551") — OrcaSlicer's own base-preset id
+    setting_id: str | None  # raw filament_settings_id from profile content
+    vendor: str | None
+    material: str | None
+    density: float | None
+    diameter: float | None
+    extruder_temp: int | None
+    bed_temp: int | None
+    color_hex: str | None
+    content: dict = {}  # full raw profile content for dynamic extra field population
+
+
+def _first_str(val: object) -> str | None:
+    """Return the first element of a list as a string, or the value itself if already a string."""
+    if isinstance(val, list):
+        return str(val[0]) if val else None
+    if isinstance(val, str):
+        return val or None
+    return None
+
+
+def _first_float(val: object) -> float | None:
+    s = _first_str(val)
+    if s is None:
+        return None
+    try:
+        return float(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _first_int(val: object) -> int | None:
+    f = _first_float(val)
+    return int(f) if f is not None else None
+
+
+async def fetch_profiles(access_token: str) -> list[dict]:
+    """Fetch all synced profiles from OrcaCloud, paginating via cursor."""
+    profiles: list[dict] = []
+    cursor: int | None = None
+    reset_done = False
+    auth_headers = {**_HEADERS, "Authorization": f"Bearer {access_token}"}
+
+    async with httpx.AsyncClient() as client:
+        while True:
+            params: dict = {}
+            if cursor is not None:
+                params["cursor"] = cursor
+
+            resp = await client.get(
+                f"{ORCA_API_URL}/api/v1/sync/pull",
+                params=params,
+                headers=auth_headers,
+                timeout=30,
+            )
+
+            if resp.status_code == HTTPStatus.NOT_MODIFIED:
+                break
+            if resp.status_code == HTTPStatus.GONE:
+                # Cursor expired — restart from the beginning (only once)
+                if reset_done:
+                    logger.error("OrcaCloud sync cursor expired again after reset, aborting")
+                    break
+                logger.warning("OrcaCloud sync cursor expired, restarting full sync")
+                cursor = None
+                reset_done = True
+                continue
+
+            resp.raise_for_status()
+            data = resp.json()
+            profiles.extend(data.get("upserts", []))
+            next_cursor = data.get("next_cursor")
+            if next_cursor is None or next_cursor == cursor:
+                break
+            cursor = next_cursor
+
+    return profiles
+
+
+def parse_filament_profile(profile: dict) -> OrcaFilamentProfile | None:
+    """Parse a raw sync entry into an OrcaFilamentProfile.
+
+    Returns None if the entry is not a filament profile.
+    """
+    content = profile.get("content", {})
+    if not isinstance(content, dict):
+        return None
+    # Filament profiles always carry one of these keys; skip printer/process profiles
+    if "filament_type" not in content and "filament_density" not in content:
+        return None
+
+    filament_id = _first_str(content.get("filament_id"))
+    setting_id = _first_str(content.get("filament_settings_id"))
+    name = (setting_id or profile.get("name") or "Unknown")[:64]
+    vendor = _first_str(content.get("filament_vendor"))
+    material = _first_str(content.get("filament_type"))
+    density = _first_float(content.get("filament_density"))
+    diameter = _first_float(content.get("filament_diameter"))
+
+    extruder_temp = _first_int(content.get("nozzle_temperature")) or _first_int(
+        content.get("nozzle_temperature_range_high")
+    )
+    bed_temp = _first_int(content.get("bed_temperature")) or _first_int(content.get("hot_plate_temp"))
+
+    color_raw = _first_str(content.get("filament_colour"))
+    color_hex = color_raw.lstrip("#").upper() if color_raw else None
+
+    return OrcaFilamentProfile(
+        orca_id=profile["id"],
+        name=name,
+        filament_id=filament_id,
+        setting_id=setting_id,
+        vendor=vendor,
+        material=material,
+        density=density,
+        diameter=diameter,
+        extruder_temp=extruder_temp,
+        bed_temp=bed_temp,
+        color_hex=color_hex,
+        content=content,
+    )


### PR DESCRIPTION
Adds an integration with Orca Cloud (cloud.orcaslicer.com) so filaments in Spoolman can be linked to the user's synced OrcaSlicer filament profiles.

Auth (Settings -> OrcaCloud):
- Google/Apple sign-in via OrcaCloud's Supabase PKCE flow. The project's redirect allowlist only honors http://localhost:*, so after sign-in the user copies the resulting localhost callback URL out of the address bar and pastes it back in (same approach other third-party integrations use).
- Direct email/password sign-in as a no-redirect alternative.
- The access/refresh token pair is persisted (auto-refreshed on expiry) so sign-in is a one-time step. Tokens are stored via the Setting table but deliberately not registered as a public setting, so the generic /setting API cannot read them. A disconnect endpoint clears them.

Linking (filament create/edit pages):
- A "Link OrcaCloud Profile" button opens a searchable picker of the user's synced profiles. Picking one fills in any defined extra field whose key matches a field in the profile (e.g. orca_filament_id, orca_setting_id, flow_ratio, ...) and changes nothing else.
- The linked profile name is displayed on the filament show/create/edit pages, read from the stored extra fields (works offline).
- The extra-fields settings page gets a quick-fill dropdown of curated OrcaSlicer profile fields to make defining matching extra fields easy.

Bulk import (Settings -> OrcaCloud): optionally create/update a filament for every synced profile at once, matched by Orca UUID (external_id orca:{uuid}) so re-importing updates instead of duplicating.

Also fixes a latent Form.Item bug on the extra-fields settings page where rendering a sibling element next to the key input inside one Form.Item silently broke the input's value binding.