### PR TITLE
client_v2: remember the library's grouping and sorting

### DIFF
--- a/client_v2/src/lib/library/params.test.ts
+++ b/client_v2/src/lib/library/params.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// What a Library URL means once the browser has a remembered view (#1036): the
+// URL still decides whenever it says anything about the layout, and only a URL
+// that mentions neither grouping nor sorting defers to what the user was last
+// looking at.
+//
+// The remembered view is read once and cached, so each case gets a fresh module
+// registry with its own stored entry.
+
+function stub(stored: string | null) {
+	const store = new Map<string, string>();
+	if (stored !== null) store.set('spoolman-v2-library-view', stored);
+	vi.stubGlobal('localStorage', {
+		getItem: (k: string) => store.get(k) ?? null,
+		setItem: (k: string, v: string) => void store.set(k, v)
+	});
+}
+
+async function parseWith(stored: string | null, query: string) {
+	vi.resetModules();
+	stub(stored);
+	const { parseLibraryState } = await import('./params');
+	return parseLibraryState(new URLSearchParams(query));
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+const GROUPED_BY_LOCATION = '{"group":"location","sort":"remaining_weight","asc":true}';
+
+describe('parseLibraryState with a remembered view', () => {
+	it('restores the remembered layout for a URL that names none of it', () => {
+		return expect(parseWith(GROUPED_BY_LOCATION, '')).resolves.toMatchObject({
+			group: 'location',
+			sortKey: 'remaining_weight',
+			sortAsc: true
+		});
+	});
+
+	it('still restores it alongside params that describe the contents, not the layout', async () => {
+		// Following a QR code or a dashboard link lands on `?sel=…`: the spool is
+		// what's being asked for, the layout around it is still the user's.
+		const state = await parseWith(GROUPED_BY_LOCATION, 'sel=spool:12&arch=1');
+		expect(state).toMatchObject({ group: 'location', showArchived: true });
+		expect(state.selection).toEqual({ kind: 'spool', id: '12' });
+	});
+
+	it('lets a URL that spells out the view win, so a shared link travels intact', async () => {
+		const state = await parseWith(GROUPED_BY_LOCATION, 'group=vendor');
+		expect(state).toMatchObject({ group: 'vendor', sortKey: 'last_used', sortAsc: false });
+	});
+
+	it('takes the remembered view whole rather than mixing it into a partial URL', async () => {
+		// `?sort=remaining_weight` alone means the sender chose that sort under the
+		// shipped grouping, ascending left at its default; splicing the remembered
+		// grouping and direction in would show neither view.
+		const state = await parseWith(GROUPED_BY_LOCATION, 'sort=remaining_weight');
+		expect(state).toMatchObject({
+			group: 'filament',
+			sortKey: 'remaining_weight',
+			sortAsc: false
+		});
+	});
+
+	it('falls back to the shipped view when nothing usable is stored', async () => {
+		await expect(parseWith(null, '')).resolves.toMatchObject({
+			group: 'filament',
+			sortKey: 'last_used',
+			sortAsc: false
+		});
+		// A grouping that no longer exists is as good as nothing stored.
+		await expect(parseWith('{"group":"colour","sort":"last_used","asc":false}', '')).resolves.toMatchObject({
+			group: 'filament'
+		});
+	});
+
+	it('keeps the grouped-view invariant over a remembered per-spool sort', async () => {
+		// Can't be stored by our own mutators, but a stale entry mustn't produce a
+		// grouped list ordered by something that can't order groups.
+		await expect(parseWith('{"group":"location","sort":"price","asc":true}', '')).resolves.toMatchObject({
+			group: 'none',
+			sortKey: 'price'
+		});
+	});
+});

--- a/client_v2/src/lib/library/params.test.ts
+++ b/client_v2/src/lib/library/params.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-// What a Library URL means once the browser has a remembered view (#1036): the
-// URL still decides whenever it says anything about the layout, and only a URL
-// that mentions neither grouping nor sorting defers to what the user was last
-// looking at.
+// Where arriving at the Library should really land once the browser has a
+// remembered view (#1036). The rule is that the URL wins whenever it says
+// anything about the layout; only a URL mentioning neither grouping nor sorting
+// is redirected to the one that spells the remembered view out.
+//
+// Returning an href — rather than folding the preference into parseLibraryState
+// — is the whole design: the address bar has to keep describing what's on
+// screen, or the view stops being linkable, SvelteKit's per-URL load cache
+// starts serving states built from a preference that has since changed, and
+// picking the default grouping stops being a navigation at all.
 //
 // The remembered view is read once and cached, so each case gets a fresh module
 // registry with its own stored entry.
@@ -17,11 +23,11 @@ function stub(stored: string | null) {
 	});
 }
 
-async function parseWith(stored: string | null, query: string) {
+async function hrefFor(stored: string | null, query: string) {
 	vi.resetModules();
 	stub(stored);
-	const { parseLibraryState } = await import('./params');
-	return parseLibraryState(new URLSearchParams(query));
+	const { rememberedViewHref } = await import('./params');
+	return rememberedViewHref(new URL(`http://host/${query}`));
 }
 
 afterEach(() => {
@@ -30,56 +36,71 @@ afterEach(() => {
 
 const GROUPED_BY_LOCATION = '{"group":"location","sort":"remaining_weight","asc":true}';
 
-describe('parseLibraryState with a remembered view', () => {
-	it('restores the remembered layout for a URL that names none of it', () => {
-		return expect(parseWith(GROUPED_BY_LOCATION, '')).resolves.toMatchObject({
-			group: 'location',
-			sortKey: 'remaining_weight',
-			sortAsc: true
-		});
+describe('rememberedViewHref', () => {
+	it('spells the remembered view out for a URL that names none of it', async () => {
+		expect(await hrefFor(GROUPED_BY_LOCATION, '')).toBe('/?group=location&sort=remaining_weight&dir=asc');
 	});
 
-	it('still restores it alongside params that describe the contents, not the layout', async () => {
+	it('keeps what the URL does say about the contents', async () => {
 		// Following a QR code or a dashboard link lands on `?sel=…`: the spool is
 		// what's being asked for, the layout around it is still the user's.
-		const state = await parseWith(GROUPED_BY_LOCATION, 'sel=spool:12&arch=1');
-		expect(state).toMatchObject({ group: 'location', showArchived: true });
-		expect(state.selection).toEqual({ kind: 'spool', id: '12' });
+		expect(await hrefFor(GROUPED_BY_LOCATION, '?sel=spool:12&arch=1')).toBe(
+			'/?group=location&sort=remaining_weight&dir=asc&arch=1&sel=spool%3A12'
+		);
 	});
 
-	it('lets a URL that spells out the view win, so a shared link travels intact', async () => {
-		const state = await parseWith(GROUPED_BY_LOCATION, 'group=vendor');
-		expect(state).toMatchObject({ group: 'vendor', sortKey: 'last_used', sortAsc: false });
+	it('leaves a URL that spells out the view alone, so a shared link travels intact', async () => {
+		expect(await hrefFor(GROUPED_BY_LOCATION, '?group=vendor')).toBeNull();
 	});
 
-	it('takes the remembered view whole rather than mixing it into a partial URL', async () => {
-		// `?sort=remaining_weight` alone means the sender chose that sort under the
-		// shipped grouping, ascending left at its default; splicing the remembered
-		// grouping and direction in would show neither view.
-		const state = await parseWith(GROUPED_BY_LOCATION, 'sort=remaining_weight');
-		expect(state).toMatchObject({
-			group: 'filament',
-			sortKey: 'remaining_weight',
-			sortAsc: false
-		});
+	it('leaves a partial one alone too, rather than mixing the two views', async () => {
+		// `?sort=remaining_weight` means the sender chose that sort under the
+		// shipped grouping; splicing the remembered grouping and direction in would
+		// show neither view.
+		expect(await hrefFor(GROUPED_BY_LOCATION, '?sort=remaining_weight')).toBeNull();
+		expect(await hrefFor(GROUPED_BY_LOCATION, '?dir=asc')).toBeNull();
 	});
 
-	it('falls back to the shipped view when nothing usable is stored', async () => {
-		await expect(parseWith(null, '')).resolves.toMatchObject({
+	it('has nothing to do when nothing usable is stored', async () => {
+		expect(await hrefFor(null, '')).toBeNull();
+		expect(await hrefFor('not json', '')).toBeNull();
+		// A grouping that no longer exists is as good as nothing stored.
+		expect(await hrefFor('{"group":"colour","sort":"last_used","asc":false}', '')).toBeNull();
+	});
+
+	it('has nothing to do when the remembered view is the shipped one', async () => {
+		// The bare URL already means exactly this, and redirecting to a query
+		// string that encodes the defaults would only make it uglier.
+		expect(await hrefFor('{"group":"filament","sort":"last_used","asc":false}', '')).toBeNull();
+	});
+});
+
+describe('parseLibraryState', () => {
+	it('reads the view from the URL alone, never from the stored preference', async () => {
+		// The load function's purity is what SvelteKit's per-URL caching rests on:
+		// a bare URL means the shipped view here, and the remembered one is applied
+		// by navigating to a URL that says so.
+		vi.resetModules();
+		stub(GROUPED_BY_LOCATION);
+		const { parseLibraryState } = await import('./params');
+
+		expect(parseLibraryState(new URLSearchParams(''))).toMatchObject({
 			group: 'filament',
 			sortKey: 'last_used',
 			sortAsc: false
 		});
-		// A grouping that no longer exists is as good as nothing stored.
-		await expect(parseWith('{"group":"colour","sort":"last_used","asc":false}', '')).resolves.toMatchObject({
-			group: 'filament'
-		});
 	});
 
 	it('keeps the grouped-view invariant over a remembered per-spool sort', async () => {
-		// Can't be stored by our own mutators, but a stale entry mustn't produce a
-		// grouped list ordered by something that can't order groups.
-		await expect(parseWith('{"group":"location","sort":"price","asc":true}', '')).resolves.toMatchObject({
+		// A stale entry can't be allowed to produce a grouped list ordered by
+		// something that can't order groups, so the href it yields has to parse
+		// back to a coherent view.
+		const href = await hrefFor('{"group":"location","sort":"price","asc":true}', '');
+		expect(href).toBe('/?group=location&sort=price&dir=asc');
+
+		vi.resetModules();
+		const { parseLibraryState } = await import('./params');
+		expect(parseLibraryState(new URL(`http://host${href}`).searchParams)).toMatchObject({
 			group: 'none',
 			sortKey: 'price'
 		});

--- a/client_v2/src/lib/library/params.ts
+++ b/client_v2/src/lib/library/params.ts
@@ -2,6 +2,7 @@ import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
 import type { EntityKind, Selection } from '$lib/types';
 import { isGroupOrderable, defaultSortAsc } from '$lib/utils/library';
+import { rememberedView, rememberView } from './viewPrefs';
 
 // The Library view's entire query state lives in the URL — this module is the
 // single place that translates between the query string and a typed
@@ -12,6 +13,10 @@ import { isGroupOrderable, defaultSortAsc } from '$lib/utils/library';
 // helpers below, each of which rewrites the query string and navigates. The
 // serialisation is canonical (defaults omitted), so an untouched view has a
 // clean, bookmarkable URL and every distinct view maps to exactly one string.
+//
+// The one thing the URL doesn't decide on its own is the grouping and sort of a
+// URL that mentions neither: those fall back to the browser's remembered view
+// rather than to the shipped defaults (see viewPrefs, and #1036).
 
 export type GroupMode = 'filament' | 'vendor' | 'material' | 'location' | 'none';
 
@@ -34,6 +39,10 @@ export interface LibraryState {
 
 const GROUP_MODES: GroupMode[] = ['filament', 'vendor', 'material', 'location', 'none'];
 const ENTITY_KINDS: EntityKind[] = ['spool', 'filament', 'vendor'];
+
+/** The params that spell out how the list is laid out, as opposed to what it
+ *  holds. A URL naming none of them defers to the remembered view. */
+const VIEW_PARAMS = ['group', 'sort', 'dir'];
 
 const DEFAULTS = {
 	group: 'filament' as GroupMode,
@@ -62,17 +71,30 @@ function parsePositiveInt(value: string | null, fallback: number): number {
 	return Number.isInteger(n) && n > 0 ? n : fallback;
 }
 
+/**
+ * How the list is laid out: what the URL says, or — when it says nothing about
+ * grouping or sorting — what this browser was last left looking at. The
+ * remembered view is taken whole, so a stored group never gets paired with a
+ * URL's sort behind the user's back.
+ */
+function parseView(params: URLSearchParams): Pick<LibraryState, 'group' | 'sortKey' | 'sortAsc'> {
+	const stored = VIEW_PARAMS.some((p) => params.has(p)) ? null : rememberedView();
+	const rawGroup = (stored ? stored.group : params.get('group')) as GroupMode | null;
+	return {
+		group: rawGroup && GROUP_MODES.includes(rawGroup) ? rawGroup : DEFAULTS.group,
+		sortKey: (stored ? stored.sortKey : params.get('sort')) ?? DEFAULTS.sortKey,
+		sortAsc: stored ? stored.sortAsc : params.get('dir') === 'asc'
+	};
+}
+
 /** Parse a URL's query params into the canonical Library state (the load fn's job). */
 export function parseLibraryState(params: URLSearchParams): LibraryState {
-	const group = params.get('group') as GroupMode | null;
-
 	const sel = params.get('sel');
 	const si = sel ? sel.indexOf(':') : -1;
 	const kind = si > 0 ? (sel!.slice(0, si) as EntityKind) : null;
 	const selection = kind && ENTITY_KINDS.includes(kind) ? { kind, id: sel!.slice(si + 1) } : null;
 
-	const rawGroup = group && GROUP_MODES.includes(group) ? group : DEFAULTS.group;
-	const sortKey = params.get('sort') ?? DEFAULTS.sortKey;
+	const { group: rawGroup, sortKey, sortAsc } = parseView(params);
 	// Enforce the grouped-view invariant: a group can only be ordered by a
 	// group-orderable sort. A hand-crafted or stale URL pairing a grouping with a
 	// per-spool sort renders flat, honouring the more specific sort intent. (Our
@@ -81,7 +103,7 @@ export function parseLibraryState(params: URLSearchParams): LibraryState {
 		selection,
 		group: isGroupOrderable(sortKey, rawGroup) ? rawGroup : 'none',
 		sortKey,
-		sortAsc: params.get('dir') === 'asc',
+		sortAsc,
 		filters: parseFilters(params.getAll('f')),
 		showArchived: params.get('arch') === '1',
 		page: parsePositiveInt(params.get('page'), DEFAULTS.page),
@@ -128,6 +150,14 @@ function currentState(): LibraryState {
  * box focused and the list from jumping.
  */
 function navigate(next: LibraryState, replace = false): void {
+	// Remember the layout the user is navigating to, so returning to the Library
+	// from another page restores it. Recorded here rather than in setGroup /
+	// setSortKey so it always matches the view actually shown, including
+	// setGroup's fallback to the default sort. Back/forward doesn't come through
+	// here: stepping through history replays old views without redefining what
+	// "the Library" means next time it's opened fresh.
+	rememberView({ group: next.group, sortKey: next.sortKey, sortAsc: next.sortAsc });
+
 	const qs = serializeState(next);
 	// Both targets are base-path-independent: a bare `?query` resolves against the
 	// current URL, and window.location.pathname already includes the base path.

--- a/client_v2/src/lib/library/params.ts
+++ b/client_v2/src/lib/library/params.ts
@@ -14,9 +14,10 @@ import { rememberedView, rememberView } from './viewPrefs';
 // serialisation is canonical (defaults omitted), so an untouched view has a
 // clean, bookmarkable URL and every distinct view maps to exactly one string.
 //
-// The one thing the URL doesn't decide on its own is the grouping and sort of a
-// URL that mentions neither: those fall back to the browser's remembered view
-// rather than to the shipped defaults (see viewPrefs, and #1036).
+// That stays true of the remembered view too (#1036): arriving on a URL that
+// mentions neither grouping nor sort doesn't quietly parse the preference into
+// the state, it navigates to the URL that spells the preference out (see
+// rememberedViewHref and viewPrefs). The address bar keeps describing the view.
 
 export type GroupMode = 'filament' | 'vendor' | 'material' | 'location' | 'none';
 
@@ -41,7 +42,9 @@ const GROUP_MODES: GroupMode[] = ['filament', 'vendor', 'material', 'location', 
 const ENTITY_KINDS: EntityKind[] = ['spool', 'filament', 'vendor'];
 
 /** The params that spell out how the list is laid out, as opposed to what it
- *  holds. A URL naming none of them defers to the remembered view. */
+ *  holds. A URL naming none of them is the one that defers to the remembered
+ *  view; naming any of them describes a view of its own, which is taken whole so
+ *  a stored grouping never gets spliced onto a link's sort. */
 const VIEW_PARAMS = ['group', 'sort', 'dir'];
 
 const DEFAULTS = {
@@ -72,29 +75,22 @@ function parsePositiveInt(value: string | null, fallback: number): number {
 }
 
 /**
- * How the list is laid out: what the URL says, or — when it says nothing about
- * grouping or sorting — what this browser was last left looking at. The
- * remembered view is taken whole, so a stored group never gets paired with a
- * URL's sort behind the user's back.
+ * Parse a URL's query params into the canonical Library state (the load fn's
+ * job). A pure function of the URL, deliberately: SvelteKit caches and preloads
+ * load results per URL, so a state that also depended on the remembered view
+ * would be served stale after that preference changed (see rememberedViewHref).
  */
-function parseView(params: URLSearchParams): Pick<LibraryState, 'group' | 'sortKey' | 'sortAsc'> {
-	const stored = VIEW_PARAMS.some((p) => params.has(p)) ? null : rememberedView();
-	const rawGroup = (stored ? stored.group : params.get('group')) as GroupMode | null;
-	return {
-		group: rawGroup && GROUP_MODES.includes(rawGroup) ? rawGroup : DEFAULTS.group,
-		sortKey: (stored ? stored.sortKey : params.get('sort')) ?? DEFAULTS.sortKey,
-		sortAsc: stored ? stored.sortAsc : params.get('dir') === 'asc'
-	};
-}
-
-/** Parse a URL's query params into the canonical Library state (the load fn's job). */
 export function parseLibraryState(params: URLSearchParams): LibraryState {
+	const group = params.get('group') as GroupMode | null;
+
 	const sel = params.get('sel');
 	const si = sel ? sel.indexOf(':') : -1;
 	const kind = si > 0 ? (sel!.slice(0, si) as EntityKind) : null;
 	const selection = kind && ENTITY_KINDS.includes(kind) ? { kind, id: sel!.slice(si + 1) } : null;
 
-	const { group: rawGroup, sortKey, sortAsc } = parseView(params);
+	const rawGroup = group && GROUP_MODES.includes(group) ? group : DEFAULTS.group;
+	const sortKey = params.get('sort') ?? DEFAULTS.sortKey;
+	const sortAsc = params.get('dir') === 'asc';
 	// Enforce the grouped-view invariant: a group can only be ordered by a
 	// group-orderable sort. A hand-crafted or stale URL pairing a grouping with a
 	// per-spool sort renders flat, honouring the more specific sort intent. (Our
@@ -141,6 +137,47 @@ function serializeState(s: LibraryState): string {
 /** Current Library state read straight off the address bar (for the nav helpers). */
 function currentState(): LibraryState {
 	return parseLibraryState(new URLSearchParams(window.location.search));
+}
+
+/**
+ * Where entering the Library on `url` should actually land: the same view with
+ * the remembered grouping and sort spelled out in the query string, or null when
+ * the URL already describes a view (or there's nothing worth restoring). The
+ * Library page navigates there on entry, replacing the history entry — see
+ * routes/+page.svelte.
+ *
+ * Restoring the view by rewriting the URL, rather than by quietly parsing the
+ * preference into the state, is what keeps the whole thing coherent. The address
+ * bar always spells out what's on screen, so the view stays linkable; the load
+ * function stays a pure function of the URL, so SvelteKit's per-URL load cache
+ * can't serve a state built from a preference that has since changed; and every
+ * distinct view keeps a distinct URL, so picking the *default* grouping is a real
+ * navigation rather than a no-op against an unchanged bare URL.
+ */
+export function rememberedViewHref(url: URL): string | null {
+	if (VIEW_PARAMS.some((p) => url.searchParams.has(p))) return null;
+
+	const stored = rememberedView();
+	if (!stored) return null;
+
+	// A grouping that no longer exists is as good as nothing stored, and a view
+	// that matches the shipped one is already what the bare URL means.
+	const group = GROUP_MODES.includes(stored.group as GroupMode)
+		? (stored.group as GroupMode)
+		: DEFAULTS.group;
+	if (
+		group === DEFAULTS.group &&
+		stored.sortKey === DEFAULTS.sortKey &&
+		stored.sortAsc === DEFAULTS.sortAsc
+	) {
+		return null;
+	}
+
+	// Everything the URL *does* say (a selection, filters, archived spools) is
+	// kept; only the layout comes from the preference.
+	const state = parseLibraryState(url.searchParams);
+	const qs = serializeState({ ...state, group, sortKey: stored.sortKey, sortAsc: stored.sortAsc });
+	return `${url.pathname}?${qs}`;
 }
 
 /**

--- a/client_v2/src/lib/library/viewPrefs.test.ts
+++ b/client_v2/src/lib/library/viewPrefs.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { parseStoredView } from './viewPrefs';
+
+// The stored view is the only piece of Library state that doesn't come from the
+// URL (#1036), so it's also the only piece that can arrive malformed — from an
+// older release, a hand-edited localStorage, or a half-written entry. Anything
+// it can't vouch for has to come back as "nothing remembered", because the
+// caller turns it straight into the view the user sees.
+
+describe('parseStoredView', () => {
+	it('reads back a stored view', () => {
+		expect(parseStoredView('{"group":"location","sort":"name","asc":true}')).toEqual({
+			group: 'location',
+			sortKey: 'name',
+			sortAsc: true
+		});
+	});
+
+	it('has nothing to restore for a browser that never stored one', () => {
+		expect(parseStoredView(null)).toBeNull();
+		expect(parseStoredView('')).toBeNull();
+	});
+
+	it('rejects entries that aren’t a complete view', () => {
+		expect(parseStoredView('not json')).toBeNull();
+		expect(parseStoredView('null')).toBeNull();
+		expect(parseStoredView('"location"')).toBeNull();
+		expect(parseStoredView('{"group":"location"}')).toBeNull();
+		// A direction stored as a string would make every sort ascending.
+		expect(parseStoredView('{"group":"location","sort":"name","asc":"true"}')).toBeNull();
+	});
+
+	it('passes an unknown grouping through for the parser to judge', () => {
+		// Validating the enum here would duplicate params.GROUP_MODES; the round
+		// trip through parseLibraryState is what decides a grouping still exists.
+		expect(parseStoredView('{"group":"colour","sort":"name","asc":false}')).toEqual({
+			group: 'colour',
+			sortKey: 'name',
+			sortAsc: false
+		});
+	});
+});

--- a/client_v2/src/lib/library/viewPrefs.ts
+++ b/client_v2/src/lib/library/viewPrefs.ts
@@ -6,9 +6,15 @@
 // address bar carries it. Every other route links back to a bare `/`, so a trip
 // to Settings, the nav tab, or a bookmark used to hand back the factory view and
 // a user who works grouped by location had to re-pick it several times a day
-// (#1036). A URL that says nothing about the view now means "however I had it
-// last" rather than "however it ships"; one that does say something still wins
-// outright, so a link shows its recipient what its sender saw.
+// (#1036). Arriving on a URL that says nothing about the view now means "however
+// I had it last"; one that does say something still wins outright, so a link
+// shows its recipient what its sender saw.
+//
+// The preference is applied by NAVIGATING to the URL that spells it out (see
+// params.rememberedViewHref), never by parsing it into the state behind the
+// URL's back. Everything downstream — linkability, SvelteKit's per-URL load
+// cache, one URL per distinct view — depends on the address bar being the whole
+// truth about what's on screen.
 //
 // Only grouping and sort are remembered. Filters, search and archived-visibility
 // hide spools, and a hidden filter silently restored days later reads as missing
@@ -18,7 +24,7 @@ const KEY = 'spoolman-v2-library-view';
 
 /**
  * A remembered view. `group` is whatever was stored rather than a GroupMode:
- * this module only guarantees the shape, and params.parseLibraryState has the
+ * this module only guarantees the shape, and params.rememberedViewHref has the
  * final say on whether the string names a grouping that still exists.
  */
 export interface StoredView {

--- a/client_v2/src/lib/library/viewPrefs.ts
+++ b/client_v2/src/lib/library/viewPrefs.ts
@@ -1,0 +1,90 @@
+// The grouping and sort order the Library was last laid out with, remembered
+// per browser.
+//
+// Everything about a Library view lives in the URL (see library/params), which
+// makes a view linkable and survives a reload — but only for as long as the
+// address bar carries it. Every other route links back to a bare `/`, so a trip
+// to Settings, the nav tab, or a bookmark used to hand back the factory view and
+// a user who works grouped by location had to re-pick it several times a day
+// (#1036). A URL that says nothing about the view now means "however I had it
+// last" rather than "however it ships"; one that does say something still wins
+// outright, so a link shows its recipient what its sender saw.
+//
+// Only grouping and sort are remembered. Filters, search and archived-visibility
+// hide spools, and a hidden filter silently restored days later reads as missing
+// data rather than as a preference.
+
+const KEY = 'spoolman-v2-library-view';
+
+/**
+ * A remembered view. `group` is whatever was stored rather than a GroupMode:
+ * this module only guarantees the shape, and params.parseLibraryState has the
+ * final say on whether the string names a grouping that still exists.
+ */
+export interface StoredView {
+	group: string;
+	sortKey: string;
+	sortAsc: boolean;
+}
+
+/** Rebuild a stored view from its JSON, or null if there isn't a usable one. */
+export function parseStoredView(raw: string | null): StoredView | null {
+	if (!raw) return null;
+	try {
+		const parsed: unknown = JSON.parse(raw);
+		if (typeof parsed !== 'object' || parsed === null) return null;
+		const { group, sort, asc } = parsed as Record<string, unknown>;
+		if (typeof group !== 'string' || typeof sort !== 'string' || typeof asc !== 'boolean') {
+			return null;
+		}
+		return { group, sortKey: sort, sortAsc: asc };
+	} catch {
+		// Corrupt entry: the shipped view is no worse than what a first-time
+		// visitor gets.
+		return null;
+	}
+}
+
+// Read once and kept here: parseLibraryState runs for every row's href, and a
+// getItem + JSON.parse per link would be paid on every render. `undefined` means
+// "not looked at yet", `null` means "nothing worth restoring".
+let cached: StoredView | null | undefined;
+
+/** The remembered view, or null when this browser has no usable one. */
+export function rememberedView(): StoredView | null {
+	if (cached === undefined) {
+		cached = parseStoredView(read());
+	}
+	return cached;
+}
+
+/** Record the view the user just navigated to, so the next bare URL restores it. */
+export function rememberView(view: StoredView): void {
+	const prev = rememberedView();
+	if (prev && prev.group === view.group && prev.sortKey === view.sortKey && prev.sortAsc === view.sortAsc) {
+		// Selecting a spool or turning a page navigates too; only the changes that
+		// actually move the view are worth a synchronous localStorage write.
+		return;
+	}
+	cached = view;
+	write(view);
+}
+
+function read(): string | null {
+	if (typeof localStorage === 'undefined') return null;
+	try {
+		return localStorage.getItem(KEY);
+	} catch {
+		// Storage disabled (private mode, blocked third-party context).
+		return null;
+	}
+}
+
+function write(view: StoredView): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(KEY, JSON.stringify({ group: view.group, sort: view.sortKey, asc: view.sortAsc }));
+	} catch {
+		/* nothing to do — remembering the view is a convenience, not a requirement */
+	}
+}

--- a/client_v2/src/routes/+page.svelte
+++ b/client_v2/src/routes/+page.svelte
@@ -3,7 +3,9 @@
 	import Inspector from '$components/library/Inspector.svelte';
 	import DetailPane from '$components/DetailPane.svelte';
 	import Splitter from '$components/Splitter.svelte';
-	import { clearSelection } from '$lib/library/params';
+	import { afterNavigate, goto } from '$app/navigation';
+	import { page } from '$app/state';
+	import { clearSelection, rememberedViewHref } from '$lib/library/params';
 	import {
 		listWidth,
 		clampListWidth,
@@ -31,6 +33,28 @@
 	let available = $state(0);
 	let width = $derived(clampListWidth(listWidth.px, available));
 	let maxWidth = $derived(available > 0 ? Math.max(LIST_MIN, available - DETAIL_MIN) : width);
+
+	// ARRIVING at the Library on a URL that names no grouping or sort — the nav
+	// tab, the logo, a bookmark of the root, a QR code's `?sel=` — means "however
+	// I had it last". Restoring that is a real navigation to the URL that spells
+	// the view out, replacing the history entry so Back still leaves the Library
+	// in one step. Doing it here rather than in the load keeps the load a pure
+	// function of the URL, which is what SvelteKit's per-URL caching assumes.
+	//
+	// Only on arrival, though. A `goto` is one of the params.* helpers acting on a
+	// choice the user just made — including the choice of the *default* view,
+	// which is exactly the bare URL — and a `popstate` is Back or Forward, whose
+	// whole job is to show the view that history recorded rather than the newest
+	// preference. Restoring on either would overrule the user, and skipping them
+	// is also what makes a loop impossible.
+	afterNavigate(({ type }) => {
+		if (type === 'goto' || type === 'popstate') return;
+		const href = rememberedViewHref(page.url);
+		// Base-path-independent already: the href is built from page.url.pathname,
+		// which carries the deploy base path.
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		if (href) void goto(href, { replaceState: true, keepFocus: true, noScroll: true });
+	});
 </script>
 
 <svelte:head>

--- a/client_v2/src/routes/+page.ts
+++ b/client_v2/src/routes/+page.ts
@@ -1,11 +1,13 @@
 import type { PageLoad } from './$types';
 import { parseLibraryState } from '$lib/library/params';
 
-// The URL is the single source of truth for the Library view. This load parses
-// the query string into typed state that flows to the page as `data.state`;
+// The URL is the source of truth for the Library view. This load parses the
+// query string into typed state that flows to the page as `data.state`;
 // SvelteKit re-runs it on every navigation (links, goto, back/forward), so the
-// view follows the address bar for free. Runs client-side only (ssr=false in
-// +layout.ts); data fetching stays in the components.
+// view follows the address bar for free. A URL that mentions neither grouping
+// nor sorting takes those from the browser's remembered view instead (see
+// lib/library/viewPrefs). Runs client-side only (ssr=false in +layout.ts); data
+// fetching stays in the components.
 export const load: PageLoad = ({ url }) => {
 	return { state: parseLibraryState(url.searchParams) };
 };

--- a/client_v2/src/routes/+page.ts
+++ b/client_v2/src/routes/+page.ts
@@ -1,13 +1,16 @@
 import type { PageLoad } from './$types';
 import { parseLibraryState } from '$lib/library/params';
 
-// The URL is the source of truth for the Library view. This load parses the
-// query string into typed state that flows to the page as `data.state`;
+// The URL is the single source of truth for the Library view. This load parses
+// the query string into typed state that flows to the page as `data.state`;
 // SvelteKit re-runs it on every navigation (links, goto, back/forward), so the
-// view follows the address bar for free. A URL that mentions neither grouping
-// nor sorting takes those from the browser's remembered view instead (see
-// lib/library/viewPrefs). Runs client-side only (ssr=false in +layout.ts); data
-// fetching stays in the components.
+// view follows the address bar for free. Runs client-side only (ssr=false in
+// +layout.ts); data fetching stays in the components.
+//
+// Kept a pure function of the URL. SvelteKit caches and preloads load results
+// per URL, so reading the remembered view (lib/library/viewPrefs) here would
+// hand back a state built from a preference that has since changed; the page
+// restores it by navigating instead — see +page.svelte.
 export const load: PageLoad = ({ url }) => {
 	return { state: parseLibraryState(url.searchParams) };
 };

--- a/tests_frontend_v2/tests/search.spec.ts
+++ b/tests_frontend_v2/tests/search.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "./fixtures";
-import { addFilter, createSpoolViaModal, onlyVisible, openApp, openToolbarMenu, searchFor, unique } from "./helpers";
+import { addFilter, createSpoolViaModal, navTab, onlyVisible, openApp, openToolbarMenu, searchFor, unique } from "./helpers";
 
 /**
  * The library's find-things subsystem: the top-bar cross-entity search, and the
@@ -158,6 +158,18 @@ test("grouping the library by location and by manufacturer", async ({ page }) =>
     // lands on the same list.
     await page.reload();
     await expect(onlyVisible(page.getByRole("button", { name: /^Group:\s*Manufacturer/ }))).toBeVisible();
+  });
+
+  await test.step("and survives leaving the library and coming back", async () => {
+    // The nav tab links to a bare `/`, which carries no view state at all, so the
+    // grouping comes back from the browser's remembered view instead (#1036).
+    // The filters deliberately do not come back: they hide spools, and one
+    // silently restored later reads as missing data rather than as a preference.
+    await navTab(page, "Settings", "Settings | Spoolman");
+    await navTab(page, "Library", "Library | Spoolman");
+
+    await expect(onlyVisible(page.getByRole("button", { name: /^Group:\s*Manufacturer/ }))).toBeVisible();
+    await expect(page.getByRole("button", { name: `Location: ${first.locationName}` })).toHaveCount(0);
   });
 });
 

--- a/tests_frontend_v2/tests/search.spec.ts
+++ b/tests_frontend_v2/tests/search.spec.ts
@@ -170,6 +170,23 @@ test("grouping the library by location and by manufacturer", async ({ page }) =>
 
     await expect(onlyVisible(page.getByRole("button", { name: /^Group:\s*Manufacturer/ }))).toBeVisible();
     await expect(page.getByRole("button", { name: `Location: ${first.locationName}` })).toHaveCount(0);
+
+    // Restored by NAVIGATING to the URL that spells the view out, not by holding
+    // it off to one side: the address bar still describes what is on screen, so
+    // the view stays linkable.
+    await expect(page).toHaveURL(/[?&]group=vendor/);
+  });
+
+  await test.step("and the default grouping is still selectable afterwards", async () => {
+    // The restored view had to become a real URL for this to work. While it was
+    // only implied, choosing the default grouping serialised back to the very
+    // same bare URL, and an unchanged URL doesn't re-run the load — so the
+    // control silently refused to move.
+    const menu = await openToolbarMenu(page, "Group");
+    await menu.getByRole("button", { name: "Filament", exact: true }).click();
+
+    await expect(onlyVisible(page.getByRole("button", { name: /^Group:\s*Filament/ }))).toBeVisible();
+    await expect(page).not.toHaveURL(/[?&]group=/);
   });
 });
 


### PR DESCRIPTION
Group and sort live in the URL, so they survive a reload of a library link but not a trip to Settings and back: every other route links to a bare `/`, which handed back the shipped view. A grouping you picked deliberately had to be re-picked several times a day.

Arriving on a URL that mentions neither grouping nor sorting now restores whatever you had last, from localStorage (like the collapsed groups and the list width). A URL that does mention either still wins outright, so a shared link shows its recipient what its sender saw. Only the layout is remembered, not filters, search or archived spools, since a hidden filter restored days later reads as missing data rather than as a preference.

The restore is a navigation to the URL that spells the view out, replacing the history entry, rather than parsing the preference into the state behind the URL's back. That keeps the view linkable and the load a pure function of the URL, which SvelteKit's per-URL load cache assumes, and it keeps one URL per distinct view: picking the default grouping serialises to the bare URL, and an unchanged URL never re-runs the load. Only on arrival, not on a goto or a popstate, so it never overrules a choice you just made or the back button.

Covered by unit tests for the stored view and the restore rule, and Playwright steps for coming back from Settings and changing the grouping afterwards.

Fixes #1036