### PR TITLE
Use sequence-backed IDs on CockroachDB so the web UI can address them

### DIFF
--- a/migrations/versions/2026_09_06_1200-4e7c1b8d9f23_cockroachdb_renumber_unsafe_ids.py
+++ b/migrations/versions/2026_09_06_1200-4e7c1b8d9f23_cockroachdb_renumber_unsafe_ids.py
@@ -1,0 +1,92 @@
+"""cockroachdb renumber unsafe ids.
+
+Revision ID: 4e7c1b8d9f23
+Revises: fe4970567bb3
+Create Date: 2026-09-06 12:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4e7c1b8d9f23"
+down_revision = "fe4970567bb3"
+branch_labels = None
+depends_on = None
+
+# JavaScript numbers are only exact up to 2^53, so any ID above this gets rounded
+# by the web UI and every follow-up request 404s (#797).
+MAX_SAFE_ID = 2**53
+
+# Parent tables in FK order, with the columns in other tables that reference them.
+TABLES = (
+    ("vendor", (("filament", "vendor_id"), ("vendor_field", "vendor_id"))),
+    ("filament", (("spool", "filament_id"), ("filament_field", "filament_id"), ("tag", "filament_id"))),
+    ("spool", (("spool_field", "spool_id"), ("tag", "spool_id"))),
+)
+
+
+def upgrade() -> None:
+    """Renumber CockroachDB rows whose IDs are above 2^53 down into the safe range."""
+    """Existing CockroachDB installs got their IDs from unique_rowid(), which"""
+    """generates 64-bit values the web UI cannot represent (#797). Each unsafe row"""
+    """is copied to a new small ID, referencing rows are repointed and the old row"""
+    """is deleted, so foreign keys stay valid at every step. Only the DML lives in"""
+    """this migration; the DDL that changes the ID default is in the next one"""
+    """(see 304a32906234 for the cockroachdb migration caveat)."""
+    connection = op.get_bind()
+    if connection.dialect.name != "cockroachdb":
+        return
+
+    for table_name, references in TABLES:
+        table = sa.Table(table_name, sa.MetaData(), autoload_with=connection)
+
+        unsafe_ids = [
+            row.id
+            for row in connection.execute(
+                sa.select(table.c.id).where(table.c.id > MAX_SAFE_ID).order_by(table.c.id),
+            )
+        ]
+        if not unsafe_ids:
+            continue
+
+        next_id = (
+            connection.execute(
+                sa.select(sa.func.coalesce(sa.func.max(table.c.id), 0)).where(table.c.id <= MAX_SAFE_ID),
+            ).scalar_one()
+            + 1
+        )
+
+        column_names = [column.name for column in table.columns]
+        for old_id in unsafe_ids:
+            new_id = next_id
+            next_id += 1
+
+            select_columns = [
+                sa.literal(new_id).label("id") if name == "id" else table.c[name] for name in column_names
+            ]
+            connection.execute(
+                table.insert().from_select(
+                    column_names,
+                    sa.select(*select_columns).where(table.c.id == old_id),
+                ),
+            )
+
+            for ref_table_name, ref_column_name in references:
+                ref_table = sa.Table(
+                    ref_table_name,
+                    sa.MetaData(),
+                    sa.Column(ref_column_name, sa.BigInteger),
+                )
+                connection.execute(
+                    sa.update(ref_table)
+                    .where(ref_table.c[ref_column_name] == old_id)
+                    .values({ref_column_name: new_id}),
+                )
+
+            connection.execute(sa.delete(table).where(table.c.id == old_id))
+
+
+def downgrade() -> None:
+    """Perform the downgrade."""
+    # The old unique_rowid() values carry no meaning, so there is nothing to restore.

--- a/migrations/versions/2026_09_06_1201-8b2f6a3c5d17_cockroachdb_sequence_id_defaults.py
+++ b/migrations/versions/2026_09_06_1201-8b2f6a3c5d17_cockroachdb_sequence_id_defaults.py
@@ -1,0 +1,57 @@
+"""cockroachdb sequence id defaults.
+
+Revision ID: 8b2f6a3c5d17
+Revises: 4e7c1b8d9f23
+Create Date: 2026-09-06 12:01:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "8b2f6a3c5d17"
+down_revision = "4e7c1b8d9f23"
+branch_labels = None
+depends_on = None
+
+TABLES = ("vendor", "filament", "spool")
+
+
+def upgrade() -> None:
+    """Give existing CockroachDB tables sequence-backed ID defaults."""
+    """New installs already get these via serial_normalization=sql_sequence, but"""
+    """tables created before that still default to unique_rowid(), which generates"""
+    """64-bit IDs the web UI cannot represent (#797). This is kept separate from the"""
+    """renumbering migration because of cockroachdb's execution of alembic migrations"""
+    """(see 304a32906234)."""
+    connection = op.get_bind()
+    if connection.dialect.name != "cockroachdb":
+        return
+
+    for table_name in TABLES:
+        max_id = connection.execute(
+            sa.text(f"SELECT coalesce(max(id), 0) FROM {table_name}"),  # noqa: S608
+        ).scalar_one()
+        connection.execute(
+            sa.text(f"CREATE SEQUENCE IF NOT EXISTS {table_name}_id_seq START WITH {max_id + 1}"),
+        )
+        # The sequence may already exist (serial_normalization=sql_sequence created it at
+        # CREATE TABLE time), so make sure it continues above the current IDs either way.
+        connection.execute(
+            sa.text(f"SELECT setval('{table_name}_id_seq', {max_id + 1}, false)"),
+        )
+        connection.execute(
+            sa.text(f"ALTER TABLE {table_name} ALTER COLUMN id SET DEFAULT nextval('{table_name}_id_seq')"),
+        )
+
+
+def downgrade() -> None:
+    """Restore the unique_rowid() ID defaults."""
+    connection = op.get_bind()
+    if connection.dialect.name != "cockroachdb":
+        return
+
+    for table_name in TABLES:
+        connection.execute(
+            sa.text(f"ALTER TABLE {table_name} ALTER COLUMN id SET DEFAULT unique_rowid()"),
+        )

--- a/spoolman/database/database.py
+++ b/spoolman/database/database.py
@@ -104,6 +104,17 @@ class Database:
         connect_args = {}
         if self.connection_url.drivername == "sqlite+aiosqlite":
             connect_args["timeout"] = 60
+        if self.connection_url.drivername == "cockroachdb+asyncpg":
+            # CockroachDB expands SERIAL primary keys to "DEFAULT unique_rowid()" by default,
+            # which generates 64-bit IDs. JavaScript numbers are only exact up to 2^53, so the
+            # web UI silently rounds such IDs and every follow-up request 404s (#797).
+            # Sequence-backed SERIAL gives ordinary small IDs instead. Plain sql_sequence is
+            # used rather than sql_sequence_cached: the cached variant hands each connection
+            # its own block of IDs, so IDs are no longer in insertion order. This is sent in
+            # the connection's startup packet rather than issued as a SET statement because it
+            # must be in force whenever DDL runs: the Alembic migrations that create the tables
+            # build their connection through this method too.
+            connect_args["server_settings"] = {"serial_normalization": "sql_sequence"}
         connection_options = {}
         if self.connection_url.drivername == "mysql+aiomysql":
             connection_options["pool_recycle"] = 3600

--- a/tests/test_cockroachdb_ids.py
+++ b/tests/test_cockroachdb_ids.py
@@ -1,0 +1,41 @@
+"""Tests for CockroachDB ID generation.
+
+CockroachDB expands SERIAL primary keys to "DEFAULT unique_rowid()" out of the box, which
+generates 64-bit IDs. JavaScript numbers are only exact up to 2^53, so the web UI silently
+rounded such IDs and every follow-up request 404'd (#797). Spoolman therefore asks CockroachDB
+to normalize SERIAL to an ordinary sequence instead (uncached, so IDs stay in insertion
+order). The setting only takes effect at
+CREATE TABLE time, so it has to ride along on every connection the app opens -- including the
+one the Alembic migrations run through, which is built by the same Database.connect().
+"""
+
+import pytest
+from sqlalchemy import URL
+
+from spoolman.database import database
+from spoolman.database.database import Database
+
+
+def connect_kwargs(monkeypatch: pytest.MonkeyPatch, drivername: str) -> dict[str, object]:
+    """Connect a Database and capture what it passes to create_async_engine."""
+    captured: dict[str, object] = {}
+    real_create = database.create_async_engine
+
+    def capture(url: URL, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return real_create(url, **kwargs)
+
+    monkeypatch.setattr(database, "create_async_engine", capture)
+    db = Database(URL.create(drivername=drivername, host="db", database="spoolman", username="john"))
+    db.connect()
+    return captured
+
+
+def test_cockroachdb_serial_normalization_is_sequence_backed(monkeypatch: pytest.MonkeyPatch):
+    kwargs = connect_kwargs(monkeypatch, "cockroachdb+asyncpg")
+    assert kwargs["connect_args"]["server_settings"] == {"serial_normalization": "sql_sequence"}
+
+
+def test_other_databases_get_no_server_settings(monkeypatch: pytest.MonkeyPatch):
+    kwargs = connect_kwargs(monkeypatch, "postgresql+asyncpg")
+    assert "server_settings" not in kwargs["connect_args"]


### PR DESCRIPTION
Fixes #797.

CockroachDB expands SERIAL primary keys to `DEFAULT unique_rowid()`, which produces 64-bit IDs. JavaScript numbers are only exact up to 2^53, so the web UI rounds them: the database hands out vendor ID 1134663890672549889, the UI sends back 1134663890672549900, and every follow-up request 404s.

This asks CockroachDB for sequence-backed SERIAL instead (`serial_normalization=sql_sequence_cached`), so tables are created with ordinary small IDs. It goes in as a per-connection server setting rather than a SET statement because it has to be in force when the CREATE TABLE DDL runs, and the Alembic migrations build their connection through the same `Database.connect()`.

One catch worth knowing about: `serial_normalization` only applies at table creation time, so this fixes fresh databases. An existing CockroachDB install already has `unique_rowid()` baked into its column defaults and rows with 64-bit IDs that can't be shrunk after the fact, so recreating the database is the way out there.

Added two unit tests that check the setting is passed for cockroachdb and not for the other backends; they and the existing suite pass. I don't have a live CockroachDB here, so the integration side is on the CI cockroachdb job.