### PR TITLE
ci: sign the released images with cosign

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,6 +393,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: write
+      # Lets cosign fetch an OIDC token from Github and sign without a private key.
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -452,7 +454,15 @@ jobs:
           echo "GIT_COMMIT=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
           echo "BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> "$GITHUB_ENV"
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4.1.2
+        with:
+          # Installer v4+ verifies cosign v3 downloads via the Sigstore bundle
+          # format; pin an explicit, current cosign release for reproducibility.
+          cosign-release: v3.1.1
+
       - name: Build and push Docker images
+        id: build
         uses: docker/build-push-action@v6.7.0
         with:
           context: .
@@ -469,6 +479,24 @@ jobs:
             type=registry,ref=ghcr.io/${{ env.GHCR_IMAGE }}:buildcache-amd64
             type=registry,ref=ghcr.io/${{ env.GHCR_IMAGE }}:buildcache-arm64
             type=registry,ref=ghcr.io/${{ env.GHCR_IMAGE }}:buildcache-armv7
+
+      # Sign the manifest by digest rather than by tag: all the tags above point
+      # at the same digest, and the same digest is valid in both registries, so
+      # signing every tag would just repeat the same signature.
+      - name: Sign the published images
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: |
+            ${{ steps.meta-ghcr.outputs.tags }}
+            ${{ steps.meta-dh.outputs.tags }}
+        run: |
+          echo "${TAGS}" | while read -r tag; do
+            [ -n "${tag}" ] || continue
+            echo "${tag%:*}"
+          done | sort --unique | while read -r repository; do
+            echo "Signing ${repository}@${DIGEST}"
+            cosign sign --yes "${repository}@${DIGEST}"
+          done
   #
   # Create Github Release if CI was triggered by a tag
   #


### PR DESCRIPTION
Published images carry no signature, so there is no way for someone pulling `ghcr.io/donkie/spoolman` to verify that the image was built by this workflow from this repository.

This signs them keyless, using the GitHub OIDC token, so no key material has to be stored or rotated on either side.

The manifest is signed by digest rather than by tag. Every tag produced for a release (`edge`, `X.Y.Z`, `X.Y`, `X`) points at the same digest, and the same digest is valid in both registries the build pushes to, so signing each tag would only repeat the same signature. The tag list is reduced to its distinct repositories, which comes out to one `cosign sign` per registry.

`cosign-installer` is pinned to `v4.1.2` with an explicit `cosign-release: v3.1.1`: the installer verifies the cosign binary it downloads, and v3 releases ship only the Sigstore-bundle signature, which older installer lines cannot check — they look for a `.sig` asset that no longer exists and fail the job before the build.

Users can verify with:

```bash
cosign verify ghcr.io/donkie/spoolman:<tag> \
  --certificate-identity-regexp '^https://github\.com/Donkie/Spoolman/\.github/workflows/ci\.yml@refs/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

The identity is matched as a regex because it differs between a tagged release (`...@refs/tags/v0.25.0`) and an `edge` build (`...@refs/heads/master`). Signing starts from the first build after this merges; images published earlier are unsigned. Happy to add that snippet to the README or the wiki if you want it documented.
