### PR TITLE
client_v2: make the library list column resizable

### DIFF
--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -335,6 +335,7 @@
     "library.noValues": "No values",
     "library.openGroup": "Open {{name}}",
     "library.openManufacturer": "Open manufacturer {{name}}",
+    "library.resizeList": "Resize the list (double-click to reset)",
     "library.section.extra": "Extra fields",
     "library.section.filament": "Filament",
     "library.section.spool": "Spool",

--- a/client_v2/src/app.css
+++ b/client_v2/src/app.css
@@ -92,6 +92,9 @@
 
 	/* Layout */
 	--topbar-h: 53px;
+	/* Library list column. The Library page overrides this per-instance from the
+	   remembered width (stores/listWidth, LIST_DEFAULT must match this); the value
+	   here is what the pane is styled with until that lands. */
 	--list-w: 470px;
 }
 

--- a/client_v2/src/lib/components/Splitter.svelte
+++ b/client_v2/src/lib/components/Splitter.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+	// A draggable divider between two side-by-side panes. It owns no width itself:
+	// it reports the width the leading pane should have and lets the parent decide
+	// what to do with it, so the same handle works for a stored preference, a
+	// derived layout, or nothing at all.
+	//
+	// A focusable separator is a real control, not decoration — it carries the
+	// width as an ARIA range and moves with the arrow keys, which is the only way
+	// to resize without a pointer.
+	interface Props {
+		/** Current width of the pane BEFORE the splitter, in px. */
+		value: number;
+		min: number;
+		max: number;
+		/** Width a double-click restores. */
+		resetValue: number;
+		/** Accessible name; also the tooltip, so mention the double-click. */
+		label: string;
+		/** `done` marks the end of a gesture — the moment worth persisting. */
+		onchange: (px: number, done: boolean) => void;
+	}
+	let { value, min, max, resetValue, label, onchange }: Props = $props();
+
+	const STEP = 16;
+	const COARSE_STEP = 64; // with Shift, for crossing the pane in a few presses
+
+	let el: HTMLDivElement;
+	let dragging = $state(false);
+	let pointerId: number | null = null;
+	let startX = 0;
+	let startW = 0;
+	let sign = 1;
+
+	function clamp(px: number): number {
+		return Math.round(Math.min(Math.max(px, min), max));
+	}
+
+	// In RTL the pane we size sits to the RIGHT of the splitter, so dragging left
+	// is what widens it. One sign flip covers both the drag and the arrow keys.
+	function direction(): number {
+		return getComputedStyle(el).direction === 'rtl' ? -1 : 1;
+	}
+
+	function pointerdown(e: PointerEvent) {
+		if (e.pointerType === 'mouse' && e.button !== 0) return;
+		pointerId = e.pointerId;
+		el.setPointerCapture(e.pointerId);
+		dragging = true;
+		startX = e.clientX;
+		startW = value;
+		sign = direction();
+		// Without this the press starts a text selection that then sweeps across
+		// whichever pane the drag runs into.
+		e.preventDefault();
+	}
+
+	// Tracking the pointer from its offset at pointerdown, rather than from where
+	// it is now, keeps the handle under the cursor once the width hits min or max:
+	// dragging back out resumes at exactly the point it stopped.
+	function pointermove(e: PointerEvent) {
+		if (!dragging || e.pointerId !== pointerId) return;
+		onchange(clamp(startW + sign * (e.clientX - startX)), false);
+	}
+
+	function pointerup(e: PointerEvent) {
+		if (e.pointerId !== pointerId) return;
+		pointerId = null;
+		if (!dragging) return;
+		dragging = false;
+		onchange(value, true);
+	}
+
+	function keydown(e: KeyboardEvent) {
+		const step = e.shiftKey ? COARSE_STEP : STEP;
+		let next: number;
+		switch (e.key) {
+			case 'ArrowLeft':
+				next = value - step * direction();
+				break;
+			case 'ArrowRight':
+				next = value + step * direction();
+				break;
+			case 'Home':
+				next = min;
+				break;
+			case 'End':
+				next = max;
+				break;
+			default:
+				return;
+		}
+		e.preventDefault();
+		onchange(clamp(next), true);
+	}
+
+	// The cursor and the selection lock belong to the whole document while a drag
+	// is running: the pointer is captured here, but it is physically over the panes
+	// either side, and they must not fight it with their own cursors.
+	$effect(() => {
+		if (!dragging) return;
+		document.body.classList.add('col-resizing');
+		return () => document.body.classList.remove('col-resizing');
+	});
+</script>
+
+<!-- A separator is non-interactive only while it is NOT focusable; a focusable one
+     is the ARIA window splitter, whose whole contract is tabindex + arrow keys +
+     aria-value*. Svelte's rule doesn't make that distinction, so both warnings
+     below are false here. -->
+<!-- svelte-ignore a11y_no_noninteractive_tabindex, a11y_no_noninteractive_element_interactions -->
+<div
+	bind:this={el}
+	class="splitter"
+	class:dragging
+	role="separator"
+	tabindex="0"
+	aria-orientation="vertical"
+	aria-label={label}
+	title={label}
+	aria-valuenow={Math.round(value)}
+	aria-valuemin={Math.round(min)}
+	aria-valuemax={Math.round(max)}
+	onpointerdown={pointerdown}
+	onpointermove={pointermove}
+	onpointerup={pointerup}
+	onpointercancel={pointerup}
+	ondblclick={() => onchange(resetValue, true)}
+	onkeydown={keydown}
+></div>
+
+<style>
+	/* The splitter draws the divider the list pane would otherwise draw itself, so
+	   the line and the thing that moves it are one and the same. */
+	.splitter {
+		flex: none;
+		/* The strip straddles the line rather than starting at it, so the divider can
+		   be grabbed from either side. The overlap is what puts it over the outer
+		   edge of the list's 8px scrollbar, which otherwise hugs the line and takes
+		   every press aimed slightly short of it. The negative margin cancels the
+		   extra width, so the strip still costs the layout the same 7px it did. */
+		width: 10px;
+		margin-inline-start: -3px;
+		align-self: stretch;
+		position: relative;
+		/* Above the panes either side. The list pane is its own stacking context (it
+		   is a size container), so without this the splitter loses the overlap to
+		   whatever the list paints there — the scrollbar, a sticky group header. */
+		z-index: 3;
+		cursor: col-resize;
+		/* Or the browser claims the touch gesture as a scroll and the drag never
+		   reaches us. */
+		touch-action: none;
+	}
+	/* The line sits exactly on the pane boundary — 3px into the strip, cancelling
+	   the negative margin above — NOT centred in the strip: the list's row
+	   hairlines have to run into it, and a couple of px of daylight between them
+	   reads as a misalignment. */
+	.splitter::before {
+		content: '';
+		position: absolute;
+		inset-block: 0;
+		inset-inline-start: 3px;
+		inline-size: 1px;
+		background: var(--border);
+		transition:
+			background 0.12s,
+			inline-size 0.12s,
+			inset-inline-start 0.12s;
+	}
+	/* Hover/focus/drag all say the same thing — this line moves — so they look the
+	   same: the hairline thickens and takes the accent. That doubles as the focus
+	   ring (matching DateTimeField's trigger, which also has no room for one). */
+	.splitter:hover::before,
+	.splitter:focus-visible::before,
+	.splitter.dragging::before {
+		background: var(--accent);
+		/* Thickens around where it already was, so the boundary doesn't appear to
+		   move when you reach for it. */
+		inset-inline-start: 2px;
+		inline-size: 3px;
+	}
+	.splitter:focus-visible {
+		outline: none;
+	}
+	/* While the drag runs the cursor is over a pane, not over us. */
+	:global(body.col-resizing) {
+		cursor: col-resize;
+		user-select: none;
+	}
+
+	/* Mobile: the list is the whole screen and the inspector is a bottom sheet —
+	   there are no two panes to divide. */
+	@media (max-width: 860px) {
+		.splitter {
+			display: none;
+		}
+	}
+</style>

--- a/client_v2/src/lib/components/library/ListToolbar.svelte
+++ b/client_v2/src/lib/components/library/ListToolbar.svelte
@@ -532,4 +532,18 @@
 			left: auto;
 		}
 	}
+
+	/* The same trade on a desktop where the list has been dragged narrow (#1034).
+	   That's the pane's width, not the window's, so it's a container query — the
+	   list pane declares the container (see routes/+page.svelte). Without this the
+	   Group/Sort cluster, which can't shrink, runs into the Filter chip. */
+	@container (max-width: 460px) {
+		.ctrl-label {
+			display: none;
+		}
+		.group-menu {
+			right: 14px;
+			left: auto;
+		}
+	}
 </style>

--- a/client_v2/src/lib/stores/listWidth.svelte.ts
+++ b/client_v2/src/lib/stores/listWidth.svelte.ts
@@ -1,0 +1,87 @@
+// How wide the Library's list column is, remembered per browser.
+//
+// Like the collapsed-group set (see stores/collapsedGroups) this is a reading
+// preference, not part of what a Library URL means — a link is worth sharing for
+// its search/filters/sort, not for how the sharer sized their panes — so it lives
+// in localStorage rather than in the address bar.
+//
+// A stored width wider than the current window is kept as-is and only clamped for
+// display: someone who sized the list on a big monitor gets that width back there
+// after working in a narrow window, instead of having it quietly whittled down.
+
+const KEY = 'spoolman-v2-list-width';
+
+/** Narrowest the list may get. Below this the row's fixed columns (id, fill,
+ *  remaining, location) leave the filament name almost nothing, and the toolbar's
+ *  Group/Sort cluster — which can't shrink — starts crowding the Filter chip even
+ *  with its labels dropped. */
+export const LIST_MIN = 340;
+
+/** Default width — must match --list-w in app.css, which styles the pane until
+ *  this store's value is applied. */
+export const LIST_DEFAULT = 470;
+
+/** Width the inspector keeps no matter how far the splitter is dragged; its
+ *  field grid stops being readable much below this. */
+export const DETAIL_MIN = 360;
+
+/**
+ * The list width to actually render: the preference, held within [LIST_MIN, max]
+ * where max leaves the inspector DETAIL_MIN. Pass the width available to both
+ * panes; omit it (or pass 0, as on the first paint before the container has been
+ * measured) to clamp against the minimum only.
+ */
+export function clampListWidth(px: number, available = 0): number {
+	if (!Number.isFinite(px)) return LIST_DEFAULT;
+	const max = available > 0 ? Math.max(LIST_MIN, available - DETAIL_MIN) : Infinity;
+	return Math.round(Math.min(Math.max(px, LIST_MIN), max));
+}
+
+class ListWidth {
+	#px = $state(LIST_DEFAULT);
+
+	constructor() {
+		this.#px = read();
+	}
+
+	/** The remembered width, before clamping to the current window. */
+	get px(): number {
+		return this.#px;
+	}
+
+	/** Follow a drag in progress. Deliberately not persisted — a drag is one
+	 *  decision, not sixty, and localStorage writes are synchronous. */
+	set(px: number) {
+		this.#px = clampListWidth(px);
+	}
+
+	/** Remember the width the user settled on (end of a drag, an arrow key, a
+	 *  double-click reset). */
+	commit(px: number) {
+		this.set(px);
+		write(this.#px);
+	}
+}
+
+function read(): number {
+	if (typeof localStorage === 'undefined') return LIST_DEFAULT;
+	try {
+		const raw = localStorage.getItem(KEY);
+		return raw === null ? LIST_DEFAULT : clampListWidth(Number(raw));
+	} catch {
+		// Corrupt entry or storage disabled: the default width is no worse than
+		// what every first-time visitor gets.
+		return LIST_DEFAULT;
+	}
+}
+
+function write(px: number) {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(KEY, String(px));
+	} catch {
+		/* nothing to do — remembering the width is a convenience, not a requirement */
+	}
+}
+
+export const listWidth = new ListWidth();

--- a/client_v2/src/lib/stores/listWidth.test.ts
+++ b/client_v2/src/lib/stores/listWidth.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { clampListWidth, DETAIL_MIN, LIST_DEFAULT, LIST_MIN } from './listWidth.svelte';
+
+// The rule the resizable list (#1034) rests on: the stored preference is never
+// what gets rendered directly — it is held to what the window can fit, so the
+// inspector can't be squeezed away and the list can't be dragged into uselessness.
+
+describe('clampListWidth', () => {
+	it('keeps a width that fits both panes', () => {
+		expect(clampListWidth(600, 1400)).toBe(600);
+	});
+
+	it('leaves the inspector its minimum', () => {
+		expect(clampListWidth(1300, 1400)).toBe(1400 - DETAIL_MIN);
+	});
+
+	it('never goes below the list minimum, however narrow the window', () => {
+		expect(clampListWidth(100, 1400)).toBe(LIST_MIN);
+		// A window too small for both minimums: the list keeps its own.
+		expect(clampListWidth(900, 500)).toBe(LIST_MIN);
+	});
+
+	it('treats an unmeasured container as no ceiling, so the first paint is not narrow', () => {
+		expect(clampListWidth(900, 0)).toBe(900);
+		expect(clampListWidth(900)).toBe(900);
+	});
+
+	it('rounds to whole pixels', () => {
+		expect(clampListWidth(512.4, 1400)).toBe(512);
+	});
+
+	it('falls back to the default for a value that isn’t a number', () => {
+		expect(clampListWidth(Number.NaN, 1400)).toBe(LIST_DEFAULT);
+	});
+});

--- a/client_v2/src/routes/+page.svelte
+++ b/client_v2/src/routes/+page.svelte
@@ -2,7 +2,15 @@
 	import FilamentList from '$components/library/FilamentList.svelte';
 	import Inspector from '$components/library/Inspector.svelte';
 	import DetailPane from '$components/DetailPane.svelte';
+	import Splitter from '$components/Splitter.svelte';
 	import { clearSelection } from '$lib/library/params';
+	import {
+		listWidth,
+		clampListWidth,
+		LIST_MIN,
+		LIST_DEFAULT,
+		DETAIL_MIN
+	} from '$lib/stores/listWidth.svelte';
 	import * as m from '$lib/paraglide/messages';
 	import type { PageData } from './$types';
 
@@ -11,17 +19,39 @@
 	// renders it. State changes happen through the params.* nav helpers in the
 	// child components — no local sync to maintain.
 	let { data }: { data: PageData } = $props();
+
+	// How the list is sized (#1034). The stored preference is held to what the
+	// window can currently fit, so a width chosen on a wide monitor never pushes
+	// the inspector off a narrow one — and is remembered at full size for when the
+	// user is back on the wide one.
+	//
+	// `available` is 0 until the container is measured; clampListWidth reads that
+	// as "no ceiling yet" and renders the stored width, so the list doesn't paint
+	// narrow and then jump on the first frame.
+	let available = $state(0);
+	let width = $derived(clampListWidth(listWidth.px, available));
+	let maxWidth = $derived(available > 0 ? Math.max(LIST_MIN, available - DETAIL_MIN) : width);
 </script>
 
 <svelte:head>
 	<title>{m['documentTitle.library.list']()}</title>
 </svelte:head>
 
-<div class="library">
+<div class="library" style="--list-w: {width}px" bind:clientWidth={available}>
 	<!-- Left list: front and centre; on mobile it fills the screen. -->
 	<div class="list-pane">
 		<FilamentList libraryState={data.state} />
 	</div>
+
+	<!-- The divider between the two panes is also the handle that moves it. -->
+	<Splitter
+		value={width}
+		min={LIST_MIN}
+		max={maxWidth}
+		resetValue={LIST_DEFAULT}
+		label={m['library.resizeList']()}
+		onchange={(px, done) => (done ? listWidth.commit(px) : listWidth.set(px))}
+	/>
 
 	<!-- The inspector: a side pane on desktop, a bottom-sheet drawer on mobile.
 	     Rendered once — DetailPane adapts via CSS. On mobile the drawer is open
@@ -38,19 +68,24 @@
 		min-height: 0;
 		width: 100%;
 	}
+	/* Width comes from the inline --list-w above (the splitter's doing); the value
+	   in app.css is the fallback for the frame before this page's script runs. */
 	.list-pane {
 		width: var(--list-w);
 		flex: none;
-		border-right: 1px solid var(--border);
 		display: flex;
 		flex-direction: column;
 		min-height: 0;
+		/* The pane's width is now the user's to choose, so what's inside it has to
+		   adapt to the PANE rather than to the window — the list toolbar sheds its
+		   "Group:"/"Sort:" prefixes off this. Safe to contain: the width above never
+		   depends on the content. */
+		container-type: inline-size;
 	}
 
 	@media (max-width: 860px) {
 		.list-pane {
 			width: 100%;
-			border-right: none;
 		}
 	}
 </style>

--- a/tests_frontend_v2/tests/list-resize.spec.ts
+++ b/tests_frontend_v2/tests/list-resize.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "./fixtures";
+import { openApp } from "./helpers";
+
+/**
+ * The Library's list/inspector splitter (#1034).
+ *
+ * The list column used to be a fixed 470px, which truncated longer filament
+ * names with no way to see the rest. The divider between the two panes is now a
+ * draggable, focusable separator, and the width it is left at is a per-browser
+ * preference — so the things worth proving are that dragging it moves the pane,
+ * that the width survives a reload, and that neither pane can be squeezed out of
+ * existence by dragging to an extreme.
+ */
+
+const LIST_MIN = 340;
+const DETAIL_MIN = 360;
+const DEFAULT_WIDTH = 470;
+
+const listPane = (page: import("@playwright/test").Page) => page.locator(".list-pane");
+const splitter = (page: import("@playwright/test").Page) => page.getByRole("separator");
+
+async function listWidth(page: import("@playwright/test").Page): Promise<number> {
+  return listPane(page).evaluate((el) => el.getBoundingClientRect().width);
+}
+
+/** Drag the splitter by `dx` px and release. */
+async function dragBy(page: import("@playwright/test").Page, dx: number): Promise<void> {
+  const box = await splitter(page).boundingBox();
+  if (!box) throw new Error("splitter has no box");
+  const y = box.y + box.height / 2;
+  await page.mouse.move(box.x + box.width / 2, y);
+  await page.mouse.down();
+  // In steps, so the page sees a real drag rather than one teleporting move.
+  await page.mouse.move(box.x + box.width / 2 + dx, y, { steps: 10 });
+  await page.mouse.up();
+}
+
+// Each test starts from a known width; the preference is per-browser and every
+// test here changes it. Seeded only when absent, because an init script runs on
+// every navigation — overwriting unconditionally would re-seed the default on
+// the reloads these tests use to prove the width persists.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript((w) => {
+    if (window.localStorage.getItem("spoolman-v2-list-width") === null)
+      window.localStorage.setItem("spoolman-v2-list-width", String(w));
+  }, DEFAULT_WIDTH);
+});
+
+test("dragging the splitter resizes the list, and the width is remembered", async ({ page }) => {
+  await openApp(page);
+  await expect(listPane(page)).toHaveJSProperty("clientWidth", DEFAULT_WIDTH);
+
+  await dragBy(page, 200);
+  const widened = await listWidth(page);
+  expect(widened).toBeGreaterThan(DEFAULT_WIDTH + 150);
+
+  await page.reload();
+  await expect(page).toHaveTitle("Library | Spoolman");
+  expect(await listWidth(page)).toBe(widened);
+});
+
+test("neither pane can be dragged away", async ({ page }) => {
+  await openApp(page);
+  const available = await page.locator(".library").evaluate((el) => el.getBoundingClientRect().width);
+
+  await test.step("dragging past the left edge stops at the list's minimum", async () => {
+    await dragBy(page, -2000);
+    expect(await listWidth(page)).toBe(LIST_MIN);
+  });
+
+  await test.step("dragging past the right edge leaves the inspector its minimum", async () => {
+    await dragBy(page, 2000);
+    expect(await listWidth(page)).toBe(available - DETAIL_MIN);
+  });
+});
+
+test("the splitter is keyboard operable and double-clicks back to the default", async ({ page }) => {
+  await openApp(page);
+  const sep = splitter(page);
+
+  // A focusable separator is the ARIA window splitter: it carries the width as a
+  // range, which is what a screen reader announces while the arrows move it.
+  await expect(sep).toHaveAttribute("aria-orientation", "vertical");
+  await expect(sep).toHaveAttribute("aria-valuenow", String(DEFAULT_WIDTH));
+
+  await sep.focus();
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowRight");
+  expect(await listWidth(page)).toBe(DEFAULT_WIDTH + 32);
+  await page.keyboard.press("ArrowLeft");
+  expect(await listWidth(page)).toBe(DEFAULT_WIDTH + 16);
+  await expect(sep).toHaveAttribute("aria-valuenow", String(DEFAULT_WIDTH + 16));
+
+  await page.keyboard.press("Home");
+  expect(await listWidth(page)).toBe(LIST_MIN);
+
+  await sep.dblclick();
+  expect(await listWidth(page)).toBe(DEFAULT_WIDTH);
+  await page.reload();
+  await expect(page).toHaveTitle("Library | Spoolman");
+  expect(await listWidth(page)).toBe(DEFAULT_WIDTH);
+});
+
+test("a width wider than the window is clamped for display, not overwritten", async ({ page }) => {
+  await page.addInitScript(() => window.localStorage.setItem("spoolman-v2-list-width", "5000"));
+  await openApp(page);
+
+  const available = await page.locator(".library").evaluate((el) => el.getBoundingClientRect().width);
+  expect(await listWidth(page)).toBe(available - DETAIL_MIN);
+
+  // The stored preference is untouched, so the same browser on a wider window
+  // gets its chosen width back.
+  expect(await page.evaluate(() => window.localStorage.getItem("spoolman-v2-list-width"))).toBe("5000");
+});


### PR DESCRIPTION
The list column was a fixed 470px, so longer filament names were truncated with no way to see the rest.

The divider between the list and the inspector is now draggable, and the chosen width is remembered per browser (localStorage, like the collapsed groups). It goes from 340px up to whatever leaves the inspector 360px, a stored width wider than the window is clamped for display but kept, and a double-click resets it to 470. It is a focusable ARIA separator too, so arrow keys / Home / End resize it without a pointer. Hidden below 860px, where the inspector is a bottom sheet instead of a pane.

Since the pane can now be narrow, the list toolbar drops its "Group:"/"Sort:" prefixes off a container query on the pane rather than the window, otherwise the Group/Sort cluster collides with the Filter chip.

Covered by a unit test for the clamping and a Playwright spec for the dragging, persistence and keyboard.

Fixes #1034