### PR TITLE
client_v2: file unused spools under their own filament

### DIFF
--- a/client_v2/src/lib/components/library/GroupRow.svelte
+++ b/client_v2/src/lib/components/library/GroupRow.svelte
@@ -8,7 +8,7 @@
 	import type { GroupSummary } from '$lib/api/types';
 	import type { LibraryState } from '$lib/library/params';
 	import * as params from '$lib/library/params';
-	import { spoolToVM } from '$lib/utils/library';
+	import { groupUnusedByFilament, spoolToVM } from '$lib/utils/library';
 	import { buildScopedSpoolQuery } from '$lib/api/query';
 	import { spoolSource } from '$lib/api/spoolSource';
 	import { isAbortError } from '$lib/api/http';
@@ -122,8 +122,12 @@
 	let inUse = $derived(
 		spools.filter((s) => !s.unused).map((s) => spoolToVM(s, inventory, settings.lowThreshold))
 	);
-	let unused = $derived(
-		spools.filter((s) => s.unused).map((s) => spoolToVM(s, inventory, settings.lowThreshold))
+	// One collapsed summary row per filament: the row speaks for its whole pile
+	// ("Jade White ×6, 1000 g each"), which only holds within a single filament.
+	let unusedByFilament = $derived(
+		groupUnusedByFilament(
+			spools.filter((s) => s.unused).map((s) => spoolToVM(s, inventory, settings.lowThreshold))
+		)
 	);
 	let moreCount = $derived(group.spoolCount - spools.length);
 	let showSwatch = $derived(group.field !== 'filament');
@@ -167,13 +171,15 @@
 		{#each inUse as vm (vm.spool.id)}
 			<SpoolRow {vm} {showSwatch} indent={26} context={group.field} />
 		{/each}
-		{#if unused.length === 1}
-			<!-- A lone unused spool gains nothing from a collapsing header — it just
-			     adds a click and a row — so render it inline like the used spools. -->
-			<SpoolRow vm={unused[0]} {showSwatch} indent={26} context={group.field} />
-		{:else if unused.length > 1}
-			<UnusedRow {unused} {showSwatch} indent={26} context={group.field} />
-		{/if}
+		{#each unusedByFilament as unused (unused[0].spool.id)}
+			{#if unused.length === 1}
+				<!-- A lone unused spool gains nothing from a collapsing header — it just
+				     adds a click and a row — so render it inline like the used spools. -->
+				<SpoolRow vm={unused[0]} {showSwatch} indent={26} context={group.field} />
+			{:else}
+				<UnusedRow {unused} {showSwatch} indent={26} context={group.field} />
+			{/if}
+		{/each}
 		{#if moreCount > 0}
 			<button class="more" onclick={loadMore} disabled={loading || loadingMore}
 				><Plus size={13} /> {m['library.showMore']({ count: moreCount })}</button

--- a/client_v2/src/lib/components/library/UnusedRow.svelte
+++ b/client_v2/src/lib/components/library/UnusedRow.svelte
@@ -21,6 +21,11 @@
 	// collapsed into a single summary row. Clicking can't know *which* instance
 	// the user wants, so instead of selecting one it expands to reveal the
 	// individual spools, each selectable and distinguishable by its #id.
+	//
+	// "of one filament" is a hard precondition, not a description: the name, swatch
+	// and "N g each" all come from `unused[0]` and are claimed for the whole pile.
+	// Callers listing a multi-filament group must bucket first — see
+	// groupUnusedByFilament (#1012).
 	let expanded = $state(false);
 
 	// Under the filament group the used SpoolRows have shed their #id-column

--- a/client_v2/src/lib/utils/library.test.ts
+++ b/client_v2/src/lib/utils/library.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { usageLabel } from './library';
+import { groupUnusedByFilament, usageLabel } from './library';
+import type { SpoolVM } from './library';
 import { mapSpool } from '$lib/api/map';
 
 // The usage status is the one thing every spool row claims, and #986 was it claiming the
@@ -43,5 +44,48 @@ describe('usageLabel', () => {
 		// The old fallback here was "in use", which reads as "printing right now" — something
 		// Spoolman has no way of knowing (#986).
 		expect(usageLabel(spool({}))).toBe('used');
+	});
+});
+
+// A collapsed "×N unused" row speaks for its whole pile with one filament's name, swatch and
+// weight, so the pile has to BE one filament. Under a vendor/material/location group it isn't,
+// which is what #1012 reported: five different SUNLU woods filed under "Wood Cherry".
+describe('groupUnusedByFilament', () => {
+	const vm = (id: number, filamentId: string) => ({ spool: { id, filamentId } }) as SpoolVM;
+	const ids = (buckets: SpoolVM[][]) => buckets.map((b) => b.map((v) => v.spool.id));
+
+	it('keeps one filament as a single bucket', () => {
+		expect(ids(groupUnusedByFilament([vm(1, 'a'), vm(2, 'a'), vm(3, 'a')]))).toEqual([[1, 2, 3]]);
+	});
+
+	it('splits a vendor group that spans several filaments', () => {
+		const buckets = groupUnusedByFilament([vm(168, 'cherry'), vm(169, 'maple'), vm(170, 'walnut')]);
+		expect(ids(buckets)).toEqual([[168], [169], [170]]);
+	});
+
+	it('collects a filament whose spools are interleaved with others', () => {
+		// Sorting by last-used interleaves filaments freely; each still gets exactly one row.
+		const buckets = groupUnusedByFilament([
+			vm(117, 'jade'),
+			vm(92, 'black'),
+			vm(119, 'jade'),
+			vm(176, 'tan'),
+			vm(177, 'tan'),
+			vm(178, 'black')
+		]);
+		expect(ids(buckets)).toEqual([
+			[117, 119],
+			[92, 178],
+			[176, 177]
+		]);
+	});
+
+	it('orders buckets by where each filament first appears', () => {
+		// The backend sort drives the list; bucketing must not reshuffle it.
+		expect(ids(groupUnusedByFilament([vm(3, 'z'), vm(1, 'a'), vm(2, 'z')]))).toEqual([[3, 2], [1]]);
+	});
+
+	it('handles an empty pile', () => {
+		expect(groupUnusedByFilament([])).toEqual([]);
 	});
 });

--- a/client_v2/src/lib/utils/library.ts
+++ b/client_v2/src/lib/utils/library.ts
@@ -76,6 +76,28 @@ export function spoolToVM(s: Spool, repo: Repo, lowThreshold: number): SpoolVM {
 	};
 }
 
+/**
+ * Split a group's unused spools into one bucket per filament, in the order each
+ * filament first appears (so the backend's sort still drives the layout).
+ *
+ * An unused pile only collapses into a summary row because every spool in it is
+ * interchangeable — same filament, so one name, one swatch and one "N g each"
+ * describe them all. That holds by construction under the filament group, but a
+ * vendor/material/location group spans many filaments, and collapsing those into
+ * a single row files them all under whichever filament happened to sort first
+ * (issue #1012). Bucketing keeps each summary row honest about what it contains.
+ */
+export function groupUnusedByFilament(unused: SpoolVM[]): SpoolVM[][] {
+	const buckets = new Map<string, SpoolVM[]>();
+	for (const vm of unused) {
+		const key = vm.spool.filamentId;
+		const bucket = buckets.get(key);
+		if (bucket) bucket.push(vm);
+		else buckets.set(key, [vm]);
+	}
+	return [...buckets.values()];
+}
+
 // --- contextual row identity ---------------------------------------------
 
 /** How a spool row is being listed: flat, or nested under a group of some axis. */


### PR DESCRIPTION
The collapsed "xN unused" row takes its filament name, swatch, weight and location from the first spool in the pile, so the pile has to be one filament. That is true under Group: Filament, but not under Manufacturer, Material or Location, where a group spans many filaments. The result was every unused spool in the group filed under whichever filament sorted first (five different SUNLU woods showing as "Wood Cherry x5 unused").

Bucket the unused spools by filament before collapsing, ordered by first appearance so the backend sort still drives the layout. A bucket of one renders inline as before, and the filament-group divider is unchanged.

Fixes #1012