### PR TITLE
Allow reordering of extra field choices

### DIFF
--- a/client/public/locales/en/common.json
+++ b/client/public/locales/en/common.json
@@ -356,6 +356,7 @@
             "boolean_true": "Yes",
             "boolean_false": "No",
             "choices_missing_error": "You cannot remove choices. The following choices are missing: {{choices}}",
+            "choices_reorder_hint": "Drag, or use the arrow keys, to reorder this choice.",
             "non_unique_key_error": "The key must be unique.",
             "key_not_changed": "Please change the key to something else.",
             "delete_confirm": "Delete field {{name}}?",

--- a/client/src/pages/settings/extraFieldsSettings.tsx
+++ b/client/src/pages/settings/extraFieldsSettings.tsx
@@ -1,4 +1,4 @@
-import { PlusOutlined } from "@ant-design/icons";
+import { HolderOutlined, PlusOutlined } from "@ant-design/icons";
 import { useTranslate } from "@refinedev/core";
 import {
   Button,
@@ -12,6 +12,7 @@ import {
   Select,
   Space,
   Table,
+  Tag,
   message,
 } from "antd";
 import { FormItemProps, Rule } from "antd/es/form";
@@ -20,7 +21,9 @@ import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
 import timezone from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { DndProvider, useDrag, useDrop } from "react-dnd";
+import { HTML5Backend } from "react-dnd-html5-backend";
 import { Trans } from "react-i18next";
 import { useParams } from "react-router";
 import { DateTimePicker } from "../../components/dateTimePicker";
@@ -53,6 +56,92 @@ const canEditField = (dataIndex: string, isNew: boolean) => {
     return true;
   }
   return dataIndex !== "key" && dataIndex !== "field_type" && dataIndex !== "multi_choice";
+};
+
+const CHOICE_DRAG_TYPE = "extraFieldChoice";
+
+interface ChoiceDragItem {
+  choice: string;
+}
+
+interface DraggableChoiceTagProps {
+  label: React.ReactNode;
+  value: string;
+  closable: boolean;
+  onClose: (e?: React.MouseEvent<HTMLElement>) => void;
+  form: FormInstance;
+}
+
+/**
+ * A tag in the choices editor that can be dragged, or arrow-keyed, to a new position.
+ * The order of the choices is the order they're presented in wherever the field is used,
+ * so it's the choices form value itself that gets reordered.
+ */
+const DraggableChoiceTag = ({ label, value, closable, onClose, form }: DraggableChoiceTagProps) => {
+  const t = useTranslate();
+  const ref = useRef<HTMLSpanElement>(null);
+
+  // Choices are unique, so a choice's own value identifies its position.
+  const moveChoice = (choice: string, before: string) => {
+    const choices: string[] = [...(form.getFieldValue("choices") || [])];
+    const from = choices.indexOf(choice);
+    const to = choices.indexOf(before);
+    if (from === -1 || to === -1 || from === to) {
+      return;
+    }
+    choices.splice(from, 1);
+    choices.splice(to, 0, choice);
+    form.setFieldValue("choices", choices);
+  };
+
+  const moveChoiceBy = (offset: number) => {
+    const choices: string[] = form.getFieldValue("choices") || [];
+    const to = choices.indexOf(value) + offset;
+    if (to < 0 || to >= choices.length) {
+      return;
+    }
+    moveChoice(value, choices[to]);
+  };
+
+  const [{ isDragging }, drag] = useDrag<ChoiceDragItem, void, { isDragging: boolean }>({
+    type: CHOICE_DRAG_TYPE,
+    item: { choice: value },
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  });
+
+  const [, drop] = useDrop<ChoiceDragItem>({
+    accept: CHOICE_DRAG_TYPE,
+    hover: (item) => moveChoice(item.choice, value),
+  });
+
+  drag(drop(ref));
+
+  return (
+    <span
+      ref={ref}
+      // rc-select wraps every custom tag in a span that preventDefaults mousedown,
+      // which stops the browser from ever starting a drag. Keep the event away from it.
+      onMouseDown={(e) => e.stopPropagation()}
+      style={{ display: "inline-flex", opacity: isDragging ? 0.4 : 1 }}
+    >
+      <Tag
+        closable={closable}
+        onClose={onClose}
+        tabIndex={0}
+        title={t("settings.extra_fields.choices_reorder_hint")}
+        onKeyDown={(e) => {
+          if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
+            e.preventDefault();
+            moveChoiceBy(e.key === "ArrowLeft" ? -1 : 1);
+          }
+        }}
+        style={{ marginInlineEnd: 4, cursor: "grab", userSelect: "none" }}
+      >
+        <HolderOutlined style={{ marginInlineEnd: 4 }} />
+        {label}
+      </Tag>
+    </span>
+  );
 };
 
 const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps }: EditableCellProps) => {
@@ -221,7 +310,22 @@ const EditableCell = ({ record, editing, dataIndex, children, form, ...restProps
     }
   } else if (dataIndex === "choices") {
     if (fieldType === FieldType.choice) {
-      inputNode = <Select mode="tags" tokenSeparators={[","]} open={false} />;
+      inputNode = (
+        <Select
+          mode="tags"
+          tokenSeparators={[","]}
+          open={false}
+          tagRender={(props) => (
+            <DraggableChoiceTag
+              label={props.label}
+              value={props.value}
+              closable={props.closable}
+              onClose={props.onClose}
+              form={form}
+            />
+          )}
+        />
+      );
       rules.push({
         required: true,
         min: 1,
@@ -608,18 +712,20 @@ export function ExtraFieldsSettings() {
         }}
       />
       <Form form={form} component={false} disabled={isSubmitting}>
-        <Table
-          components={{
-            body: {
-              cell: EditableCell,
-            },
-          }}
-          columns={mergedColumns}
-          dataSource={tableFields}
-          loading={fields.isLoading}
-          rowClassName="editable-row"
-          pagination={false}
-        />
+        <DndProvider backend={HTML5Backend}>
+          <Table
+            components={{
+              body: {
+                cell: EditableCell,
+              },
+            }}
+            columns={mergedColumns}
+            dataSource={tableFields}
+            loading={fields.isLoading}
+            rowClassName="editable-row"
+            pagination={false}
+          />
+        </DndProvider>
       </Form>
       {newField == null && (
         <Flex justify="center">

--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -417,6 +417,7 @@
     "settings.extraFields.params.name": "Name",
     "settings.extraFields.params.order": "Order",
     "settings.extraFields.params.unit": "Unit",
+    "settings.extraFields.reorderChoice": "Drag, or use the arrow keys, to reorder this choice.",
     "settings.extraFields.saveField": "Save field",
     "settings.extraFields.tab": "Extra Fields",
     "settings.general.baseUrl.label": "Base URL",

--- a/client_v2/src/lib/components/settings/ExtraFieldsManager.svelte
+++ b/client_v2/src/lib/components/settings/ExtraFieldsManager.svelte
@@ -12,6 +12,7 @@
 	import * as m from '$lib/paraglide/messages';
 	import Plus from '@lucide/svelte/icons/plus';
 	import X from '@lucide/svelte/icons/x';
+	import GripVertical from '@lucide/svelte/icons/grip-vertical';
 
 	const ENTITIES: { key: EntityType; label: () => string }[] = [
 		{ key: 'spool', label: m['library.section.spool'] },
@@ -142,6 +143,38 @@
 	function removeChoice(c: string) {
 		if (!isNew && originalChoices.includes(c)) return; // append-only
 		choices = choices.filter((x) => x !== c);
+	}
+
+	// Choices may not be removed once saved, but their order is free to change —
+	// it is the order they are offered in wherever the field is used.
+	let draggedChoice = $state<string | null>(null);
+
+	function moveChoice(choice: string, before: string) {
+		const next = [...choices];
+		const from = next.indexOf(choice);
+		const to = next.indexOf(before);
+		if (from === -1 || to === -1 || from === to) return;
+		next.splice(from, 1);
+		next.splice(to, 0, choice);
+		choices = next;
+	}
+
+	function moveChoiceBy(choice: string, offset: number) {
+		const to = choices.indexOf(choice) + offset;
+		if (to < 0 || to >= choices.length) return;
+		moveChoice(choice, choices[to]);
+	}
+
+	function onChoiceDragOver(e: DragEvent, target: string) {
+		if (draggedChoice === null) return;
+		e.preventDefault();
+		moveChoice(draggedChoice, target);
+	}
+
+	function onGripKeydown(e: KeyboardEvent, choice: string) {
+		if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+		e.preventDefault();
+		moveChoiceBy(choice, e.key === 'ArrowLeft' ? -1 : 1);
 	}
 
 	async function save() {
@@ -303,7 +336,24 @@
 					<span>{m['settings.extraFields.params.choices']()}</span>
 					<div class="chips">
 						{#each choices as c (c)}
-							<span class="chip">
+							<span
+								class="chip"
+								class:dragging={draggedChoice === c}
+								role="group"
+								aria-label={c}
+								ondragover={(e) => onChoiceDragOver(e, c)}
+							>
+								<button
+									class="chip-grip"
+									draggable="true"
+									ondragstart={() => (draggedChoice = c)}
+									ondragend={() => (draggedChoice = null)}
+									onkeydown={(e) => onGripKeydown(e, c)}
+									title={m['settings.extraFields.reorderChoice']()}
+									aria-label={m['settings.extraFields.reorderChoice']()}
+								>
+									<GripVertical size={11} />
+								</button>
 								{c}
 								{#if isNew || !originalChoices.includes(c)}
 									<button class="chip-x" onclick={() => removeChoice(c)} aria-label={m['common.remove']()}
@@ -519,6 +569,17 @@
 		border-radius: var(--radius-sm);
 		padding: 2px 7px;
 		font-size: 12px;
+	}
+	.chip.dragging {
+		opacity: 0.4;
+	}
+	.chip-grip {
+		display: inline-flex;
+		background: none;
+		border: none;
+		color: var(--accent-muted);
+		cursor: grab;
+		padding: 0;
 	}
 	.chip-x {
 		background: none;


### PR DESCRIPTION
Closes #994.

Choice values could only be appended, so putting a value in the right place meant deleting everything after it and typing it back in. Each choice now has a grip handle: drag it, or focus it and press the left/right arrow keys, to move it. Done in both clients.

The backend already accepts a reordered list, it only refuses removals, so this is frontend only.

One catch worth knowing about: rc-select wraps every custom tag in a span that preventDefaults mousedown, which stops the browser from ever starting a drag. The tag stops propagation so the native drag survives.

Verified in a browser against a real backend in both clients: drag, arrow keys, adding a choice by typing, removing one, and the saved order round-tripping through the API.