### PR TITLE
Show all filament and manufacturer fields in the library detail views

### DIFF
--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -138,6 +138,8 @@
     "inspector.noExtraFields": "None yet — add your own fields to track anything Spoolman doesn't.",
     "inspector.ofRemaining": "of {{weight}} remaining · {{length}} m",
     "inspector.openFilament": "Open filament",
+    "inspector.openLink": "Open {{url}} in a new tab",
+    "inspector.openManufacturer": "Open manufacturer",
     "inspector.specs": "Specs — edit in place",
     "inspector.spoolsCount": "Spools · {{count}}",
     "inspector.spoolsTotalRemaining": "{{weight}} total",

--- a/client_v2/src/lib/components/EditableField.svelte
+++ b/client_v2/src/lib/components/EditableField.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
+	/* eslint-disable svelte/no-navigation-without-resolve --
+	   The href below is an external absolute URL out of the user's own field value;
+	   there is no deploy base path to resolve it against. */
+	import ExternalLink from '@lucide/svelte/icons/external-link';
 	import { getFieldLabelId } from './fieldLabel';
+	import { extractUrls } from '$lib/utils/links';
+	import * as m from '$lib/paraglide/messages';
 
 	interface Props {
 		value: string | number;
@@ -8,25 +14,51 @@
 		oninput?: (value: string) => void;
 		/** Accessible name, for use outside a <Field> that supplies one. */
 		ariaLabel?: string;
+		/**
+		 * Offer any URLs in the value as links beside the input (#992). The value
+		 * stays editable text — an inline anchor can't also be a caret target — so
+		 * the links sit next to the field rather than replacing it.
+		 */
+		linkify?: boolean;
 	}
 
-	let { value, placeholder = '—', mono = false, oninput, ariaLabel }: Props = $props();
+	let { value, placeholder = '—', mono = false, oninput, ariaLabel, linkify = false }: Props = $props();
 
 	// Named by the enclosing <Field>'s label cell when there is one; see fieldLabel.ts.
 	const labelId = getFieldLabelId();
+
+	let urls = $derived(linkify ? extractUrls(String(value ?? '')) : []);
 </script>
 
-<input
-	class="edit"
-	class:mono
-	{value}
-	{placeholder}
-	aria-label={ariaLabel}
-	aria-labelledby={ariaLabel ? undefined : labelId}
-	oninput={(e) => oninput?.(e.currentTarget.value)}
-/>
+<span class="row">
+	<input
+		class="edit"
+		class:mono
+		{value}
+		{placeholder}
+		aria-label={ariaLabel}
+		aria-labelledby={ariaLabel ? undefined : labelId}
+		oninput={(e) => oninput?.(e.currentTarget.value)}
+	/>
+	{#each urls as url (url)}
+		<a
+			class="open"
+			href={url}
+			target="_blank"
+			rel="nofollow noopener"
+			title={url}
+			aria-label={m['inspector.openLink']({ url })}><ExternalLink size={13} /></a
+		>
+	{/each}
+</span>
 
 <style>
+	.row {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		width: 100%;
+	}
 	.edit {
 		background: none;
 		border: none;
@@ -35,8 +67,33 @@
 		font-size: 12.5px;
 		padding: 2px 0;
 		width: 100%;
+		flex: 1;
+		min-width: 0;
 	}
 	.edit:focus {
 		border-bottom-color: var(--accent);
+	}
+	.open {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		flex: none;
+		color: var(--accent-link);
+	}
+	.open::before {
+		/* Roomy tap target on touch, laid over the icon so it doesn't grow the row
+		   — the same trick the ⓘ help toggle in Field.svelte uses. Kept narrower
+		   than it is tall so that when a value holds several URLs, neighbouring
+		   targets never reach across another icon's glyph. */
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 50%;
+		width: 24px;
+		height: 32px;
+		transform: translate(-50%, -50%);
+	}
+	.open:hover {
+		color: var(--accent);
 	}
 </style>

--- a/client_v2/src/lib/components/ExtraFieldInput.svelte
+++ b/client_v2/src/lib/components/ExtraFieldInput.svelte
@@ -2,6 +2,8 @@
 	import { FieldType, NUMERIC_FIELD_TYPES, type FieldDef } from '$lib/api/fields';
 	import Toggle from './Toggle.svelte';
 	import DateTimeField from './DateTimeField.svelte';
+	import EditableField from './EditableField.svelte';
+	import LinkedText from './LinkedText.svelte';
 	import { formatDateTime } from '$lib/utils/datetime';
 	import * as m from '$lib/paraglide/messages';
 
@@ -76,18 +78,15 @@
 		<span>{parsed === true ? m.yes() : m.no()}</span>
 	{:else if field.field_type === FieldType.choice && field.multi_choice}
 		<span>{selected.length ? selected.join(', ') : '—'}</span>
+	{:else if field.field_type === FieldType.text}
+		<LinkedText text={parsed !== undefined && parsed !== '' ? withUnit(String(parsed)) : ''} />
 	{:else}
 		<span class:mono={NUMERIC_FIELD_TYPES.has(field.field_type)}
 			>{parsed !== undefined && parsed !== '' ? withUnit(String(parsed)) : '—'}</span
 		>
 	{/if}
 {:else if field.field_type === FieldType.text}
-	<input
-		class="edit"
-		value={parsed ?? ''}
-		aria-label={field.name}
-		oninput={(e) => onText(e.currentTarget.value)}
-	/>
+	<EditableField value={parsed ?? ''} placeholder="" ariaLabel={field.name} linkify oninput={onText} />
 {:else if field.field_type === FieldType.integer}
 	<span class="numrow">
 		<input

--- a/client_v2/src/lib/components/ExtraFieldsSection.svelte
+++ b/client_v2/src/lib/components/ExtraFieldsSection.svelte
@@ -22,8 +22,16 @@
 		 * another entity, where an empty section is just noise.
 		 */
 		manage?: boolean;
+		/**
+		 * Emit only the field rows — no section header, no grid of its own — so the
+		 * caller can drop them straight into its own <FieldGrid>. Used by the
+		 * read-only mirrors of another entity, where a second "Extra fields" heading
+		 * in the same panel reads as a peer section rather than as more of the
+		 * entity above it (#992).
+		 */
+		headless?: boolean;
 	}
-	let { entity, extra, onchange, readonly = false, manage = false }: Props = $props();
+	let { entity, extra, onchange, readonly = false, manage = false, headless = false }: Props = $props();
 
 	$effect(() => {
 		fields.ensure(entity);
@@ -43,20 +51,21 @@
 	>
 {/snippet}
 
-{#if show}
+{#snippet rows()}
+	{#each defs as f (f.key)}
+		<Field label={f.name}>
+			<ExtraFieldInput field={f} value={extra[f.key]} onchange={(json) => onchange(f.key, json)} {readonly} />
+		</Field>
+	{/each}
+{/snippet}
+
+{#if headless}
+	{@render rows()}
+{:else if show}
 	<SectionLabel right={manage ? manageLink : undefined}>{m['settings.extraFields.tab']()}</SectionLabel>
 	{#if defs.length}
 		<FieldGrid>
-			{#each defs as f (f.key)}
-				<Field label={f.name}>
-					<ExtraFieldInput
-						field={f}
-						value={extra[f.key]}
-						onchange={(json) => onchange(f.key, json)}
-						{readonly}
-					/>
-				</Field>
-			{/each}
+			{@render rows()}
 		</FieldGrid>
 	{:else}
 		<div class="none">{m['inspector.noExtraFields']()}</div>

--- a/client_v2/src/lib/components/LinkedText.svelte
+++ b/client_v2/src/lib/components/LinkedText.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	/* eslint-disable svelte/no-navigation-without-resolve --
+	   The hrefs below are external absolute URLs out of the user's own field values;
+	   there is no deploy base path to resolve them against. */
+	import { splitLinks } from '$lib/utils/links';
+
+	// Read-only text value with any URLs in it rendered as real links (#992).
+	// Use this wherever a free-text field is *shown* rather than edited; the
+	// editable inputs get the same links as an affordance beside them instead.
+	let { text, placeholder = '—' }: { text: string; placeholder?: string } = $props();
+
+	let segments = $derived(splitLinks(text ?? ''));
+</script>
+
+<!-- prettier-ignore -->
+{#if !segments.length}<span class="empty">{placeholder}</span>{:else}{#each segments as seg, i (i)}{#if seg.href}<a class="link" href={seg.href} target="_blank" rel="nofollow noopener">{seg.text}</a>{:else}{seg.text}{/if}{/each}{/if}
+
+<style>
+	.empty {
+		color: var(--text-dim);
+	}
+	.link {
+		color: var(--accent-link);
+		text-decoration: none;
+		/* Long order URLs must not push the field grid wider than its column. */
+		overflow-wrap: anywhere;
+	}
+	.link:hover {
+		text-decoration: underline;
+	}
+</style>

--- a/client_v2/src/lib/components/library/FilamentInspector.svelte
+++ b/client_v2/src/lib/components/library/FilamentInspector.svelte
@@ -18,6 +18,7 @@
 	import Breadcrumbs from '../Breadcrumbs.svelte';
 	import FieldGrid from '../FieldGrid.svelte';
 	import Field from '../Field.svelte';
+	import VendorSection from './VendorSection.svelte';
 	import type { Filament, Spool } from '$lib/types';
 	import { inventory } from '$lib/stores/inventory.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
@@ -299,13 +300,23 @@
 						oninput={(v) => set({ articleNumber: v })}
 					/>
 				</Field>
+				{#if filament.externalId}
+					<Field label={m['filament.fields.externalId']()} mono>{filament.externalId}</Field>
+				{/if}
 				<Field label={m['filament.fields.registered']()}>{filament.registeredLabel}</Field>
 				<Field label={m['filament.fields.comment']()}>
-					<EditableField value={filament.comment} oninput={(v) => set({ comment: v })} />
+					<EditableField value={filament.comment} linkify oninput={(v) => set({ comment: v })} />
 				</Field>
 			</FieldGrid>
 
 			<ExtraFieldsSection entity="filament" extra={filament.extra} onchange={extraSaver.change} manage />
+		</div>
+
+		<div class="col">
+			<VendorSection
+				{vendor}
+				href={vendor ? params.selectHref(page.url.searchParams, 'vendor', vendor.id) : undefined}
+			/>
 		</div>
 	</div>
 </div>
@@ -420,10 +431,19 @@
 		color: var(--text-dim);
 		flex: none;
 	}
+	/* Specs on the left, the manufacturer's own fields on the right — same split as
+	   the manufacturer view, which puts its filament list in the second column. */
 	.grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		gap: 0 32px;
 		padding: 4px 20px 24px;
+		align-items: start;
 	}
 	@media (max-width: 620px) {
+		.grid {
+			grid-template-columns: 1fr;
+		}
 		/* Keep the header actions reachable on narrow panels by wrapping them onto
 		   their own full-width row instead of hiding them. */
 		.head {

--- a/client_v2/src/lib/components/library/SpoolInspector.svelte
+++ b/client_v2/src/lib/components/library/SpoolInspector.svelte
@@ -18,6 +18,8 @@
 	import Breadcrumbs from '../Breadcrumbs.svelte';
 	import FieldGrid from '../FieldGrid.svelte';
 	import Field from '../Field.svelte';
+	import LinkedText from '../LinkedText.svelte';
+	import VendorSection from './VendorSection.svelte';
 	import type { Filament, Spool } from '$lib/types';
 	import { inventory } from '$lib/stores/inventory.svelte';
 	import { settings } from '$lib/stores/settings.svelte';
@@ -322,7 +324,7 @@
 					<DateTimeField value={spool.lastUsed} oninput={(iso) => set({ lastUsed: iso })} />
 				</Field>
 				<Field label={m['spool.fields.comment']()}>
-					<EditableField value={spool.comment} oninput={(v) => set({ comment: v })} />
+					<EditableField value={spool.comment} linkify oninput={(v) => set({ comment: v })} />
 				</Field>
 			</FieldGrid>
 
@@ -360,14 +362,28 @@
 				<Field label={m['filament.fields.weight']()} help={m['filament.fieldsHelp.weight']()} mono
 					>{filament.weight} g</Field
 				>
-				{#if filament.spoolWeight}
-					<Field label={m['filament.fields.spoolWeight']()} help={m['filament.fieldsHelp.spoolWeight']()} mono
-						>{filament.spoolWeight} g</Field
-					>
+				<Field label={m['filament.fields.spoolWeight']()} help={m['filament.fieldsHelp.spoolWeight']()} mono
+					>{filament.spoolWeight != null ? `${filament.spoolWeight} g` : '—'}</Field
+				>
+				<Field label={m['filament.fields.price']()} mono>{settings.formatPrice(filament.price)}</Field>
+				<Field
+					label={m['filament.fields.articleNumber']()}
+					help={m['filament.fieldsHelp.articleNumber']()}
+					mono>{filament.articleNumber || '—'}</Field
+				>
+				{#if filament.externalId}
+					<Field label={m['filament.fields.externalId']()} mono>{filament.externalId}</Field>
 				{/if}
+				<Field label={m['filament.fields.registered']()}>{filament.registeredLabel}</Field>
+				<Field label={m['filament.fields.comment']()}><LinkedText text={filament.comment} /></Field>
 			</FieldGrid>
 
 			<ExtraFieldsSection entity="filament" extra={filament.extra} onchange={() => {}} readonly />
+
+			<VendorSection
+				{vendor}
+				href={vendor ? params.selectHref(page.url.searchParams, 'vendor', vendor.id) : undefined}
+			/>
 		</div>
 	</div>
 </div>

--- a/client_v2/src/lib/components/library/SpoolInspector.svelte
+++ b/client_v2/src/lib/components/library/SpoolInspector.svelte
@@ -376,9 +376,11 @@
 				{/if}
 				<Field label={m['filament.fields.registered']()}>{filament.registeredLabel}</Field>
 				<Field label={m['filament.fields.comment']()}><LinkedText text={filament.comment} /></Field>
+				<!-- The filament's own custom fields, as further rows of this grid: a
+				     second "Extra fields" heading here would read as a peer of FILAMENT
+				     and MANUFACTURER rather than as more of the filament. -->
+				<ExtraFieldsSection entity="filament" extra={filament.extra} onchange={() => {}} readonly headless />
 			</FieldGrid>
-
-			<ExtraFieldsSection entity="filament" extra={filament.extra} onchange={() => {}} readonly />
 
 			<VendorSection
 				{vendor}

--- a/client_v2/src/lib/components/library/VendorInspector.svelte
+++ b/client_v2/src/lib/components/library/VendorInspector.svelte
@@ -98,9 +98,12 @@
 						onchange={(v) => set({ emptyWeight: Math.round(v) })}
 					/>
 				</Field>
+				{#if vendor.externalId}
+					<Field label={m['vendor.fields.externalId']()} mono>{vendor.externalId}</Field>
+				{/if}
 				<Field label={m['vendor.fields.registered']()}>{vendor.registeredLabel}</Field>
 				<Field label={m['vendor.fields.comment']()}>
-					<EditableField value={vendor.comment} oninput={(v) => set({ comment: v })} />
+					<EditableField value={vendor.comment} linkify oninput={(v) => set({ comment: v })} />
 				</Field>
 			</FieldGrid>
 

--- a/client_v2/src/lib/components/library/VendorSection.svelte
+++ b/client_v2/src/lib/components/library/VendorSection.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+	/* eslint-disable svelte/no-navigation-without-resolve --
+	   `href` comes from a src/lib/library/params.ts helper, which already resolves
+	   against the deploy base path; resolving again would double-apply it. */
+	import SectionLabel from '../SectionLabel.svelte';
+	import FieldGrid from '../FieldGrid.svelte';
+	import Field from '../Field.svelte';
+	import LinkedText from '../LinkedText.svelte';
+	import ExtraFieldsSection from '../ExtraFieldsSection.svelte';
+	import ArrowRight from '@lucide/svelte/icons/arrow-right';
+	import type { Vendor } from '$lib/types';
+	import * as m from '$lib/paraglide/messages';
+
+	// Read-only mirror of a manufacturer's fields, shown inside the filament and
+	// spool detail views. Before #992 those views named the manufacturer and
+	// stopped there, so its empty-spool weight, comment and extra fields were only
+	// reachable by navigating away to the manufacturer itself.
+	interface Props {
+		/** Undefined when the filament has no manufacturer, or it isn't cached yet. */
+		vendor: Vendor | undefined;
+		/** Link to the manufacturer's own detail view. */
+		href?: string;
+	}
+	let { vendor, href }: Props = $props();
+</script>
+
+{#snippet open()}
+	<a class="link" {href} data-sveltekit-keepfocus data-sveltekit-noscroll
+		>{m['inspector.openManufacturer']()} <ArrowRight size={13} /></a
+	>
+{/snippet}
+
+<SectionLabel right={vendor && href ? open : undefined}>
+	{m['library.section.vendor']()}
+</SectionLabel>
+
+{#if vendor}
+	<!-- 140px, as in the manufacturer's own view: "Empty Spool Weight" plus its ⓘ
+	     wraps to two lines in the default 120px label column. -->
+	<FieldGrid labelWidth="140px">
+		<Field label={m['vendor.fields.name']()}>{vendor.name}</Field>
+		<Field label={m['vendor.fields.emptySpoolWeight']()} help={m['vendor.fieldsHelp.emptySpoolWeight']()} mono
+			>{vendor.emptyWeight} g</Field
+		>
+		{#if vendor.externalId}
+			<Field label={m['vendor.fields.externalId']()} mono>{vendor.externalId}</Field>
+		{/if}
+		<Field label={m['vendor.fields.registered']()}>{vendor.registeredLabel}</Field>
+		<Field label={m['vendor.fields.comment']()}><LinkedText text={vendor.comment} /></Field>
+	</FieldGrid>
+
+	<ExtraFieldsSection entity="vendor" extra={vendor.extra} onchange={() => {}} readonly />
+{:else}
+	<div class="none">{m['add.noManufacturer']()}</div>
+{/if}
+
+<style>
+	.link {
+		display: inline-flex;
+		align-items: center;
+		gap: 3px;
+		font-size: 11.5px;
+		color: var(--accent-link);
+		text-decoration: none;
+	}
+	.none {
+		font-size: 12px;
+		color: var(--text-dim);
+	}
+</style>

--- a/client_v2/src/lib/components/library/VendorSection.svelte
+++ b/client_v2/src/lib/components/library/VendorSection.svelte
@@ -47,9 +47,10 @@
 		{/if}
 		<Field label={m['vendor.fields.registered']()}>{vendor.registeredLabel}</Field>
 		<Field label={m['vendor.fields.comment']()}><LinkedText text={vendor.comment} /></Field>
+		<!-- Rows of this same grid rather than their own headed section — see the
+		     `headless` prop's note in ExtraFieldsSection. -->
+		<ExtraFieldsSection entity="vendor" extra={vendor.extra} onchange={() => {}} readonly headless />
 	</FieldGrid>
-
-	<ExtraFieldsSection entity="vendor" extra={vendor.extra} onchange={() => {}} readonly />
 {:else}
 	<div class="none">{m['add.noManufacturer']()}</div>
 {/if}

--- a/client_v2/src/lib/utils/links.test.ts
+++ b/client_v2/src/lib/utils/links.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { extractUrls, splitLinks } from './links';
+
+// These run over user-authored comments and text extra fields, whose contents are
+// rendered as anchors. Both halves matter: finding the link the user meant, and
+// never producing an href from something that isn't a web URL.
+
+describe('splitLinks', () => {
+	it('returns nothing for empty text', () => {
+		expect(splitLinks('')).toEqual([]);
+	});
+
+	it('leaves link-free text as one plain segment', () => {
+		expect(splitLinks('Bought at the local shop')).toEqual([{ text: 'Bought at the local shop' }]);
+	});
+
+	it('links a bare url', () => {
+		expect(splitLinks('https://example.com/p?id=4')).toEqual([
+			{ text: 'https://example.com/p?id=4', href: 'https://example.com/p?id=4' }
+		]);
+	});
+
+	it('keeps the text around a url', () => {
+		expect(splitLinks('order https://shop.example/x thanks')).toEqual([
+			{ text: 'order ' },
+			{ text: 'https://shop.example/x', href: 'https://shop.example/x' },
+			{ text: ' thanks' }
+		]);
+	});
+
+	it('links several urls in one value', () => {
+		expect(extractUrls('a http://one.example b https://two.example/c')).toEqual([
+			'http://one.example',
+			'https://two.example/c'
+		]);
+	});
+
+	it('gives a bare www. host a https scheme', () => {
+		expect(splitLinks('www.example.com/x')).toEqual([
+			{ text: 'www.example.com/x', href: 'https://www.example.com/x' }
+		]);
+	});
+
+	it('leaves sentence punctuation out of the url', () => {
+		expect(extractUrls('see https://example.com/p.')).toEqual(['https://example.com/p']);
+		expect(extractUrls('https://example.com/a, https://example.com/b!')).toEqual([
+			'https://example.com/a',
+			'https://example.com/b'
+		]);
+	});
+
+	it('drops a wrapping paren but keeps a balanced one', () => {
+		expect(extractUrls('(https://example.com/p)')).toEqual(['https://example.com/p']);
+		expect(extractUrls('https://example.com/Foo_(bar)')).toEqual(['https://example.com/Foo_(bar)']);
+	});
+
+	it('accepts a schemed host without a dot, for LAN links', () => {
+		expect(extractUrls('http://octopi/spool')).toEqual(['http://octopi/spool']);
+	});
+
+	it('does not link prose that merely looks host-like', () => {
+		expect(extractUrls('www.something')).toEqual([]);
+		expect(extractUrls('Sold out, see notes.txt')).toEqual([]);
+	});
+
+	it('never links a non-web scheme', () => {
+		// The renderer trusts these hrefs, so anything that could execute must not
+		// come back as a link at all.
+		expect(extractUrls('javascript:alert(1)')).toEqual([]);
+		expect(extractUrls('data:text/html,<script>')).toEqual([]);
+		expect(extractUrls('file:///etc/passwd')).toEqual([]);
+	});
+
+	it('reassembles to the original text', () => {
+		const text = 'buy (https://example.com/a) or www.example.org/b. done';
+		expect(
+			splitLinks(text)
+				.map((s) => s.text)
+				.join('')
+		).toBe(text);
+	});
+});

--- a/client_v2/src/lib/utils/links.ts
+++ b/client_v2/src/lib/utils/links.ts
@@ -1,0 +1,96 @@
+// Find URLs inside free-text field values (comments, text extra fields) so they
+// can be rendered as real links instead of dead text — a comment holding an
+// order link or a product page is a common way to use these fields (#992).
+//
+// Only http(s) and bare www. forms are recognised, which is deliberate: the
+// values come from users but are rendered as anchors, and never producing a
+// `javascript:`/`data:` href is the simplest way to keep that safe.
+
+export interface TextSegment {
+	/** The text to render. */
+	text: string;
+	/** Set when this segment is a URL: the href to link it to. */
+	href?: string;
+}
+
+/** Matches a candidate URL; the trailing run is trimmed down by `trimUrl`. */
+const URL_PATTERN = /(?:https?:\/\/|www\.)[^\s<>"'`]+/gi;
+
+/** Sentence punctuation that follows a URL far more often than it belongs to one. */
+const TRAILING_PUNCT = /[.,;:!?'"]+$/;
+
+const BRACKETS: [string, string][] = [
+	['(', ')'],
+	['[', ']'],
+	['{', '}']
+];
+
+function count(s: string, ch: string): number {
+	let n = 0;
+	for (const c of s) if (c === ch) n++;
+	return n;
+}
+
+/**
+ * Trim what the regex over-matched: "see https://example.com/p." ends a sentence,
+ * and "(https://example.com/p)" wraps the URL in parens. A *balanced* bracket is
+ * kept, since paths legitimately contain them.
+ */
+function trimUrl(raw: string): string {
+	let url = raw.replace(TRAILING_PUNCT, '');
+	let trimmed = true;
+	while (trimmed) {
+		trimmed = false;
+		for (const [open, close] of BRACKETS) {
+			if (url.endsWith(close) && count(url, close) > count(url, open)) {
+				url = url.slice(0, -1).replace(TRAILING_PUNCT, '');
+				trimmed = true;
+			}
+		}
+	}
+	return url;
+}
+
+/**
+ * Reject matches that can't be a real destination. An explicit scheme only needs
+ * a host — LAN links like `http://octopi/` are perfectly valid — but the bare
+ * `www.` form needs a dotted name, so prose like "www.something" isn't linked.
+ */
+function isUsable(url: string): boolean {
+	const scheme = /^https?:\/\//i.exec(url);
+	const host = url.slice(scheme ? scheme[0].length : 0).split(/[/?#]/)[0];
+	if (!host || host.startsWith('.') || host.endsWith('.')) return false;
+	return scheme ? true : /^www\.[^.\s]+\.[^.\s]/i.test(host);
+}
+
+function toHref(url: string): string {
+	return /^https?:\/\//i.test(url) ? url : 'https://' + url;
+}
+
+/**
+ * Split free text into plain and linked segments, in order. Text with no URLs
+ * comes back as a single plain segment (or none, when empty).
+ */
+export function splitLinks(text: string): TextSegment[] {
+	const out: TextSegment[] = [];
+	if (!text) return out;
+	const re = new RegExp(URL_PATTERN.source, 'gi');
+	let last = 0;
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(text)) !== null) {
+		const url = trimUrl(match[0]);
+		if (!url || !isUsable(url)) continue;
+		if (match.index > last) out.push({ text: text.slice(last, match.index) });
+		out.push({ text: url, href: toHref(url) });
+		last = match.index + url.length;
+	}
+	if (last < text.length) out.push({ text: text.slice(last) });
+	return out;
+}
+
+/** The hrefs of every URL in `text`, in order. Empty when there are none. */
+export function extractUrls(text: string): string[] {
+	return splitLinks(text)
+		.map((s) => s.href)
+		.filter((h): h is string => !!h);
+}


### PR DESCRIPTION
Fixes #992.

The spool view's filament section only listed the specs, and neither the spool nor the filament view showed anything of the manufacturer beyond its name.

- The filament section in the spool view gains price, article number, external ID, registered and comment, and always shows spool weight instead of hiding it when unset.
- Both the spool and filament views get a read-only manufacturer section (its fields, its extra fields, and a link to it).
- URLs in comments and text extra fields are now links, opening in a new tab with rel="nofollow noopener". Read-only values render them inline; where the value stays editable, each URL gets an external-link icon next to the input, since an inline anchor cannot also be a caret target.

Only http(s) and www. forms are linked, so a value can never produce a javascript: or data: href. Trailing sentence punctuation and wrapping parens are trimmed off the match.

The mirrored extra fields are emitted as rows of the section's own field grid rather than under their own "Extra fields" heading, which otherwise reads as a peer of FILAMENT and MANUFACTURER. Sections that own their extra fields keep the heading and its "Manage fields" link.