### PR TITLE
Point the translation workflows at client_v2, close the legacy client to translation

### DIFF
--- a/.github/workflows/guard-translations.yml
+++ b/.github/workflows/guard-translations.yml
@@ -2,13 +2,22 @@ name: Guard Translations
 
 # Translations are managed exclusively through Weblate (https://hosted.weblate.org/projects/spoolman/).
 # Only the "en" source locale is edited by hand in this repo; every other language is written back
-# by the Weblate bot. This workflow fails any PR (except Weblate's own) that MODIFIES or DELETES an
-# existing non-English translation file, so manual edits don't get overwritten and lost on the next
-# Weblate sync.
+# by the Weblate bot. This workflow fails any PR (except Weblate's own) that hand-edits a non-English
+# translation file, so manual edits don't get overwritten and lost on the next Weblate sync.
 #
-# ADDING a brand-new language file is allowed: contributors bootstrapping a new language must add the
-# code entry in client/src/i18n.ts, and they may include the initial client/public/locales/<lang>/
-# file in the same PR. Only edits to files that ALREADY exist on the base branch are blocked.
+# Two clients, two different rules:
+#
+#   client_v2/locales/           — the ACTIVE translation target. Weblate translates this one.
+#                                  MODIFY/DELETE of an existing non-English file is blocked; ADDING a
+#                                  brand-new language file is allowed, because bootstrapping a language
+#                                  also needs two hand-written code entries (see NEW_LANGUAGE_HOWTO
+#                                  below) that only a human PR can add.
+#
+#   client/public/locales/       — the LEGACY React client, CLOSED to translation work. Its Weblate
+#                                  component is locked, so nothing new arrives from translators and
+#                                  the files here are frozen at whatever shipped. Any change to a
+#                                  non-English file is blocked, including adding a new language:
+#                                  effort spent there is effort not spent on the client users get.
 
 on:
   pull_request:
@@ -43,57 +52,92 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Files changed in this PR, keyed by change type. --no-renames turns any rename into a
-          # delete + add pair, so a "renamed" (i.e. rewritten) existing file still trips the delete
-          # rule below and can't be smuggled through as a fresh add.
+          # --no-renames turns any rename into a delete + add pair, so a "renamed" (i.e. rewritten)
+          # existing file still trips the delete rule and can't be smuggled through as a fresh add.
           #
-          # --diff-filter=MD keeps only Modified and Deleted paths: edits to files that ALREADY
-          # exist on the base branch. Added (A) files are intentionally excluded, so a contributor
-          # may add a brand-new client/public/locales/<lang>/ file for a new language.
-          offending="$(git diff --no-renames --diff-filter=MD --name-only "$BASE_SHA" "$HEAD_SHA" \
+          # --diff-filter=MD keeps only Modified and Deleted paths: edits to files that ALREADY exist
+          # on the base branch. Added (A) files are handled separately per client below.
+          edited="$(git diff --no-renames --diff-filter=MD --name-only "$BASE_SHA" "$HEAD_SHA" || true)"
+          added="$(git diff --no-renames --diff-filter=A --name-only "$BASE_SHA" "$HEAD_SHA" || true)"
+
+          # Active client: edits to existing non-English files are blocked, new languages are fine.
+          offending_v2="$(printf '%s\n' "$edited" \
+            | grep -E '^client_v2/locales/[^/]+/' \
+            | grep -vE '^client_v2/locales/en/' \
+            || true)"
+
+          # Legacy client: every non-English change is blocked, adds included.
+          offending_legacy="$(printf '%s\n' "$edited" "$added" \
             | grep -E '^client/public/locales/[^/]+/' \
             | grep -vE '^client/public/locales/en/' \
             || true)"
 
-          if [ -n "$offending" ]; then
-            echo "::error title=Manual translation edits are not allowed::This PR edits existing non-English translation files. See the job summary for details."
-
-            {
-              echo "## ❌ Manual translation edits detected"
-              echo ""
-              echo "This PR modifies or deletes one or more **existing non-English** translation files:"
-              echo ""
-              echo '```'
-              echo "$offending"
-              echo '```'
-              echo ""
-              echo "### Why this is blocked"
-              echo ""
-              echo "Every language except the English source (\`client/public/locales/en/\`) is managed"
-              echo "**exclusively through Weblate**. Any manual edit to an existing non-English file here"
-              echo "will be **silently overwritten and lost** the next time Weblate syncs — so we don't"
-              echo "accept them."
-              echo ""
-              echo "### What to do instead"
-              echo ""
-              echo "- **To fix or improve an existing translation:** contribute it through Weblate at"
-              echo "  <https://hosted.weblate.org/projects/spoolman/>. It's free, requires no coding,"
-              echo "  and your change flows back into the repo automatically."
-              echo "- **To add or change a user-facing string:** edit **only** the English source files under"
-              echo "  \`client/public/locales/en/\`. Weblate will pick up the new keys and expose them to"
-              echo "  translators. Revert your changes to every other language and push again."
-              echo "- **To add a brand-new language:** that IS allowed here. Add the language entry to"
-              echo "  \`client/src/i18n.ts\` and, if you like, an initial \`client/public/locales/<lang>/\`"
-              echo "  file — new files are fine, only edits to existing ones are blocked."
-              echo ""
-              echo "> If you believe an existing file genuinely needs a manual change (e.g. a structural"
-              echo "> fix), please explain it in a PR comment so a maintainer can review."
-            } >> "$GITHUB_STEP_SUMMARY"
-
-            echo ""
-            echo "Offending files:"
-            echo "$offending"
-            exit 1
+          if [ -z "$offending_v2" ] && [ -z "$offending_legacy" ]; then
+            echo "No manual edits to non-English translation files detected. ✅"
+            exit 0
           fi
 
-          echo "No manual edits to existing non-English translation files detected. ✅"
+          echo "::error title=Manual translation edits are not allowed::This PR hand-edits non-English translation files. See the job summary for details."
+
+          {
+            echo "## ❌ Manual translation edits detected"
+            echo ""
+
+            if [ -n "$offending_v2" ]; then
+              echo "### Existing translations edited by hand"
+              echo ""
+              echo "This PR modifies or deletes existing non-English translation files:"
+              echo ""
+              echo '```'
+              echo "$offending_v2"
+              echo '```'
+              echo ""
+              echo "Every language except the English source (\`client_v2/locales/en/common.json\`) is"
+              echo "managed **exclusively through Weblate**. A manual edit here will be **silently"
+              echo "overwritten and lost** the next time Weblate syncs — so we don't accept them."
+              echo ""
+              echo "**What to do instead:**"
+              echo ""
+              echo "- **To fix or improve a translation:** contribute it through Weblate at"
+              echo "  <https://hosted.weblate.org/projects/spoolman/>. It's free, requires no coding,"
+              echo "  and your change flows back into the repo automatically."
+              echo "- **To add or change a user-facing string:** edit **only**"
+              echo "  \`client_v2/locales/en/common.json\`. Weblate picks up the new keys and exposes"
+              echo "  them to translators. Revert your changes to every other language and push again."
+              echo "- **To add a brand-new language:** that IS allowed here — new files aren't blocked,"
+              echo "  only edits to existing ones. A new language needs two code entries as well:"
+              echo "  the locale code in \`client_v2/project.inlang/settings.json\` (so paraglide compiles"
+              echo "  it) and an endonym in \`client_v2/src/lib/i18n/languages.ts\` (so it appears in the"
+              echo "  language picker). Without both, the translation file is built but unreachable."
+              echo ""
+            fi
+
+            if [ -n "$offending_legacy" ]; then
+              echo "### Legacy client translations are closed"
+              echo ""
+              echo "This PR changes non-English translation files of the **legacy React client**:"
+              echo ""
+              echo '```'
+              echo "$offending_legacy"
+              echo '```'
+              echo ""
+              echo "\`client/public/locales/\` belongs to the old client, which is only kept around for"
+              echo "the \`SPOOLMAN_LEGACY_CLIENT\` fallback. Its Weblate component is **locked** and its"
+              echo "translations are frozen — nothing here reaches the UI that users get by default."
+              echo ""
+              echo "**Translate \`client_v2\` instead:** the same strings, in the client everyone actually"
+              echo "sees, at <https://hosted.weblate.org/projects/spoolman/>."
+              echo ""
+            fi
+
+            echo "> If you believe a file genuinely needs a manual change (e.g. a structural fix),"
+            echo "> please explain it in a PR comment so a maintainer can review."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo ""
+          echo "Offending files:"
+          # Plain `if` rather than `[ -n … ] && echo …`: under `set -e` a false test makes the
+          # whole && list return non-zero and abort the step, which would skip the second echo.
+          if [ -n "$offending_v2" ]; then echo "$offending_v2"; fi
+          if [ -n "$offending_legacy" ]; then echo "$offending_legacy"; fi
+          exit 1

--- a/.github/workflows/weblate-automerge.yml
+++ b/.github/workflows/weblate-automerge.yml
@@ -2,8 +2,8 @@ name: Auto-merge Weblate PRs
 
 # Translations are managed exclusively through Weblate (https://hosted.weblate.org/projects/spoolman/),
 # which opens a pull request for every sync back to this repo (see guard-translations.yml). Those PRs
-# are machine-generated, always scoped to client/public/locales/, and gated by the full CI suite just
-# like any other PR. Rather than hand-merging each one, this workflow turns on GitHub's native
+# are machine-generated, always scoped to a locale tree (client_v2/locales/ today), and gated by the
+# full CI suite just like any other PR. Rather than hand-merging each one, this workflow turns on GitHub's native
 # auto-merge for Weblate-authored PRs so they merge themselves once all required status checks pass.
 #
 # Why auto-merge instead of giving Weblate direct push access to master:
@@ -37,9 +37,14 @@ jobs:
     steps:
       # Defence in depth: don't trust the author alone, trust the diff. Even a compromised Weblate
       # token can only ever get auto-merged if the PR is confined to locale JSON files. Anything
-      # else (a code file, a workflow, a non-.json file, a file outside client/public/locales/)
+      # else (a code file, a workflow, a non-.json file, a file outside the two locale trees)
       # fails this step, auto-merge is never enabled, and the PR waits for a human. The file list is
       # read from the API — this step never checks out or runs PR code, so pull_request_target is safe.
+      #
+      # Both locale trees are allowed. client_v2/locales/ is where translations go now; the legacy
+      # client/public/locales/ tree stays on the list only so that a sync opened before its Weblate
+      # component was locked isn't stranded half-merged. Locking the component, not this allowlist,
+      # is what stops new legacy translations (see guard-translations.yml).
       - name: Verify PR only changes locale JSON files
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -55,15 +60,18 @@ jobs:
             exit 1
           fi
 
-          # Every changed path must be a .json file under client/public/locales/<lang>/.
-          offending="$(printf '%s\n' "$files" | grep -vE '^client/public/locales/[^/]+/.+\.json$' || true)"
+          # Every changed path must be a .json file under client_v2/locales/<lang>/ (active) or
+          # client/public/locales/<lang>/ (legacy, being wound down).
+          offending="$(printf '%s\n' "$files" \
+            | grep -vE '^(client_v2/locales|client/public/locales)/[^/]+/.+\.json$' || true)"
 
           if [ -n "$offending" ]; then
-            echo "::error title=Out-of-scope Weblate PR::PR touches files outside client/public/locales/**/*.json; not auto-merging."
+            echo "::error title=Out-of-scope Weblate PR::PR touches files outside the locale trees; not auto-merging."
             {
               echo "## ❌ Auto-merge blocked: out-of-scope changes"
               echo ""
-              echo "This Weblate PR changes files that are **not** locale JSON under \`client/public/locales/\`:"
+              echo "This Weblate PR changes files that are **not** locale JSON under"
+              echo "\`client_v2/locales/\` or \`client/public/locales/\`:"
               echo ""
               echo '```'
               echo "$offending"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spoolman is a self-hosted web service designed to help you efficiently manage yo
   * Search, group and filter your inventory by manufacturer, material, location and more.
   * Add custom fields to tailor information to your specific needs.
   * Design and print labels with QR codes for easy spool identification and tracking.
-  * Contribute to its translation into 18 languages via [Weblate](https://hosted.weblate.org/projects/spoolman/).
+  * Contribute to its translation into 26 languages via [Weblate](https://hosted.weblate.org/projects/spoolman/). Translations are accepted through Weblate only — please don't send them as pull requests, they get overwritten on the next sync.
 * **Database Support**: SQLite, PostgreSQL, MySQL, and CockroachDB.
 * **Multi-Printer Management**: Handles spool updates from several printers simultaneously.
 * **Advanced Monitoring**: Integrate with [Prometheus](https://prometheus.io/) for detailed historical analysis of filament usage, helping you track and optimize your printing processes. See the [Wiki](https://github.com/Donkie/Spoolman/wiki/Filament-Usage-History) for instructions on how to set it up.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Spoolman is a self-hosted web service designed to help you efficiently manage yo
   * Search, group and filter your inventory by manufacturer, material, location and more.
   * Add custom fields to tailor information to your specific needs.
   * Design and print labels with QR codes for easy spool identification and tracking.
-  * Contribute to its translation into 26 languages via [Weblate](https://hosted.weblate.org/projects/spoolman/). Translations are accepted through Weblate only — please don't send them as pull requests, they get overwritten on the next sync.
+  * Contribute to its translation into 18 languages via [Weblate](https://hosted.weblate.org/projects/spoolman/).
 * **Database Support**: SQLite, PostgreSQL, MySQL, and CockroachDB.
 * **Multi-Printer Management**: Handles spool updates from several printers simultaneously.
 * **Advanced Monitoring**: Integrate with [Prometheus](https://prometheus.io/) for detailed historical analysis of filament usage, helping you track and optimize your printing processes. See the [Wiki](https://github.com/Donkie/Spoolman/wiki/Filament-Usage-History) for instructions on how to set it up.


### PR DESCRIPTION
Repo-side half of moving Weblate onto `client_v2`. The Weblate-side changes (new component + locking the legacy one) still need to be done in the hosted.weblate.org UI — see the checklist at the bottom.

## Why

Both translation workflows only knew about `client/public/locales/`. As-is:

- a Weblate sync PR for `client_v2/locales/` would fail the auto-merge scope check and sit unmerged, and
- a contributor hand-editing `client_v2/locales/de/common.json` would pass the guard unchallenged, then get silently overwritten on the next sync.

## Changes

**`weblate-automerge.yml`** — the file allowlist now accepts locale JSON under either `client_v2/locales/` or `client/public/locales/`. The legacy tree stays on the list only so a sync opened before its component gets locked isn't stranded; the Weblate-side lock, not this allowlist, is what ends legacy translation.

**`guard-translations.yml`** — guards both trees, with deliberately different rules:

| Tree | Modify/delete non-en | Add new language |
|---|---|---|
| `client_v2/locales/` (active) | blocked | **allowed** |
| `client/public/locales/` (legacy) | blocked | blocked |

New `client_v2` languages stay allowed because bootstrapping one also needs two hand-written code entries — the locale code in `project.inlang/settings.json` (so paraglide compiles it) and an endonym in `src/lib/i18n/languages.ts` (so it reaches the picker). Without both, the file builds but is unreachable, so the failure message now spells that out. The legacy message redirects translators to the client users actually get.

## Verification

Extracted the guard's shell script and ran it against synthetic PR file lists with a stubbed `git` — 9/9 as intended:

- allowed: no locale changes, `client_v2` en edit, legacy en edit, new `client_v2` language
- blocked: `client_v2` non-en modify, `client_v2` non-en delete, legacy non-en edit, legacy new language
- a PR tripping both rules exits 1 and renders both summary sections

Auto-merge regex: accepts both locale trees incl. `zh-Hant`; rejects source files, workflows, non-`.json`, a file directly under `locales/`, and a `evil/client_v2/locales/...` prefix-smuggling path.

**Format risk checked and cleared.** Weblate's i18next v4 writer may emit nested JSON rather than the flat dotted keys in the repo. Converted `locales/de/common.json` to fully nested and recompiled: German round-tripped intact (`buttons.save` → `Speichern`), and a nested `addN_one`/`addN_other` pair compiled into a correct CLDR plural function with untranslated locales still aliasing to English. So a nested writeback would not break the build. (`scripts/strip-empty-locales.mjs` already handles both shapes too.)

No lint surface touched — the workflows aren't linted.

## Not done here — Weblate UI steps

1. Add component **Spoolman Web UI**, as a *linked* repository (`weblate://spoolman/<existing>`) so it reuses the existing push/PR credentials.
   - File format: **i18next JSON v4** (matches the `_one`/`_other` suffixes)
   - Filemask: `client_v2/locales/*/common.json`
   - Monolingual base: `client_v2/locales/en/common.json`
   - Edit base file: **off** (English is edited in-repo)
2. Lock the legacy component and rename it so translators see why.
3. Suggested addons on the new component: *Cleanup translation files* (v2 keys are still churning) and *Customize JSON output* (4-space indent, matching the repo).

## Open decision (not addressed)

Six locale dirs exist under `client_v2/locales/` but are wired into neither `settings.json` nor `languages.ts`, so they're dead weight today: `et`, `hi-Latn`, `ko`, `lv`, `sk`, `sl`. Four carry ~30% of v2's keys; `lv` and `sk` carry 1–2%. Wiring them in is a one-commit product call (a 1%-translated language in the picker is mostly English), so I left it alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)