### PR TITLE
Distinguish the search result material tag from the match tag

### DIFF
--- a/client_v2/src/lib/components/MaterialBadge.svelte
+++ b/client_v2/src/lib/components/MaterialBadge.svelte
@@ -1,8 +1,16 @@
 <script lang="ts">
-	let { label }: { label: string } = $props();
+	interface Props {
+		label: string;
+		/** `solid` is the default chip. `outline` is for places where a filled chip
+		 *  would read as the same kind of thing as a neighbouring filled chip that
+		 *  says something else entirely — see the search panel's "matched" tag. */
+		variant?: 'solid' | 'outline';
+	}
+
+	let { label, variant = 'solid' }: Props = $props();
 </script>
 
-<span class="badge mono">{label}</span>
+<span class="badge mono" class:outline={variant === 'outline'}>{label}</span>
 
 <style>
 	.badge {
@@ -12,5 +20,12 @@
 		background: var(--surface-raised);
 		color: var(--text-2);
 		white-space: nowrap;
+	}
+	.badge.outline {
+		background: none;
+		border: 1px solid var(--border);
+		color: var(--text-dim);
+		padding: 0 5px;
+		letter-spacing: 0.02em;
 	}
 </style>

--- a/client_v2/src/lib/components/library/SearchBox.svelte
+++ b/client_v2/src/lib/components/library/SearchBox.svelte
@@ -282,10 +282,17 @@
 								size={20}
 							/>
 							<span class="text">
-								<span class="title">{filament.entity.name}</span>
+								<!-- Material sits with the name because it describes the filament, unlike
+								     the trailing "matched" tag which describes the search hit. Two chips
+								     of the same shape side by side read as the same kind of fact. -->
+								<span class="line">
+									<span class="title">{filament.entity.name}</span>
+									{#if filament.entity.material}
+										<MaterialBadge label={filament.entity.material} variant="outline" />
+									{/if}
+								</span>
 								{#if vendor?.name}<span class="sub">{vendor.name}</span>{/if}
 							</span>
-							{#if filament.entity.material}<MaterialBadge label={filament.entity.material} />{/if}
 							<span class="match">{matchLabel('filament', filament.matchField)}</span>
 						</a>
 					{/each}
@@ -411,12 +418,22 @@
 		flex-direction: column;
 		line-height: 1.25;
 	}
+	.line {
+		display: flex;
+		align-items: center;
+		gap: 6px;
+		min-width: 0;
+	}
 	.title {
 		font-size: 12.5px;
 		font-weight: 600;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+	/* A long name yields to the material chip rather than pushing it out of the row. */
+	.line .title {
+		min-width: 0;
 	}
 	.sub {
 		font-size: 11px;


### PR DESCRIPTION
In the search panel the filament material chip and the "matched: <field>" chip sat next to each other at the right edge with identical styling, so two unrelated things looked like the same kind of tag. Worst case was searching a material, where a row would show "PLA" next to "Material".

Material now sits right after the filament name (same as the group header does it) and uses a new outline variant of MaterialBadge, so the filled chip on the right only ever means "why this result matched".