### PR TITLE
fix(externaldb): report the unwritable path instead of raising NameError

### DIFF
--- a/spoolman/externaldb.py
+++ b/spoolman/externaldb.py
@@ -25,11 +25,14 @@ controller = hishel.Controller(allow_stale=True)
 try:
     cache_path = get_cache_dir() / "hishel"
     cache_storage = hishel.AsyncFileStorage(base_path=cache_path)
-except PermissionError:
+except PermissionError as exc:
+    # Take the path from the exception rather than from cache_path: the data
+    # directory is created while cache_path is being evaluated, so when that is
+    # what fails, cache_path is never bound.
     logger.warning(
         "Failed to setup disk-based cache due to permission error. Ensure the path %s is writable. "
         "Using in-memory cache instead as fallback.",
-        str(cache_path.resolve()),
+        exc.filename or "of the Spoolman data directory",
     )
     cache_storage = hishel.AsyncInMemoryStorage()
 


### PR DESCRIPTION
The fallback to an in-memory cache never worked in the case it was written for.

```python
try:
    cache_path = get_cache_dir() / "hishel"
    cache_storage = hishel.AsyncFileStorage(base_path=cache_path)
except PermissionError:
    logger.warning("... Ensure the path %s is writable ...", str(cache_path.resolve()))
    cache_storage = hishel.AsyncInMemoryStorage()
```

`get_cache_dir()` calls `get_data_dir()`, which creates the data directory. When *that* is what raises `PermissionError`, the exception leaves the expression before `cache_path` is ever bound, so the handler dereferences a name that does not exist and dies with `NameError: name 'cache_path' is not defined`. It happens at import time, which means the application goes down before the startup check that would have reported the permission problem in plain language ever runs.

Taking the path from the exception instead fixes it. `filename` is set for both cases: the data directory that could not be created, and the cache directory underneath it.

This does not make Spoolman run as a user that cannot write its data directory — the startup check still refuses, as it should. It replaces a `NameError` that hides the cause with a message that names the path.

## Testing

Verified against the published image by running it as a UID that owns neither directory, which is what a restricted Kubernetes SecurityContext does:

```
$ docker run --rm --user 1000670000:0 ghcr.io/donkie/spoolman:0.24.0

# before
  File "/home/app/spoolman/spoolman/externaldb.py", line 32, in <module>
    str(cache_path.resolve()),
NameError: name 'cache_path' is not defined

# after
WARNING  Failed to setup disk-based cache due to permission error.
         Ensure the path /.local is writable. Using in-memory cache instead as fallback.
WARNING  spoolman.env  Data directory is not writable, trying to fix it...
PermissionError: [Errno 13] Permission denied: '/.local'
```

No test is added: this runs at import time, and the repository has no unit-test harness for `spoolman/` — pytest only runs inside the tester container against a live API. Adding one would mean a new CI job for a five-line fix. Happy to add it if you would rather have the harness.
