### PR TITLE
fix(docker): link libstdc++ into the armv7 greenlet extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,19 @@ COPY alembic.ini README.md uv.lock pyproject.toml /home/app/spoolman/
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --locked
 
+# greenlet ships no 32-bit ARM wheel, so on armv7 it is compiled from source.
+# setuptools links the C++ extension with gcc, which leaves libstdc++ out of the
+# .so's NEEDED list, and it then crashes at import with an undefined libstdc++
+# typeinfo symbol, taking startup down during the DB migration. Add libstdc++ to
+# the NEEDED list so the loader pulls it in. Only armv7 is affected; amd64 and
+# arm64 use a correctly linked prebuilt wheel.
+RUN if [ "$(uname -m)" = "armv7l" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends patchelf \
+        && patchelf --add-needed libstdc++.so.6 \
+            "$(find /home/app/spoolman/.venv -name '_greenlet*.so')" \
+        && apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi
+
 FROM python:3.14-slim-bookworm AS python-runner
 
 LABEL org.opencontainers.image.source=https://github.com/Donkie/Spoolman


### PR DESCRIPTION
greenlet has no 32-bit ARM wheel, so on armv7 it's built from source and setuptools links the C++ extension with gcc. That leaves libstdc++ out of the `.so`'s NEEDED list, so it fails to import with `undefined symbol: _ZTVN10__cxxabiv120__si_class_type_infoE` (a libstdc++ typeinfo symbol). The import dies during `alembic upgrade head`, so any armv7 host like a 32-bit Raspberry Pi crashloops on startup. v0.24.0 is affected, v0.23.1 works.

patchelf adds libstdc++ to the NEEDED list so the loader pulls it in. amd64 and arm64 use a correctly linked prebuilt wheel, so the step only runs on armv7.

Checked against the shipped 0.24.0 armv7 image and a local armv7 build with this change: it gets past `alembic upgrade head` and `/api/v1/health` returns healthy instead of crashing at import. The new armv7 smoke test covers it.

Closes #965, closes #966.
