### PR TITLE
fix(add): let filament extra fields be filled in while creating a filament

### DIFF
--- a/client_v2/src/lib/components/AddSpoolModal.svelte
+++ b/client_v2/src/lib/components/AddSpoolModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import Swatch from './Swatch.svelte';
 	import ColorEditor from './ColorEditor.svelte';
 	import Button from './Button.svelte';
@@ -16,6 +17,7 @@
 	import { serverInfo } from '$lib/stores/serverInfo.svelte';
 	import { spoolSource, type NewFilamentDraft } from '$lib/api/spoolSource';
 	import { fields } from '$lib/stores/fields.svelte';
+	import type { EntityType } from '$lib/api/fields';
 	import { externalColors, externalDirection, type ExternalFilament } from '$lib/api/external';
 	import { roundGrams, weightAuto } from '$lib/utils/format';
 	import { loadMaterials, type MaterialSpec } from '$lib/data/materials';
@@ -64,6 +66,9 @@
 		articleNumber: '',
 		comment: ''
 	});
+	// Custom-field values for the filament being created. Separate from the spool's
+	// `extraValues` below: the two entities have their own field definitions.
+	let filamentExtra = $state<Extra>({});
 	let showAdvanced = $state(false);
 	let nameInput = $state<HTMLInputElement | undefined>();
 	// Display-only: an untouched empty name shows the naming guidance rather than
@@ -135,6 +140,7 @@
 			initialized = true;
 			runSearch();
 			fields.ensure('spool');
+			fields.ensure('filament');
 			spoolSource
 				.locations()
 				.then((l) => (locations = l))
@@ -220,16 +226,37 @@
 					: ''
 	);
 
-	function seedExtraDefaults(): Extra {
-		const out: Extra = {};
-		for (const f of fields.get('spool')) if (f.default_value != null) out[f.key] = f.default_value;
+	/** `current` with a default filled in for every field it doesn't already carry. */
+	function withDefaults(entity: EntityType, current: Extra): Extra {
+		const out = { ...current };
+		for (const f of fields.get(entity))
+			if (f.default_value != null && !(f.key in out)) out[f.key] = f.default_value;
 		return out;
 	}
-	function setExtra(key: string, json: string | undefined) {
-		const next = { ...extraValues };
+	// Definitions are fetched on open, so they can land after the form is already on
+	// screen — opening straight into a preset or a duplicate leaves no time for the
+	// request. Top up the defaults when they arrive; anything already there, seeded
+	// or typed, is left alone. The writes are untracked so this doesn't re-run itself.
+	$effect(() => {
+		fields.get('spool');
+		fields.get('filament');
+		untrack(() => {
+			extraValues = withDefaults('spool', extraValues);
+			filamentExtra = withDefaults('filament', filamentExtra);
+		});
+	});
+
+	function setExtraOn(current: Extra, key: string, json: string | undefined): Extra {
+		const next = { ...current };
 		if (json === undefined) delete next[key];
 		else next[key] = json;
-		extraValues = next;
+		return next;
+	}
+	function setExtra(key: string, json: string | undefined) {
+		extraValues = setExtraOn(extraValues, key, json);
+	}
+	function setFilamentExtra(key: string, json: string | undefined) {
+		filamentExtra = setExtraOn(filamentExtra, key, json);
 	}
 
 	function resetSpoolForm() {
@@ -241,7 +268,7 @@
 		fillWeight = '';
 		firstUsed = undefined;
 		lastUsed = undefined;
-		extraValues = seedExtraDefaults();
+		extraValues = withDefaults('spool', {});
 	}
 
 	function choose(c: Choice) {
@@ -276,6 +303,7 @@
 			articleNumber: '',
 			comment: ''
 		};
+		filamentExtra = withDefaults('filament', {});
 		netWeight = '1000';
 		spoolWeight = '';
 		price = '';
@@ -286,10 +314,11 @@
 	/**
 	 * Start a new filament copied from an existing one — the "I bought the same
 	 * filament in another colour" case. Everything that describes the *product*
-	 * carries over (manufacturer, material, specs, weights, price, custom fields);
-	 * everything that identifies the *variant* is left for the user: the colour is
-	 * cleared and the article number (a per-colour SKU) is dropped. The name is
-	 * kept as a starting point since it's usually one word away from the new one,
+	 * carries over (manufacturer, material, specs, weights, price, custom fields — all
+	 * of it still editable in the form); everything that identifies the *variant* is
+	 * left for the user: the colour is cleared and the article number (a per-colour
+	 * SKU) is dropped. The name is kept as a starting point since it's usually one
+	 * word away from the new one,
 	 * with a nudge below the field until it's changed.
 	 */
 	function startDuplicate(f: Filament) {
@@ -313,6 +342,7 @@
 			articleNumber: '',
 			comment: f.comment
 		};
+		filamentExtra = withDefaults('filament', { ...f.extra });
 		netWeight = String(f.weight || 1000);
 		spoolWeight = f.spoolWeight ? String(f.spoolWeight) : '';
 		price = f.price ? String(f.price) : '';
@@ -386,9 +416,7 @@
 					price: parseFloat(price) || undefined,
 					articleNumber: nf.articleNumber.trim() || undefined,
 					comment: nf.comment.trim() || undefined,
-					// A duplicate carries the original's custom-field values too; they
-					// aren't editable here, so the inspector is where they get adjusted.
-					extra: cloneSource?.extra
+					extra: filamentExtra
 				};
 				const f = await spoolSource.createFilament(draft);
 				created = f;
@@ -744,6 +772,10 @@
 									</label>
 								</div>
 							{/if}
+							<!-- Outside the advanced block: a custom field only exists because
+							     someone defined it, so it isn't an advanced detail to them. The
+							     section renders nothing when no filament fields are defined. -->
+							<ExtraFieldsSection entity="filament" extra={filamentExtra} onchange={setFilamentExtra} />
 						</div>
 						<div class="sec-divider"></div>
 					{:else if chosen}

--- a/tests_frontend_v2/tests/crud.spec.ts
+++ b/tests_frontend_v2/tests/crud.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures";
-import { createSpoolViaModal, navTab, openApp, unique } from "./helpers";
+import { createSpoolViaModal, navTab, openApp, searchFor, unique } from "./helpers";
 
 /**
  * The core happy path a real user walks on first use. client_v2 folds what the
@@ -40,4 +40,63 @@ test("create a manufacturer, filament and spool through the add-spool modal", as
     await navTab(page, "Dashboard", "Dashboard | Spoolman");
     await expect(page.getByText(locationName, { exact: true })).toBeVisible();
   });
+});
+
+/**
+ * Extra fields defined for filaments have to be fillable *while* the filament is
+ * being created, not only afterwards in the inspector — the add-spool modal is
+ * the only filament create form client_v2 has (#988).
+ */
+test("a filament's extra fields can be filled in while creating it", async ({ page }) => {
+  const fieldKey = `test_fil_field_${Date.now().toString(36)}`;
+  const fieldName = unique("Batch");
+  const fieldValue = unique("Lot");
+  const vendorName = unique("Vendor");
+  const filamentName = unique("Filament");
+  const locationName = unique("Shelf");
+
+  await openApp(page);
+
+  try {
+    await test.step("define a filament text field", async () => {
+      await navTab(page, "Settings", "Settings | Spoolman");
+      // The manager opens on the spool tab; each entity has its own field list.
+      await page.locator(".tabs").getByRole("button", { name: "Filament", exact: true }).click();
+      await page.getByRole("button", { name: "Add Filament field" }).click();
+      await page.getByPlaceholder("lower_snake_case").fill(fieldKey);
+      await page.getByPlaceholder("Display name").fill(fieldName);
+      await page.getByRole("button", { name: "Save field" }).click();
+      await expect(page.getByText(fieldKey, { exact: true })).toBeVisible();
+    });
+
+    await test.step("fill it in on the new-filament form", async () => {
+      await navTab(page, "Library", "Library | Spoolman");
+      await createSpoolViaModal(page, {
+        vendorName,
+        filamentName,
+        locationName,
+        filamentExtra: { [fieldName]: fieldValue },
+      });
+    });
+
+    await test.step("the value is on the created filament", async () => {
+      // Straight from the API on a fresh view of the filament, so this proves the
+      // value was sent with the create rather than merely typed into the form.
+      const panel = await searchFor(page, filamentName);
+      await panel.getByRole("link").filter({ hasText: filamentName }).first().click();
+      await expect(page).toHaveURL(/[?&]sel=filament(:|%3A)\d+/);
+      await expect(page.getByLabel(fieldName, { exact: true })).toHaveValue(fieldValue);
+    });
+  } finally {
+    // Field definitions are instance-wide, so this one has to go whatever happened
+    // above — otherwise every later spec sees an extra section in the modal.
+    await navTab(page, "Settings", "Settings | Spoolman");
+    await page.locator(".tabs").getByRole("button", { name: "Filament", exact: true }).click();
+    page.once("dialog", (dialog) => dialog.accept());
+    await page
+      .locator(".table .row", { hasText: fieldKey })
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+    await expect(page.getByText(fieldKey, { exact: true })).toHaveCount(0);
+  }
 });

--- a/tests_frontend_v2/tests/helpers.ts
+++ b/tests_frontend_v2/tests/helpers.ts
@@ -95,6 +95,8 @@ export interface NewSpool {
   weightG?: number;
   /** How much of it has already been used, in grams. Omit for a full spool. */
   usedG?: number;
+  /** Values for the filament's extra fields, keyed by their display name. */
+  filamentExtra?: Record<string, string>;
 }
 
 /**
@@ -109,7 +111,7 @@ export interface NewSpool {
  * their own on top.
  */
 export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<void> {
-  const { vendorName, filamentName, locationName, material = "PLA", weightG = 1000, usedG } = spool;
+  const { vendorName, filamentName, locationName, material = "PLA", weightG = 1000, usedG, filamentExtra } = spool;
 
   const dialog = await openAddSpoolModal(page);
 
@@ -133,6 +135,12 @@ export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<
   await dialog.getByRole("button", { name: /^Advanced specs/ }).click();
   await numberField(dialog, "Density").fill("1.24");
   await expect(numberField(dialog, "Diameter")).toHaveValue("1.75");
+
+  // Extra fields defined for filaments get their own section in the same form.
+  // Their inputs carry the field's display name as an aria-label.
+  for (const [name, value] of Object.entries(filamentExtra ?? {})) {
+    await dialog.getByLabel(name, { exact: true }).fill(value);
+  }
 
   await expect(numberField(dialog, "Count")).toHaveValue("1");
   await numberField(dialog, "Weight").fill(String(weightG));


### PR DESCRIPTION
Fixes #988.

The add-spool modal is the only place client_v2 creates filaments, and its new-filament form had no extra fields, so custom filament fields could only be filled in afterwards from the inspector. Duplicating a filament carried the original values along with no way to edit them.

Adds the extra-fields section to that form, outside "Advanced specs" since a custom field is not an advanced detail to whoever defined it. It renders nothing when no filament fields are defined.

Also fixes default values getting dropped when the modal opens straight into a preset filament or a duplicate, where the seeding ran before the field definitions had arrived. The spool section had the same miss.

Covered by a new test in tests_frontend_v2.