### PR TITLE
Offer a filament's spools in the search results

### DIFF
--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -364,6 +364,7 @@
     "scanner.starting": "Starting camera...",
     "scanner.title": "QR Code Scanner",
     "search.colorHint": "Color names must be entered in English.",
+    "search.moreSpools": "+{{count}} more",
     "search.noResults": "No matches found",
     "search.searching": "Searching...",
     "search.section.filaments": "Filaments",

--- a/client_v2/src/lib/api/search.ts
+++ b/client_v2/src/lib/api/search.ts
@@ -1,5 +1,5 @@
-import type { SearchMatch, SearchResults } from './types';
-import type { Filament, Spool, Vendor } from '$lib/types';
+import type { FilamentSearchMatch, FilamentSpoolHit, SearchMatch, SearchResults } from './types';
+import type { Spool, Vendor } from '$lib/types';
 import { API_BASE } from './config';
 import { mapFilament, mapSpool, mapVendor } from './map';
 import { inventory } from '$lib/stores/inventory.svelte';
@@ -7,6 +7,11 @@ import { inventory } from '$lib/stores/inventory.svelte';
 // Cross-entity search against GET /api/v1/search. Like the spool source, every
 // entity it fetches is upserted into the reactive cache so that clicking a result
 // (which opens its inspector) has the data ready immediately.
+
+// Spools to request per matching filament, shown as shortcut pills under the
+// filament (issue #993: searching a filament name should lead to a spool). Kept
+// small: the panel only has room for a few, and every keystroke re-queries.
+const SPOOLS_PER_FILAMENT = 5;
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type Json = Record<string, any>;
@@ -24,12 +29,29 @@ function mapSpoolHit(m: Json): SearchMatch<Spool> {
 	return { entity: spool, matchField: m.match_field };
 }
 
-function mapFilamentHit(m: Json): SearchMatch<Filament> {
+function mapFilamentSpool(s: Json): FilamentSpoolHit {
+	return {
+		id: s.id,
+		remainingWeight: s.remaining_weight ?? undefined,
+		location: s.location ?? undefined,
+		archived: !!s.archived
+	};
+}
+
+function mapFilamentHit(m: Json): FilamentSearchMatch {
 	const raw: Json = m.filament ?? {};
 	if (raw.vendor) inventory.upsertVendor(mapVendor(raw.vendor));
 	const filament = mapFilament(raw);
 	inventory.upsertFilament(filament);
-	return { entity: filament, matchField: m.match_field };
+	// These are too partial to upsert into the inventory cache; opening one fetches
+	// the full spool (see Inspector.svelte), which is what a plain deep link does too.
+	const spools = (m.spools ?? []).map(mapFilamentSpool);
+	return {
+		entity: filament,
+		matchField: m.match_field,
+		spools,
+		spoolCount: m.spool_count ?? spools.length
+	};
 }
 
 function mapVendorHit(m: Json): SearchMatch<Vendor> {
@@ -50,7 +72,11 @@ export async function searchAll(
 	const q = query.trim();
 	if (!q) return EMPTY;
 
-	const params = new URLSearchParams({ q, color_similarity_threshold: String(threshold) });
+	const params = new URLSearchParams({
+		q,
+		color_similarity_threshold: String(threshold),
+		spools_per_filament: String(SPOOLS_PER_FILAMENT)
+	});
 	const res = await fetch(`${API_BASE}/search?${params.toString()}`, { signal });
 	if (!res.ok) throw new Error(`GET /search → ${res.status}`);
 	const data = (await res.json()) as Json;

--- a/client_v2/src/lib/api/types.ts
+++ b/client_v2/src/lib/api/types.ts
@@ -100,10 +100,25 @@ export interface SearchMatch<T> {
 	matchField: string;
 }
 
+/** One of a matched filament's spools, in the fields a shortcut pill shows. */
+export interface FilamentSpoolHit {
+	id: number;
+	remainingWeight?: number;
+	location?: string;
+	archived: boolean;
+}
+
+/** A filament search hit, plus the spools offered as shortcuts beneath it. */
+export interface FilamentSearchMatch extends SearchMatch<Filament> {
+	spools: FilamentSpoolHit[];
+	/** Total spools of this filament, of which `spools` holds at most the first few. */
+	spoolCount: number;
+}
+
 /** Categorized results of a cross-entity search. */
 export interface SearchResults {
 	spools: SearchMatch<Spool>[];
-	filaments: SearchMatch<Filament>[];
+	filaments: FilamentSearchMatch[];
 	vendors: SearchMatch<Vendor>[];
 	/** True when the query was recognized as a color (a threshold slider is relevant). */
 	isColorQuery: boolean;

--- a/client_v2/src/lib/components/library/SearchBox.svelte
+++ b/client_v2/src/lib/components/library/SearchBox.svelte
@@ -12,6 +12,7 @@
 	import { page } from '$app/state';
 	import { inventory } from '$lib/stores/inventory.svelte';
 	import { fields } from '$lib/stores/fields.svelte';
+	import { weightAuto } from '$lib/utils/format';
 	import type { EntityKind } from '$lib/types';
 	import * as m from '$lib/paraglide/messages';
 
@@ -100,14 +101,34 @@
 	interface FlatItem {
 		kind: EntityKind;
 		id: string;
+		/** Unique per row. A spool can be both its own result and a pill under a
+		 *  filament, so kind+id alone would highlight two rows at once. */
+		key: string;
 	}
 
 	let flat = $derived<FlatItem[]>(
 		results
 			? [
-					...results.spools.map((m) => ({ kind: 'spool' as const, id: String(m.entity.id) })),
-					...results.filaments.map((m) => ({ kind: 'filament' as const, id: m.entity.id })),
-					...results.vendors.map((m) => ({ kind: 'vendor' as const, id: m.entity.id }))
+					...results.spools.map((m) => ({
+						kind: 'spool' as const,
+						id: String(m.entity.id),
+						key: `spool:${m.entity.id}`
+					})),
+					// Each filament is followed by its spool pills, so arrowing down walks
+					// from the filament straight into its spools.
+					...results.filaments.flatMap((m) => [
+						{ kind: 'filament' as const, id: m.entity.id, key: `filament:${m.entity.id}` },
+						...m.spools.map((s) => ({
+							kind: 'spool' as const,
+							id: String(s.id),
+							key: `filament:${m.entity.id}/spool:${s.id}`
+						}))
+					]),
+					...results.vendors.map((m) => ({
+						kind: 'vendor' as const,
+						id: m.entity.id,
+						key: `vendor:${m.entity.id}`
+					}))
 				]
 			: []
 	);
@@ -194,9 +215,9 @@
 		return matchField in MATCH_LABEL[kind] ? MATCH_LABEL[kind][matchField]() : matchField;
 	}
 
-	// The flat index of an item, so hover/selection highlight lines up with keyboard nav.
-	function indexOf(kind: EntityKind, id: string): number {
-		return flat.findIndex((f) => f.kind === kind && f.id === id);
+	// The flat index of a row, so hover/selection highlight lines up with keyboard nav.
+	function indexOf(key: string): number {
+		return flat.findIndex((f) => f.key === key);
 	}
 </script>
 
@@ -239,7 +260,7 @@
 						{@const filament = inventory.filamentById(spool.entity.filamentId)}
 						<a
 							class="result"
-							class:active={activeIndex === indexOf('spool', String(spool.entity.id))}
+							class:active={activeIndex === indexOf(`spool:${spool.entity.id}`)}
 							href={searchResultHref(
 								page.url.searchParams,
 								page.url.pathname,
@@ -266,7 +287,7 @@
 						{@const vendor = inventory.vendorById(filament.entity.vendorId)}
 						<a
 							class="result"
-							class:active={activeIndex === indexOf('filament', filament.entity.id)}
+							class:active={activeIndex === indexOf(`filament:${filament.entity.id}`)}
 							href={searchResultHref(
 								page.url.searchParams,
 								page.url.pathname,
@@ -288,6 +309,44 @@
 							{#if filament.entity.material}<MaterialBadge label={filament.entity.material} />{/if}
 							<span class="match">{matchLabel('filament', filament.matchField)}</span>
 						</a>
+						<!-- Shortcut straight to a spool of this filament (#993). Sibling of the
+						     result anchor rather than inside it: an <a> may not nest. -->
+						{#if filament.spools.length}
+							<div class="pills">
+								{#each filament.spools as s (s.id)}
+									<a
+										class="pill"
+										class:active={activeIndex === indexOf(`filament:${filament.entity.id}/spool:${s.id}`)}
+										class:archived={s.archived}
+										href={searchResultHref(page.url.searchParams, page.url.pathname, 'spool', String(s.id))}
+										title={s.location ?? undefined}
+										data-sveltekit-noscroll
+										onclick={onResultClick}
+									>
+										<span class="mono">#{s.id}</span>
+										{#if s.remainingWeight !== undefined}<span class="pill-weight"
+												>{weightAuto(s.remainingWeight)}</span
+											>{/if}
+									</a>
+								{/each}
+								{#if filament.spoolCount > filament.spools.length}
+									<!-- The filament page lists them all, so send the overflow there. -->
+									<a
+										class="pill more"
+										href={searchResultHref(
+											page.url.searchParams,
+											page.url.pathname,
+											'filament',
+											filament.entity.id
+										)}
+										data-sveltekit-noscroll
+										onclick={onResultClick}
+									>
+										{m['search.moreSpools']({ count: filament.spoolCount - filament.spools.length })}
+									</a>
+								{/if}
+							</div>
+						{/if}
 					{/each}
 				{/if}
 
@@ -296,7 +355,7 @@
 					{#each results.vendors as vendor (vendor.entity.id)}
 						<a
 							class="result"
-							class:active={activeIndex === indexOf('vendor', vendor.entity.id)}
+							class:active={activeIndex === indexOf(`vendor:${vendor.entity.id}`)}
 							href={searchResultHref(page.url.searchParams, page.url.pathname, 'vendor', vendor.entity.id)}
 							data-sveltekit-noscroll
 							onclick={onResultClick}
@@ -439,5 +498,44 @@
 		width: 20px;
 		text-align: center;
 		flex: none;
+	}
+	/* Indented to line up with the filament's title, so the pills read as belonging
+	   to the result above rather than as results of their own. */
+	.pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 4px;
+		padding: 0 12px 7px 41px;
+	}
+	.pill {
+		display: inline-flex;
+		align-items: baseline;
+		gap: 5px;
+		padding: 2px 7px;
+		border: 1px solid var(--hairline);
+		border-radius: 999px;
+		background: var(--surface-raised);
+		color: var(--text-dim);
+		font-size: 11px;
+		text-decoration: none;
+		white-space: nowrap;
+	}
+	.pill:hover,
+	.pill.active {
+		border-color: var(--border-strong);
+		background: var(--surface-2);
+		color: var(--text);
+	}
+	.pill .mono {
+		font-size: 11px;
+	}
+	.pill-weight {
+		color: var(--text-muted);
+	}
+	.pill.archived {
+		opacity: 0.55;
+	}
+	.pill.more {
+		border-style: dashed;
 	}
 </style>

--- a/spoolman/api/v1/models.py
+++ b/spoolman/api/v1/models.py
@@ -2,13 +2,18 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import BaseModel, Field, PlainSerializer
 
 from spoolman.database import models
 from spoolman.math import length_from_weight
 from spoolman.settings import SettingDefinition, SettingType
+
+if TYPE_CHECKING:
+    # Only for typing: spoolman.database.search reaches spoolman.database.filament,
+    # which imports this module, so importing it for real would be circular.
+    from spoolman.database import search
 
 
 def datetime_to_str(dt: datetime) -> str:
@@ -441,6 +446,44 @@ class SearchResultSpool(BaseModel):
     )
 
 
+class SearchResultFilamentSpool(BaseModel):
+    """A spool of a filament that matched a search, in the fields needed to offer it as a shortcut."""
+
+    id: int = Field(description="Unique internal ID of this spool of filament.")
+    remaining_weight: float | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Estimated remaining weight of filament on the spool in grams. "
+            "Only set if the spool or its filament type has a weight set."
+        ),
+        examples=[500.6],
+    )
+    location: str | None = Field(
+        None,
+        max_length=64,
+        description="Where this spool can be found.",
+        examples=["Shelf A"],
+    )
+    archived: bool = Field(description="Whether this spool is archived and should not be used anymore.")
+
+    @staticmethod
+    def from_db(item: "search.FilamentSpool", filament_weight: float | None) -> "SearchResultFilamentSpool":
+        """Create the compact spool object, deriving its weight the way `Spool.from_db` does."""
+        remaining_weight: float | None = None
+        if item.initial_weight is not None:
+            remaining_weight = max(item.initial_weight - item.used_weight, 0)
+        elif filament_weight is not None:
+            remaining_weight = max(filament_weight - item.used_weight, 0)
+
+        return SearchResultFilamentSpool(
+            id=item.id,
+            remaining_weight=remaining_weight,
+            location=item.location,
+            archived=item.archived,
+        )
+
+
 class SearchResultFilament(BaseModel):
     """A filament that matched a search, with which field matched."""
 
@@ -451,6 +494,22 @@ class SearchResultFilament(BaseModel):
             "'article_number', 'comment'), 'color' for a color-similarity match, or 'extra.<key>'."
         ),
         examples=["color"],
+    )
+    spools: list[SearchResultFilamentSpool] | None = Field(
+        default=None,
+        description=(
+            "The filament's first spools, oldest id first, so a filament hit can be followed "
+            "straight to one of its spools. Only present if spools_per_filament was requested. "
+            "Obeys allow_archived like the rest of the response."
+        ),
+    )
+    spool_count: int | None = Field(
+        default=None,
+        description=(
+            "How many spools this filament has in total, of which `spools` holds at most "
+            "spools_per_filament. Only present if spools_per_filament was requested."
+        ),
+        examples=[3],
     )
 
 

--- a/spoolman/api/v1/search.py
+++ b/spoolman/api/v1/search.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from spoolman.api.v1.models import (
     Filament,
     SearchResultFilament,
+    SearchResultFilamentSpool,
     SearchResults,
     SearchResultSpool,
     SearchResultVendor,
@@ -41,7 +42,8 @@ router = APIRouter(
         "is a hex code (e.g. '#ff0000') or a CSS color name (e.g. 'red') additionally runs a "
         "color-similarity search over filaments. Results are categorized by entity and each result "
         "reports which field matched. Archived spools are excluded unless allow_archived is set, "
-        "matching the behavior of the spool endpoint."
+        "matching the behavior of the spool endpoint. Set spools_per_filament to also get each "
+        "matching filament's first few spools, so a filament hit leads straight to a spool."
     ),
     response_model_exclude_none=True,
 )
@@ -87,6 +89,18 @@ async def search_endpoint(
             description="Whether to include archived spools in the results.",
         ),
     ] = False,
+    spools_per_filament: Annotated[
+        int,
+        Query(
+            title="Spools Per Filament",
+            description=(
+                "How many of each matching filament's spools to include with it, so a filament hit "
+                "can be followed straight to one of its spools. 0 (the default) omits them entirely."
+            ),
+            ge=0,
+            le=10,
+        ),
+    ] = 0,
 ) -> SearchResults:
     result = await search.search(
         db=db,
@@ -94,11 +108,21 @@ async def search_endpoint(
         color_similarity_threshold=color_similarity_threshold,
         limit=limit,
         allow_archived=allow_archived,
+        spools_per_filament=spools_per_filament,
     )
     return SearchResults(
         spools=[SearchResultSpool(spool=Spool.from_db(m.spool), match_field=m.match_field) for m in result.spools],
         filaments=[
-            SearchResultFilament(filament=Filament.from_db(m.filament), match_field=m.match_field)
+            SearchResultFilament(
+                filament=Filament.from_db(m.filament),
+                match_field=m.match_field,
+                spools=(
+                    None
+                    if m.spools is None
+                    else [SearchResultFilamentSpool.from_db(s, m.filament.weight) for s in m.spools]
+                ),
+                spool_count=m.spool_count,
+            )
             for m in result.filaments
         ],
         vendors=[

--- a/spoolman/database/search.py
+++ b/spoolman/database/search.py
@@ -64,9 +64,24 @@ class SpoolMatch:
 
 
 @dataclass
+class FilamentSpool:
+    """A spool of a matched filament, in the few raw columns a search result needs."""
+
+    id: int
+    initial_weight: float | None
+    used_weight: float
+    location: str | None
+    archived: bool
+
+
+@dataclass
 class FilamentMatch:
     filament: models.Filament
     match_field: str
+    # Both stay None unless the caller asked for spools, so "not requested" is
+    # distinguishable from "this filament has no spools".
+    spools: list[FilamentSpool] | None = None
+    spool_count: int | None = None
 
 
 @dataclass
@@ -332,6 +347,76 @@ async def _search_filaments(
     return [FilamentMatch(filament=filaments[fid], match_field=field) for fid, (field, _rank) in ordered]
 
 
+async def _attach_filament_spools(
+    db: AsyncSession,
+    matches: list[FilamentMatch],
+    per_filament: int,
+    *,
+    allow_archived: bool,
+) -> None:
+    """Annotate each filament match with its first few spools, and how many it has in total.
+
+    A filament hit answers "you own this filament"; the spools answer "and here is
+    the one to click". Searching a filament name is the common way to reach a spool
+    (issue #993), and without this the search box can only offer the filament.
+
+    One query fetches the few scalar columns of every spool of every matched filament,
+    then the rows are grouped, counted and trimmed in Python. That is bounded by the
+    spools of at most ``limit`` filaments -- a handful of rows for any real inventory --
+    and it keeps the exact total for free. The portable alternative for a per-group
+    limit is a window function, which is deliberately avoided: this has to behave
+    identically on SQLite, PostgreSQL, MySQL/MariaDB and CockroachDB.
+
+    Spools are ordered by id, so the "first" spools are the oldest ones, the same
+    numbering the user sees on the spool itself. Ordering by ``last_used`` would read
+    better but sorts nulls differently across those four databases.
+    """
+    if not matches or per_filament <= 0:
+        return
+
+    by_id = {m.filament.id: m for m in matches}
+    stmt = (
+        select(
+            models.Spool.filament_id,
+            models.Spool.id,
+            models.Spool.initial_weight,
+            models.Spool.used_weight,
+            models.Spool.location,
+            models.Spool.archived,
+        )
+        .where(models.Spool.filament_id.in_(by_id.keys()))
+        .order_by(models.Spool.id)
+    )
+    if not allow_archived:
+        # Same archived clause as everywhere else here, so the pills can't offer a
+        # spool that the spool section of the very same response is hiding.
+        stmt = stmt.where(
+            or_(
+                models.Spool.archived.is_(False),
+                models.Spool.archived.is_(None),
+            ),
+        )
+
+    counts: dict[int, int] = dict.fromkeys(by_id, 0)
+    spools: dict[int, list[FilamentSpool]] = {fid: [] for fid in by_id}
+    for filament_id, spool_id, initial_weight, used_weight, location, archived in (await db.execute(stmt)).all():
+        counts[filament_id] += 1
+        if len(spools[filament_id]) < per_filament:
+            spools[filament_id].append(
+                FilamentSpool(
+                    id=spool_id,
+                    initial_weight=initial_weight,
+                    used_weight=used_weight,
+                    location=location,
+                    archived=bool(archived),
+                ),
+            )
+
+    for filament_id, match in by_id.items():
+        match.spools = spools[filament_id]
+        match.spool_count = counts[filament_id]
+
+
 async def _search_vendors(db: AsyncSession, terms: list[str], limit: int) -> list[VendorMatch]:
     native_fields = (
         ("name", models.Vendor.name),
@@ -409,6 +494,7 @@ async def search(
     color_similarity_threshold: float = 20.0,
     limit: int = 20,
     allow_archived: bool = False,
+    spools_per_filament: int = 0,
 ) -> SearchResult:
     """Run a cross-entity search for ``query`` and return categorized, annotated results."""
     q = query.strip()
@@ -424,6 +510,9 @@ async def search(
     spools = await _search_spools(db, terms, limit, allow_archived=allow_archived)
     filaments = await _search_filaments(db, terms, limit, color_hits)
     vendors = await _search_vendors(db, terms, limit)
+
+    # After trimming to `limit`, so we only fetch spools for filaments we return.
+    await _attach_filament_spools(db, filaments, spools_per_filament, allow_archived=allow_archived)
 
     # Numeric query: surface the spool with that exact id at the very top.
     if q.isdigit():

--- a/tests_frontend_v2/tests/helpers.ts
+++ b/tests_frontend_v2/tests/helpers.ts
@@ -97,6 +97,8 @@ export interface NewSpool {
   usedG?: number;
   /** Values for the filament's extra fields, keyed by their display name. */
   filamentExtra?: Record<string, string>;
+  /** How many identical spools of the filament to create. Defaults to one. */
+  count?: number;
 }
 
 /**
@@ -111,7 +113,16 @@ export interface NewSpool {
  * their own on top.
  */
 export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<void> {
-  const { vendorName, filamentName, locationName, material = "PLA", weightG = 1000, usedG, filamentExtra } = spool;
+  const {
+    vendorName,
+    filamentName,
+    locationName,
+    material = "PLA",
+    weightG = 1000,
+    usedG,
+    filamentExtra,
+    count = 1,
+  } = spool;
 
   const dialog = await openAddSpoolModal(page);
 
@@ -143,6 +154,7 @@ export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<
   }
 
   await expect(numberField(dialog, "Count")).toHaveValue("1");
+  if (count !== 1) await numberField(dialog, "Count").fill(String(count));
   await numberField(dialog, "Weight").fill(String(weightG));
   await dialog.getByPlaceholder("e.g. Shelf A").fill(locationName);
 
@@ -153,7 +165,8 @@ export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<
     await dialog.getByPlaceholder("0", { exact: true }).fill(String(usedG));
   }
 
-  await dialog.getByRole("button", { name: "Add 1 spool", exact: true }).click();
+  const submitLabel = count === 1 ? "Add 1 spool" : `Add ${count} spools`;
+  await dialog.getByRole("button", { name: submitLabel, exact: true }).click();
 
   // A successful submit closes the modal.
   await expect(dialog).toBeHidden();

--- a/tests_frontend_v2/tests/search.spec.ts
+++ b/tests_frontend_v2/tests/search.spec.ts
@@ -75,6 +75,36 @@ test("the top-bar search covers all three entities", async ({ page }) => {
   });
 });
 
+test("a filament result offers its spools as shortcuts", async ({ page }) => {
+  // Issue #993: a spool only matches on its own text, so searching a filament
+  // name used to be a dead end — the hit named the filament you own but gave no
+  // way to reach any of its spools. Each filament hit now carries the first few.
+  const many = {
+    vendorName: unique("PillVendor"),
+    filamentName: unique("PillFilament"),
+    locationName: unique("PillShelf"),
+    count: 6,
+  };
+
+  await openApp(page);
+  await createSpoolViaModal(page, many);
+
+  const panel = await searchFor(page, many.filamentName);
+  await expect(panel.getByText(many.filamentName, { exact: true })).toBeVisible();
+
+  // Six spools, five pills: the rest are behind an overflow link to the filament,
+  // which lists all of them.
+  const pills = panel.locator(".pills a:not(.more)");
+  await expect(pills).toHaveCount(5);
+  await expect(pills.first()).toHaveText(/^#\d+/);
+  await expect(panel.locator(".pills a.more")).toHaveText("+1 more");
+
+  // The point of the whole thing: one click from a filament name to a spool.
+  await pills.first().click();
+  await expect(page).toHaveURL(/[?&]sel=spool(:|%3A)\d+/);
+  await expect(panel).toBeHidden();
+});
+
 test("a search that matches nothing says so", async ({ page }) => {
   await openApp(page);
 

--- a/tests_integration/tests/search/test_search.py
+++ b/tests_integration/tests/search/test_search.py
@@ -102,12 +102,15 @@ def _search(
     color_similarity_threshold: float | None = None,
     *,
     allow_archived: bool | None = None,
+    spools_per_filament: int | None = None,
 ) -> dict[str, Any]:
     params: dict[str, Any] = {"q": query}
     if color_similarity_threshold is not None:
         params["color_similarity_threshold"] = color_similarity_threshold
     if allow_archived is not None:
         params["allow_archived"] = allow_archived
+    if spools_per_filament is not None:
+        params["spools_per_filament"] = spools_per_filament
     result = httpx.get(f"{URL}/api/v1/search", params=params)
     result.raise_for_status()
     return result.json()
@@ -238,3 +241,85 @@ def test_search_by_id_respects_allow_archived(archived_spool: dict[str, Any]):
     spool_id = archived_spool["id"]
     assert not _has(_search(str(spool_id))["spools"], "spool", spool_id, "id")
     assert _has(_search(str(spool_id), allow_archived=True)["spools"], "spool", spool_id, "id")
+
+
+# --- spools attached to filament results (issue #993) -------------------------------
+
+
+@pytest.fixture
+def extra_spools(data: Fixture) -> Iterable[list[dict[str, Any]]]:
+    """Two more spools of the fixture's filament, so it has three in total."""
+    spools = []
+    for _ in range(2):
+        result = httpx.post(
+            f"{URL}/api/v1/spool",
+            json={"filament_id": data.filament["id"], "remaining_weight": 600},
+        )
+        result.raise_for_status()
+        spools.append(result.json())
+    yield spools
+    for spool in spools:
+        httpx.delete(f"{URL}/api/v1/spool/{spool['id']}").raise_for_status()
+
+
+def _filament_hit(body: dict[str, Any], filament_id: int) -> dict[str, Any]:
+    return next(i for i in body["filaments"] if i["filament"]["id"] == filament_id)
+
+
+def test_filament_spools_omitted_by_default(data: Fixture, extra_spools: list[dict[str, Any]]):
+    """Not asking for spools leaves the response exactly as it was before."""
+    assert extra_spools  # the filament does have spools to omit
+    hit = _filament_hit(_search(FILAMENT_NAME), data.filament["id"])
+    assert "spools" not in hit
+    assert "spool_count" not in hit
+
+
+def test_filament_spools_returned_when_requested(data: Fixture, extra_spools: list[dict[str, Any]]):
+    """A filament hit carries its spools, oldest id first, plus the total count."""
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=5), data.filament["id"])
+    expected = sorted([data.spool["id"], *(s["id"] for s in extra_spools)])
+    assert [s["id"] for s in hit["spools"]] == expected
+    assert hit["spool_count"] == 3
+
+
+def test_filament_spools_have_remaining_weight(data: Fixture, extra_spools: list[dict[str, Any]]):
+    """The compact spool derives the same remaining weight the spool endpoint reports."""
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=5), data.filament["id"])
+    by_id = {s["id"]: s for s in hit["spools"]}
+    assert by_id[data.spool["id"]]["remaining_weight"] == pytest.approx(1000)
+    assert by_id[extra_spools[0]["id"]]["remaining_weight"] == pytest.approx(600)
+
+
+def test_filament_spools_location(data: Fixture):
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=5), data.filament["id"])
+    assert hit["spools"][0]["location"] == SPOOL_LOCATION
+
+
+def test_filament_spools_respect_the_requested_count(data: Fixture, extra_spools: list[dict[str, Any]]):
+    """Only the first N come back, but the count still reports every spool."""
+    assert extra_spools
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=2), data.filament["id"])
+    assert len(hit["spools"]) == 2
+    assert hit["spool_count"] == 3
+
+
+def test_filament_spools_zero_means_omitted(data: Fixture):
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=0), data.filament["id"])
+    assert "spools" not in hit
+
+
+def test_filament_spools_exclude_archived_by_default(data: Fixture, archived_spool: dict[str, Any]):
+    """An archived spool must not be offered as a shortcut, nor counted."""
+    hit = _filament_hit(_search(FILAMENT_NAME, spools_per_filament=10), data.filament["id"])
+    assert archived_spool["id"] not in [s["id"] for s in hit["spools"]]
+    assert hit["spool_count"] == 1
+
+
+def test_filament_spools_include_archived_when_allowed(data: Fixture, archived_spool: dict[str, Any]):
+    hit = _filament_hit(
+        _search(FILAMENT_NAME, allow_archived=True, spools_per_filament=10),
+        data.filament["id"],
+    )
+    archived = next(s for s in hit["spools"] if s["id"] == archived_spool["id"])
+    assert archived["archived"] is True
+    assert hit["spool_count"] == 2


### PR DESCRIPTION
Searching a filament name only ever returned the filament. Spools match on their own text (comment, location, lot number, extra fields) or an exact id, so a name that lives on the filament could not reach any of its spools.

Filament results now show their first 5 spools as pills, with a "+N more" link to the filament for the rest.

`GET /search` gains an opt-in `spools_per_filament` parameter. It defaults to 0, which leaves the response exactly as it was, so nothing else reading the endpoint changes. The spools are fetched in one query and grouped in Python rather than with a per-group window function, so the behaviour is identical on all four databases and the exact total count comes for free. They respect `allow_archived` like the rest of the response, and are ordered by id.

Fixes #993