### PR TITLE
fix: ignore Kubernetes service-link value in SPOOLMAN_PORT

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,17 @@ fail() {
     exit 1
 }
 
+# Kubernetes sets a Docker-style "service link" variable for every Service that
+# exists in the namespace when the pod starts, so a Service named "spoolman"
+# makes SPOOLMAN_PORT=tcp://<clusterIP>:8000 here. That is the Service address,
+# not a port, and uvicorn refuses to start on it. Ignore it and keep the default.
+case "$SPOOLMAN_PORT" in
+    *://*)
+        echo "Warning: ignoring SPOOLMAN_PORT=\"$SPOOLMAN_PORT\", which is a Kubernetes service link rather than a port number. Using 8000 instead." >&2
+        SPOOLMAN_PORT=8000
+        ;;
+esac
+
 if [ "$(id -u app)" -ne "$PUID" ]; then
     usermod -o -u "$PUID" app ||
         fail "Failed to update app UID to $PUID"


### PR DESCRIPTION
Kubernetes injects Docker-style service-link variables for every Service that already exists in the namespace when a pod starts. A Service named `spoolman` therefore sets `SPOOLMAN_PORT=tcp://10.43.0.1:8000` inside the container, and the entrypoint passed that straight to `uvicorn --port`:

```
Error: Invalid value for '--port': 'tcp://10.43.0.1:8000' is not a valid integer.
```

The container never comes up. It looks like it breaks at random, because it only happens when the Service is created before the pod.

The address in that value belongs to the Service, not to the container, and the port in it is the Service port — so there is nothing worth recovering from it. This ignores any `<proto>://` form (a real port never contains `://`), warns, and keeps the default port. Any other non-numeric or out-of-range value now fails with a clear message instead of an obscure uvicorn error.

## Testing

The service-link recovery path is exercised end-to-end by the existing integration matrix: the sqlite compose file now starts Spoolman with the offending value, so the container fails to boot if the entrypoint ever stops handling it.

The reject paths are covered by `tests_entrypoint.sh`, a self-contained shell test that runs the entrypoint against stub `id`/`usermod`/`uvicorn` on `PATH`. It needs neither Docker nor the image and runs as one small CI job on the runner's dash. It has teeth — against the previous entrypoint, its service-link and reject checks fail.

Verified against the published image:

```
# before
$ docker run --rm --env SPOOLMAN_PORT=tcp://10.43.0.1:8000 ghcr.io/donkie/spoolman:0.24.0
Error: Invalid value for '--port': 'tcp://10.43.0.1:8000' is not a valid integer.
$ echo $?  →  2

# after: warns, listens on 8000, /api/v1/health returns {"status":"healthy"}
```

A related collision exists for `SPOOLMAN_DB_PORT` when a Service is named `spoolman-db` — happy to send that as a follow-up if you want it.

Fixes #647.
