### PR TITLE
Show every unassigned spool when grouping by an extra field

### DIFF
--- a/client_v2/src/lib/components/ExtraFieldInput.svelte
+++ b/client_v2/src/lib/components/ExtraFieldInput.svelte
@@ -31,7 +31,11 @@
 	const emit = (v: unknown) => onchange(v === undefined ? undefined : JSON.stringify(v));
 
 	function onText(v: string) {
-		emit(v);
+		// Emptying the box clears the field rather than storing an empty string. A field
+		// holding "" is not distinguishable from an unset one anywhere it is read — it renders
+		// as em-dash, groups as "unassigned" and matches the unset filter — so storing one only
+		// creates a value that looks unset but isn't. Single-choice below does the same.
+		emit(v === '' ? undefined : v);
 	}
 	function onInt(v: string) {
 		emit(v.trim() === '' ? undefined : Math.round(Number(v)));

--- a/client_v2/src/lib/dashboard/fields.test.ts
+++ b/client_v2/src/lib/dashboard/fields.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Spool } from '$lib/types';
+
+// The dashboard writes the grouped-by field when a spool is dragged between cards, so what
+// these produce goes straight into a PATCH body. Clearing is the case worth pinning down:
+// the API validates every value in the `extra` map as a JSON-encoded *string*, so the empty
+// group has to be spelled as a real null — the string 'null' is a 400, which is what broke
+// dragging onto the unassigned card (issue #1019).
+
+const saveSpool = vi.fn();
+vi.mock('$lib/api/spoolSource', () => ({
+	spoolSource: {
+		saveSpool: (...args: unknown[]) => saveSpool(...args),
+		renameFieldValue: vi.fn()
+	}
+}));
+vi.mock('$lib/stores/inventory.svelte', () => ({
+	inventory: { patchSpool: vi.fn() }
+}));
+
+const { dashboardFields } = await import('./fields');
+const { FieldType } = await import('$lib/api/fields');
+
+const def = {
+	key: 'printer',
+	name: 'Printer',
+	field_type: FieldType.text,
+	entity_type: 'spool' as const,
+	order: 0
+};
+const printerField = () => dashboardFields([def])[1];
+const spool = (extra: Record<string, string>) => ({ id: 7, extra }) as unknown as Spool;
+
+describe('dashboard extra field', () => {
+	it('reads the decoded value, and an absent key as unassigned', () => {
+		const f = printerField();
+		expect(f.valueOf(spool({ printer: '"Prusa"' }))).toBe('Prusa');
+		expect(f.valueOf(spool({}))).toBe('');
+	});
+
+	it('drops the key rather than storing a blank when a spool is unassigned', () => {
+		const f = printerField();
+		expect(f.withValue(spool({ printer: '"Prusa"' }), '')).toMatchObject({ extra: {} });
+		expect(f.withValue(spool({}), 'Prusa')).toMatchObject({ extra: { printer: '"Prusa"' } });
+	});
+
+	it('clears with a real null, not the string the API rejects', async () => {
+		const f = printerField();
+		saveSpool.mockClear();
+		await f.assign(spool({ printer: '"Prusa"' }), '');
+		expect(saveSpool).toHaveBeenCalledWith(7, { extra: { printer: null } });
+	});
+
+	it('assigns a value JSON-encoded', async () => {
+		const f = printerField();
+		saveSpool.mockClear();
+		await f.assign(spool({}), 'Prusa');
+		expect(saveSpool).toHaveBeenCalledWith(7, { extra: { printer: '"Prusa"' } });
+	});
+});

--- a/client_v2/src/lib/dashboard/fields.ts
+++ b/client_v2/src/lib/dashboard/fields.ts
@@ -1,4 +1,4 @@
-import type { Spool } from '$lib/types';
+import type { Extra, Spool } from '$lib/types';
 import type { GroupField } from '$lib/api/types';
 import { FieldType, type FieldDef } from '$lib/api/fields';
 import { spoolSource } from '$lib/api/spoolSource';
@@ -61,12 +61,23 @@ const LOCATION: DashboardField = {
 
 /**
  * Extra-field values are stored JSON-encoded; the group key is the decoded string.
- * Clearing writes JSON null rather than dropping the key: the API patches the extra map
- * key by key, so an omitted key would leave the old value in place.
+ *
+ * Clearing sends JSON null for the key rather than leaving the key out: the API patches the
+ * extra map key by key, so an omitted key would keep the old value. It has to be a real null
+ * and not the string 'null' — every value in the map is validated as a JSON-encoded *string*,
+ * and the string 'null' is rejected with a 400, which is what made dragging a spool onto the
+ * unassigned card fail on every extra-field board. Locally there is no null to store, so the
+ * board's own copy of the spool drops the key instead.
  */
 function extraField(def: FieldDef): DashboardField {
 	const key = `extra.${def.key}` as GroupField;
-	const encode = (value: GroupKey) => (value === '' ? 'null' : JSON.stringify(value));
+	const encode = (value: GroupKey) => (value === '' ? null : JSON.stringify(value));
+	const applied = (extra: Extra, value: GroupKey): Extra => {
+		const next = { ...extra };
+		if (value === '') delete next[def.key];
+		else next[def.key] = JSON.stringify(value);
+		return next;
+	};
 	return {
 		key,
 		label: def.name,
@@ -80,11 +91,10 @@ function extraField(def: FieldDef): DashboardField {
 				return '';
 			}
 		},
-		withValue: (spool, value) => ({ ...spool, extra: { ...spool.extra, [def.key]: encode(value) } }),
+		withValue: (spool, value) => ({ ...spool, extra: applied(spool.extra, value) }),
 		async assign(spool, value) {
-			const extra = { [def.key]: encode(value) };
-			inventory.patchSpool(spool.id, { extra: { ...spool.extra, ...extra } });
-			await spoolSource.saveSpool(spool.id, { extra });
+			inventory.patchSpool(spool.id, { extra: applied(spool.extra, value) });
+			await spoolSource.saveSpool(spool.id, { extra: { [def.key]: encode(value) } });
 		},
 		rename: async (from, to) => {
 			await spoolSource.renameFieldValue(key, from, to);

--- a/spoolman/database/extra_field_query.py
+++ b/spoolman/database/extra_field_query.py
@@ -337,6 +337,11 @@ def add_where_clause_extra_field(  # noqa: C901, PLR0912, PLR0915
             empty_conditions = [
                 field_table.value.is_(None),
                 field_table.value == "null",
+                # A stored empty string is unset too, the same way `location=` matches both NULL
+                # and '' on a built-in string column (add_where_clause_str_opt). Clearing a text
+                # box writes one of these, and without this they would be counted in the "no
+                # value" group by group_by but missing from the listing of that same group.
+                field_table.value == json.dumps(""),
             ]
             if field_type == ExtraFieldType.boolean:
                 empty_conditions.append(field_table.value == json.dumps(bool(0)))

--- a/spoolman/database/spool.py
+++ b/spoolman/database/spool.py
@@ -236,6 +236,13 @@ GROUP_BY_COLUMNS = {
     "location": models.Spool.location,
 }
 
+# The two axes keyed by an entity id rather than by a value, and the column that names each
+# group. The rest are their own title.
+ENTITY_GROUP_BY_TITLES = {
+    "filament": models.Filament.name,
+    "vendor": models.Vendor.name,
+}
+
 # Prefix marking a reference to one of the spool's extra fields rather than a built-in column.
 EXTRA_FIELD_PREFIX = "extra."
 
@@ -283,6 +290,18 @@ def _apply_spool_filters(
     return stmt
 
 
+def _blank_as_null(col: ColumnElement) -> ColumnElement:
+    """Fold an empty string into NULL, so a value-keyed axis has ONE "no value" group.
+
+    A spool with no value for a string field can spell that as NULL or as an empty string, and
+    the two are distinct to the database — left alone they become two groups the client can only
+    render as the same "unassigned" one. Filtering already treats both as unset (see
+    add_where_clause_str_opt and the empty branch of add_where_clause_extra_field), so grouping
+    has to agree or a group's count will not match the spools that group's filter returns.
+    """
+    return func.nullif(col, "")
+
+
 async def _resolve_group_by(
     db: AsyncSession,
     group_by: str,
@@ -296,15 +315,15 @@ async def _resolve_group_by(
         field_key = _extra_field_key(await get_extra_fields(db, EntityType.spool), group_by)
         join = extra_field_join(EntityType.spool, field_key)
         # The value is the group's title as well; there is no separate entity to name it.
-        return join.value, join.value, join
+        col = _blank_as_null(join.value)
+        return col, col, join
+    if group_by in ENTITY_GROUP_BY_TITLES:
+        # Keyed by entity id, which has no blank spelling; the entity names the group.
+        return GROUP_BY_COLUMNS[group_by], ENTITY_GROUP_BY_TITLES[group_by], None
     if group_by in GROUP_BY_COLUMNS:
-        title_col = {
-            "filament": models.Filament.name,
-            "vendor": models.Vendor.name,
-            "material": models.Filament.material,
-            "location": models.Spool.location,
-        }[group_by]
-        return GROUP_BY_COLUMNS[group_by], title_col, None
+        # material/location: the value is the group's title, and a blank one is no value.
+        col = _blank_as_null(GROUP_BY_COLUMNS[group_by])
+        return col, col, None
     raise ValueError(
         f"Invalid group_by field '{group_by}'. Must be one of {sorted(GROUP_BY_COLUMNS)} "
         f"or '{EXTRA_FIELD_PREFIX}<spool extra field key>'.",

--- a/tests_integration/tests/spool/test_group.py
+++ b/tests_integration/tests/spool/test_group.py
@@ -322,6 +322,96 @@ def test_group_by_extra_field_scope_matches_spool_search(extra_field_spools: Ext
     assert len(result.json()) == 1
 
 
+def test_group_by_extra_field_unset_spellings_are_one_group(random_filament: dict[str, Any]):
+    """Every way of spelling "no value" is the same group, and that group's filter returns all of it.
+
+    A spool can carry no row for the field, a row holding JSON null, or a row holding the empty
+    string that clearing a text box writes. All three read as unset, so they have to group
+    together AND come back from the empty filter that scopes the group — issue #1019, where the
+    dashboard counted 11 unassigned spools and then listed 3 of them.
+    """
+    field_key = f"printer_{uuid.uuid4().hex[:8]}"
+    httpx.post(
+        f"{URL}/api/v1/field/spool/{field_key}",
+        json={"name": "Printer", "field_type": "text"},
+    ).raise_for_status()
+
+    filament_id = random_filament["id"]
+    spool_ids: list[int] = []
+    try:
+        # No row for the field at all.
+        result = httpx.post(f"{URL}/api/v1/spool", json={"filament_id": filament_id})
+        result.raise_for_status()
+        spool_ids.append(result.json()["id"])
+        # A row that was set and then cleared with a null, dropping it.
+        for cleared in (None, ""):
+            result = httpx.post(
+                f"{URL}/api/v1/spool",
+                json={"filament_id": filament_id, "extra": {field_key: json.dumps("Prusa")}},
+            )
+            result.raise_for_status()
+            spool_id = result.json()["id"]
+            spool_ids.append(spool_id)
+            value = None if cleared is None else json.dumps(cleared)
+            httpx.patch(f"{URL}/api/v1/spool/{spool_id}", json={"extra": {field_key: value}}).raise_for_status()
+        # One spool that really is assigned, as a control.
+        result = httpx.post(
+            f"{URL}/api/v1/spool",
+            json={"filament_id": filament_id, "extra": {field_key: json.dumps("Prusa")}},
+        )
+        result.raise_for_status()
+        spool_ids.append(result.json()["id"])
+
+        result = httpx.get(
+            f"{URL}/api/v1/spool/group",
+            params={"group_by": f"extra.{field_key}", "filament.id": str(filament_id)},
+        )
+        result.raise_for_status()
+        # One unset group, not one per spelling — the client keys them all as "unassigned".
+        assert _counts_by_key(result.json()) == {None: 3, "Prusa": 1}
+
+        result = httpx.get(
+            f"{URL}/api/v1/spool",
+            params={f"extra.{field_key}": "", "filament.id": str(filament_id)},
+        )
+        result.raise_for_status()
+        assert len(result.json()) == 3
+        assert result.headers["x-total-count"] == "3"
+    finally:
+        for spool_id in spool_ids:
+            httpx.delete(f"{URL}/api/v1/spool/{spool_id}").raise_for_status()
+        httpx.delete(f"{URL}/api/v1/field/spool/{field_key}").raise_for_status()
+
+
+def test_group_by_location_blank_and_null_are_one_group(random_filament: dict[str, Any]):
+    """A blank location groups with an absent one, the same as the extra-field case above."""
+    filament_id = random_filament["id"]
+    spool_ids: list[int] = []
+    try:
+        for payload in (
+            {"filament_id": filament_id},
+            {"filament_id": filament_id, "location": ""},
+            {"filament_id": filament_id, "location": "Shelf A"},
+        ):
+            result = httpx.post(f"{URL}/api/v1/spool", json=payload)
+            result.raise_for_status()
+            spool_ids.append(result.json()["id"])
+
+        result = httpx.get(
+            f"{URL}/api/v1/spool/group",
+            params={"group_by": "location", "filament.id": str(filament_id)},
+        )
+        result.raise_for_status()
+        assert _counts_by_key(result.json()) == {None: 2, "Shelf A": 1}
+
+        result = httpx.get(f"{URL}/api/v1/spool", params={"location": "", "filament.id": str(filament_id)})
+        result.raise_for_status()
+        assert len(result.json()) == 2
+    finally:
+        for spool_id in spool_ids:
+            httpx.delete(f"{URL}/api/v1/spool/{spool_id}").raise_for_status()
+
+
 def test_group_by_unknown_extra_field():
     """Grouping by an extra field that isn't registered is a client error."""
     result = httpx.get(f"{URL}/api/v1/spool/group", params={"group_by": "extra.does_not_exist"})


### PR DESCRIPTION
Fixes #1019.

A dashboard card grouped by a custom spool field counted more spools than it listed. Grouping and filtering disagreed about what "no value" means: `group_by` keys on the decoded value, so a spool holding the JSON empty string became its own group, separate from the null one, and the client draws both as "Unassigned" and adds the counts. The card then fetches its spools with `extra.<key>=`, whose empty branch matched only NULL and JSON null, never the empty string. Built-in string columns have always matched both NULL and `''` (`add_where_clause_str_opt`), which is why grouping by location was unaffected.

The empty strings come from the client: clearing a text extra field stored `""` instead of clearing it.

Changes:

* The empty extra-field filter matches a stored empty string too.
* Value-keyed group axes (extra fields, location, material) fold a blank into NULL, so "unassigned" is one group rather than two the client can only draw as one.
* Emptying a text extra field clears it instead of storing `""`.
* The dashboard clears an extra field with a real JSON null. It sent the string `'null'`, which the API rejects as not-a-string, so dragging a spool onto the unassigned card returned 400 on every extra-field board. Second bug, found while reproducing this one.

Existing data is fixed by the backend change, no migration needed.

Tests: two integration tests in `test_group.py` (all three spellings of unset form one group and that group's filter returns all of it; same for a blank location), plus a vitest for the clear-with-null encoding. Integration suite passes on all four databases.
