### PR TITLE
client_v2: accept decimal commas in every numeric field

### DIFF
--- a/client_v2/src/lib/components/AddSpoolModal.svelte
+++ b/client_v2/src/lib/components/AddSpoolModal.svelte
@@ -20,6 +20,7 @@
 	import type { EntityType } from '$lib/api/fields';
 	import { externalColors, externalDirection, type ExternalFilament } from '$lib/api/external';
 	import { roundGrams, weightAuto } from '$lib/utils/format';
+	import { parseDecimal } from '$lib/utils/numeric';
 	import { loadMaterials, type MaterialSpec } from '$lib/data/materials';
 	import * as m from '$lib/paraglide/messages';
 
@@ -482,8 +483,8 @@
 	) {
 		const t = v.trim();
 		if (t === '') return required ? m['validation.required']() : '';
-		const n = Number(t);
-		if (!Number.isFinite(n)) return m['validation.mustBeNumber']();
+		const n = parseDecimal(t);
+		if (n === null) return m['validation.mustBeNumber']();
 		if (gt != null && n <= gt) return m['validation.mustBeGt']({ value: gt });
 		if (min != null && n < min) return m['validation.mustBeMin']({ value: min });
 		if (max != null && n > max) return m['validation.mustBeMax']({ value: max });
@@ -886,7 +887,7 @@
 						</label>
 						<label
 							>{m['filament.fields.price']()} <span class="u">{settings.currency}</span>
-							<input class="mono" bind:value={price} placeholder="—" class:invalid={errors.price} />
+							<NumberInput bind:value={price} min={0} placeholder="—" spaced invalid={!!errors.price} />
 							{#if errors.price}<span class="err">{errors.price}</span>{/if}
 						</label>
 						<label>{m['spool.fields.lotNr']()}<input class="mono" bind:value={lot} placeholder="—" /></label>

--- a/client_v2/src/lib/components/ExtraFieldInput.svelte
+++ b/client_v2/src/lib/components/ExtraFieldInput.svelte
@@ -5,6 +5,7 @@
 	import EditableField from './EditableField.svelte';
 	import LinkedText from './LinkedText.svelte';
 	import { formatDateTime } from '$lib/utils/datetime';
+	import { numericInput, parseDecimal } from '$lib/utils/numeric';
 	import * as m from '$lib/paraglide/messages';
 
 	interface Props {
@@ -37,11 +38,28 @@
 		// creates a value that looks unset but isn't. Single-choice below does the same.
 		emit(v === '' ? undefined : v);
 	}
+	// The numeric fields are text inputs guarded by `numericInput` so a decimal comma
+	// is accepted and letters can't be typed at all; `parseDecimal` reads either
+	// separator. What the user typed is kept in `drafts` and shown back for as long as
+	// it means the same number as the stored value — otherwise emitting "1," (which
+	// stores 1) would immediately rewrite the box to "1" and eat the comma mid-typing.
+	let drafts = $state<Record<string, string>>({});
+	function shown(key: string, stored: unknown): string {
+		const value = stored === undefined || stored === null ? '' : String(stored);
+		const draft = drafts[key];
+		return draft !== undefined && parseDecimal(draft) === parseDecimal(value) ? draft : value;
+	}
+	function typed(key: string, raw: string): string {
+		drafts[key] = raw;
+		return raw;
+	}
+
 	function onInt(v: string) {
-		emit(v.trim() === '' ? undefined : Math.round(Number(v)));
+		const n = parseDecimal(v);
+		emit(n === null ? undefined : Math.round(n));
 	}
 	function onFloat(v: string) {
-		emit(v.trim() === '' ? undefined : Number(v));
+		emit(parseDecimal(v) ?? undefined);
 	}
 
 	// Ranges: [low, high], each number-or-null.
@@ -49,8 +67,8 @@
 	let hi = $derived(Array.isArray(parsed) ? (parsed[1] ?? '') : '');
 	function onRange(which: 0 | 1, raw: string, isInt: boolean) {
 		const cur: [unknown, unknown] = Array.isArray(parsed) ? [parsed[0], parsed[1]] : [null, null];
-		const n = raw.trim() === '' ? null : isInt ? Math.round(Number(raw)) : Number(raw);
-		cur[which] = n;
+		const parsedNum = parseDecimal(raw);
+		cur[which] = parsedNum === null ? null : isInt ? Math.round(parsedNum) : parsedNum;
 		if (cur[0] === null && cur[1] === null) emit(undefined);
 		else emit(cur);
 	}
@@ -95,11 +113,12 @@
 	<span class="numrow">
 		<input
 			class="edit mono"
-			type="number"
-			step="1"
-			value={parsed ?? ''}
+			type="text"
+			inputmode="decimal"
+			use:numericInput
+			value={shown('int', parsed)}
 			aria-label={field.name}
-			oninput={(e) => onInt(e.currentTarget.value)}
+			oninput={(e) => onInt(typed('int', e.currentTarget.value))}
 		/>
 		{#if field.unit}<span class="unit">{field.unit}</span>{/if}
 	</span>
@@ -107,11 +126,12 @@
 	<span class="numrow">
 		<input
 			class="edit mono"
-			type="number"
-			step="any"
-			value={parsed ?? ''}
+			type="text"
+			inputmode="decimal"
+			use:numericInput
+			value={shown('float', parsed)}
 			aria-label={field.name}
-			oninput={(e) => onFloat(e.currentTarget.value)}
+			oninput={(e) => onFloat(typed('float', e.currentTarget.value))}
 		/>
 		{#if field.unit}<span class="unit">{field.unit}</span>{/if}
 	</span>
@@ -120,21 +140,23 @@
 	<span class="numrow">
 		<input
 			class="edit mono narrow"
-			type="number"
-			step={isInt ? '1' : 'any'}
-			value={lo}
+			type="text"
+			inputmode="decimal"
+			use:numericInput
+			value={shown('lo', lo)}
 			aria-label={`${field.name} ${m['settings.extraFields.min']()}`}
-			oninput={(e) => onRange(0, e.currentTarget.value, isInt)}
+			oninput={(e) => onRange(0, typed('lo', e.currentTarget.value), isInt)}
 			placeholder={m['settings.extraFields.min']()}
 		/>
 		<span class="dash">–</span>
 		<input
 			class="edit mono narrow"
-			type="number"
-			step={isInt ? '1' : 'any'}
-			value={hi}
+			type="text"
+			inputmode="decimal"
+			use:numericInput
+			value={shown('hi', hi)}
 			aria-label={`${field.name} ${m['settings.extraFields.max']()}`}
-			oninput={(e) => onRange(1, e.currentTarget.value, isInt)}
+			oninput={(e) => onRange(1, typed('hi', e.currentTarget.value), isInt)}
 			placeholder={m['settings.extraFields.max']()}
 		/>
 		{#if field.unit}<span class="unit">{field.unit}</span>{/if}

--- a/client_v2/src/lib/components/NumberInput.svelte
+++ b/client_v2/src/lib/components/NumberInput.svelte
@@ -1,8 +1,12 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import * as m from '$lib/paraglide/messages';
 	import { getFieldLabelId } from './fieldLabel';
-	// A themed numeric input. Native spinners are hidden app-wide (see app.css);
-	// this component supplies its own up/down steppers styled to match the dark UI.
+	import { normalizeDecimal, numericInput, parseDecimal } from '$lib/utils/numeric';
+	// A themed numeric input. It is a text input rather than `type="number"`: that
+	// lets it accept a decimal comma ("1,75") as well as a point, and lets it refuse
+	// letters outright instead of silently reporting an unparseable value as empty.
+	// See $lib/utils/numeric.ts. Steppers are ours too, styled to match the dark UI.
 	//
 	// Two usage modes:
 	//   1. String/bindable (default): `bind:value` with a string; updates live on input.
@@ -55,13 +59,24 @@
 	// Named by the enclosing <Field>'s label cell when there is one; see fieldLabel.ts.
 	const labelId = getFieldLabelId();
 
-	// Commit mode keeps a local draft so keystrokes don't fire onchange; the controlled
-	// `value` re-seeds it whenever the parent changes it (e.g. a new element is selected).
-	let draft = $state('');
+	// What the parent sees is always canonical (a dot, or a number). What the user
+	// sees is the text they typed, kept here as a draft — that's how a decimal comma,
+	// and a half-finished "1," or "", survive a round trip through the parent.
+	// The draft is dropped as soon as the parent moves the value somewhere the draft
+	// doesn't mean (a clamp, a preset button, another element selected); a value that
+	// merely echoes back what was typed leaves it alone. In commit mode the draft is
+	// also what defers `onchange` until blur or a step.
+	let draft = $state<string | null>(null);
+	const external = $derived(value == null ? '' : String(value));
+	const shown = $derived(draft ?? external);
 	$effect(() => {
-		if (onchange) draft = String(value ?? '');
+		const incoming = external;
+		untrack(() => {
+			if (draft !== null && parseDecimal(draft) !== parseDecimal(incoming)) draft = null;
+		});
 	});
-	const shown = $derived(onchange ? draft : String(value ?? ''));
+	// A minus sign is only offered where a negative value is actually allowed.
+	const negative = $derived(min == null || min < 0);
 
 	function clamp(n: number): number {
 		if (min != null && n < min) n = min;
@@ -69,45 +84,54 @@
 		return n;
 	}
 	function onInput(v: string) {
-		if (onchange) draft = v;
-		else value = v;
+		draft = v;
+		if (!onchange) value = normalizeDecimal(v);
 	}
 	function commit() {
 		if (!onchange) return;
-		if (onclear && draft.trim() === '') onclear();
-		else onchange(clamp(parseFloat(draft) || 0));
+		const raw = (draft ?? external).trim();
+		if (onclear && raw === '') onclear();
+		else onchange(clamp(parseDecimal(raw) ?? 0));
 	}
 	function bump(dir: 1 | -1) {
-		const cur = parseFloat(shown);
-		const base = Number.isFinite(cur) ? cur : (min ?? 0);
+		const base = parseDecimal(shown) ?? min ?? 0;
 		let next = clamp(base + dir * step);
 		next = Math.round(next * 1e6) / 1e6; // trim float noise
-		if (onchange) {
-			draft = String(next);
-			onchange(next);
-		} else {
-			value = String(next);
+		draft = String(next);
+		if (onchange) onchange(next);
+		else value = String(next);
+	}
+	// A text input has no native stepping, so keep the arrow keys a number input gave us.
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'ArrowUp') {
+			e.preventDefault();
+			bump(1);
+		} else if (e.key === 'ArrowDown') {
+			e.preventDefault();
+			bump(-1);
 		}
 	}
 </script>
 
 <div class="ni" class:spaced class:invalid class:dense class:disabled style:width>
-	<!-- value/oninput (not bind:value) so the value stays a string — Svelte would
-	     otherwise coerce a type=number binding to a number. -->
+	<!-- value/oninput (not bind:value) so the value stays a string, and so the draft
+	     above decides what is displayed. `numericInput` filters the keystrokes; min,
+	     max and step are enforced by this component, not by the browser. -->
 	<input
 		class="mono"
-		type="number"
+		type="text"
+		use:numericInput={{ negative }}
 		value={shown}
 		oninput={(e) => onInput(e.currentTarget.value)}
 		onchange={commit}
-		{min}
-		{max}
-		{step}
+		onkeydown={onKeydown}
 		{placeholder}
 		{disabled}
 		aria-label={ariaLabel}
 		aria-labelledby={ariaLabel ? undefined : labelId}
 		inputmode="decimal"
+		autocomplete="off"
+		spellcheck="false"
 	/>
 	{#if unit}<span class="unit">{unit}</span>{/if}
 	<div class="spin">

--- a/client_v2/src/lib/components/settings/ExtraFieldsManager.svelte
+++ b/client_v2/src/lib/components/settings/ExtraFieldsManager.svelte
@@ -9,6 +9,7 @@
 		type FieldParams
 	} from '$lib/api/fields';
 	import { fields } from '$lib/stores/fields.svelte';
+	import { numericInput, parseDecimal } from '$lib/utils/numeric';
 	import * as m from '$lib/paraglide/messages';
 	import Plus from '@lucide/svelte/icons/plus';
 	import X from '@lucide/svelte/icons/x';
@@ -65,7 +66,10 @@
 
 	let key = $state('');
 	let name = $state('');
-	let order = $state(0);
+	// The order box is a plain text field (numeric fields accept a decimal comma and
+	// refuse letters — see $lib/utils/numeric.ts); `order` is the whole number it means.
+	let orderText = $state('0');
+	let order = $derived(Math.max(0, Math.round(parseDecimal(orderText) ?? 0)));
 	let fieldType = $state<FieldType>(FieldType.text);
 	let unit = $state('');
 	let defaultJson = $state<string | undefined>(undefined);
@@ -95,7 +99,7 @@
 		error = '';
 		key = '';
 		name = '';
-		order = Math.max(0, ...defs.map((f) => f.order)) + 1;
+		orderText = String(Math.max(0, ...defs.map((f) => f.order)) + 1);
 		fieldType = FieldType.text;
 		unit = '';
 		defaultJson = undefined;
@@ -111,7 +115,7 @@
 		error = '';
 		key = f.key;
 		name = f.name;
-		order = f.order;
+		orderText = String(f.order);
 		fieldType = f.field_type;
 		unit = f.unit ?? '';
 		defaultJson = f.default_value ?? undefined;
@@ -205,7 +209,7 @@
 
 		const params: FieldParams = {
 			name: name.trim(),
-			order: Math.max(0, Math.round(order)),
+			order,
 			field_type: fieldType,
 			unit: showsUnit && unit.trim() ? unit.trim() : null,
 			default_value: defaultJson ?? null,
@@ -301,7 +305,13 @@
 			</label>
 			<label class="fld">
 				<span>{m['settings.extraFields.params.order']()}</span>
-				<input class="in mono" type="number" min="0" bind:value={order} />
+				<input
+					class="in mono"
+					type="text"
+					inputmode="numeric"
+					use:numericInput={{ negative: false }}
+					bind:value={orderText}
+				/>
 			</label>
 			<label class="fld wide">
 				<span>{m['settings.extraFields.params.name']()}</span>

--- a/client_v2/src/lib/utils/numeric.test.ts
+++ b/client_v2/src/lib/utils/numeric.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import { filterDecimalInsertion, isPartialDecimal, normalizeDecimal, parseDecimal } from './numeric';
+
+// These rules stand between the keyboard and every weight, price, temperature and
+// diameter in the app: a decimal comma has to survive, and nothing that isn't a
+// number may reach the API.
+
+describe('parseDecimal', () => {
+	it('reads a decimal point', () => {
+		expect(parseDecimal('1.75')).toBe(1.75);
+	});
+
+	it('reads a decimal comma the same way', () => {
+		expect(parseDecimal('1,75')).toBe(1.75);
+	});
+
+	it('reads plain integers and signs', () => {
+		expect(parseDecimal('250')).toBe(250);
+		expect(parseDecimal('-4,5')).toBe(-4.5);
+		expect(parseDecimal('+7')).toBe(7);
+	});
+
+	it('reads values with the separator at either end', () => {
+		expect(parseDecimal('1,')).toBe(1);
+		expect(parseDecimal(',5')).toBe(0.5);
+	});
+
+	it('ignores surrounding whitespace', () => {
+		expect(parseDecimal('  12.5  ')).toBe(12.5);
+	});
+
+	it('passes finite numbers straight through', () => {
+		expect(parseDecimal(3)).toBe(3);
+		expect(parseDecimal(NaN)).toBeNull();
+	});
+
+	it('returns null for anything that is not a plain number', () => {
+		for (const bad of ['', '   ', 'abc', '1e5', '0x10', 'Infinity', '1 2', '1.2.3', '-', ',']) {
+			expect(parseDecimal(bad), bad).toBeNull();
+		}
+	});
+
+	it('returns null rather than 0 for no value at all', () => {
+		expect(parseDecimal(null)).toBeNull();
+		expect(parseDecimal(undefined)).toBeNull();
+		expect(parseDecimal('0')).toBe(0);
+	});
+});
+
+describe('normalizeDecimal', () => {
+	it('turns the typed comma into the canonical point', () => {
+		expect(normalizeDecimal('1,75')).toBe('1.75');
+		expect(normalizeDecimal('1.75')).toBe('1.75');
+		expect(normalizeDecimal('')).toBe('');
+	});
+});
+
+describe('isPartialDecimal', () => {
+	it('accepts a number still being typed', () => {
+		for (const s of ['', '-', '1', '1,', '1.', ',5', '-0.4']) {
+			expect(isPartialDecimal(s), s).toBe(true);
+		}
+	});
+
+	it('rejects letters, exponents and second separators', () => {
+		for (const s of ['a', '1e', '1e5', '1..2', '1,2,3', '1 ', '+1']) {
+			expect(isPartialDecimal(s), s).toBe(false);
+		}
+	});
+
+	it('rejects a minus where negatives are not allowed', () => {
+		expect(isPartialDecimal('-1', false)).toBe(false);
+		expect(isPartialDecimal('1', false)).toBe(true);
+	});
+});
+
+describe('filterDecimalInsertion', () => {
+	it('keeps a clean paste as-is', () => {
+		expect(filterDecimalInsertion('1,75')).toBe('1,75');
+	});
+
+	it('drops a trailing unit', () => {
+		expect(filterDecimalInsertion('12,5 g')).toBe('12,5');
+	});
+
+	it('skips leading junk', () => {
+		expect(filterDecimalInsertion('$12.50')).toBe('12.50');
+	});
+
+	it('truncates at a second separator rather than closing the gap', () => {
+		// "1.23" would silently be ten times the pasted 1.2.
+		expect(filterDecimalInsertion('1.2.3')).toBe('1.2');
+	});
+
+	it('yields nothing for text with no number in it', () => {
+		expect(filterDecimalInsertion('abc')).toBe('');
+	});
+
+	it('respects a separator already in the field', () => {
+		expect(filterDecimalInsertion('5.5', '1.', '')).toBe('5');
+	});
+
+	it('respects text that follows the caret', () => {
+		expect(filterDecimalInsertion('2.5', '', '.75')).toBe('2');
+	});
+
+	it('only keeps a minus at the very front', () => {
+		expect(filterDecimalInsertion('-5')).toBe('-5');
+		expect(filterDecimalInsertion('-5', '1', '')).toBe('5');
+		expect(filterDecimalInsertion('-5', '', '', { negative: false })).toBe('5');
+	});
+});

--- a/client_v2/src/lib/utils/numeric.ts
+++ b/client_v2/src/lib/utils/numeric.ts
@@ -1,0 +1,137 @@
+// Shared behaviour for every numeric field in the app.
+//
+// Two problems this solves, both of which `<input type="number">` handles badly:
+//
+//  1. Decimal comma. Most of the world writes "1,75", not "1.75". A native number
+//     input only accepts the separator the *browser locale* dictates and reports
+//     `.value === ''` for anything it considers invalid — so a user typing "1,75"
+//     can silently end up submitting an empty field.
+//  2. Junk characters. A number input happily accepts "e", "+" and "-" anywhere in
+//     the text (they're legal in exponent syntax) and then reports the whole value
+//     as empty, so "1e" reads back as nothing at all.
+//
+// So numeric fields are plain text inputs with `inputmode="decimal"`, guarded by the
+// `numericInput` action below and parsed with `parseDecimal`. Both '.' and ',' are
+// accepted while typing; everything stored or handed to a parent is canonical (dot).
+
+/** Canonical form of a number as typed: decimal comma becomes a decimal point. */
+export function normalizeDecimal(raw: string): string {
+	return raw.replace(',', '.');
+}
+
+// Deliberately stricter than Number(): no hex, no exponents, no "Infinity", no
+// embedded whitespace — a field that only ever holds a plain decimal number.
+const DECIMAL_RE = /^[+-]?(\d+(\.\d*)?|\.\d+)$/;
+
+/**
+ * Parse user-entered text as a number, accepting either decimal separator.
+ * Returns null for anything that isn't a plain finite decimal — including empty
+ * text and half-typed values like "-" or "," — so callers can tell "no value"
+ * apart from a real 0.
+ */
+export function parseDecimal(raw: string | number | null | undefined): number | null {
+	if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+	if (raw == null) return null;
+	const t = normalizeDecimal(raw).trim();
+	if (!DECIMAL_RE.test(t)) return null;
+	const n = Number(t);
+	return Number.isFinite(n) ? n : null;
+}
+
+export interface NumericInputOptions {
+	/** Allow a leading minus sign. Defaults to true. */
+	negative?: boolean;
+}
+
+/**
+ * Is this text *on its way* to being a number? "", "-", "1,", ",5" all qualify —
+ * a keystroke filter has to let a partially typed number through.
+ */
+export function isPartialDecimal(s: string, negative = true): boolean {
+	return negative ? /^-?\d*[.,]?\d*$/.test(s) : /^\d*[.,]?\d*$/.test(s);
+}
+
+/**
+ * The usable part of `data` when inserted between `before` and `after`.
+ *
+ * Leading junk is skipped ("$12,5" → "12,5"), then characters are taken while the
+ * field would still read as a number and dropped from the first one that wouldn't
+ * ("12,5 g" → "12,5", "1.2.3" → "1.2"). Truncating rather than deleting the stray
+ * separator matters: turning a pasted "1.2.3" into "1.23" would silently inflate a
+ * weight tenfold. Used for pasted and dropped text, where rejecting the whole
+ * insertion would be more annoying than cleaning it.
+ */
+export function filterDecimalInsertion(
+	data: string,
+	before = '',
+	after = '',
+	{ negative = true }: NumericInputOptions = {}
+): string {
+	let out = '';
+	let started = false;
+	for (const c of data) {
+		if (isPartialDecimal(before + out + c + after, negative)) {
+			out += c;
+			started = true;
+		} else if (started) {
+			break; // stop at the first character that no longer fits
+		}
+	}
+	return out;
+}
+
+/**
+ * Svelte action that makes a text input reject anything that isn't part of a
+ * decimal number, whether typed, pasted or dropped. Both '.' and ',' survive —
+ * normalizing to a point is the reader's job (`parseDecimal`), so the user keeps
+ * seeing the separator they typed.
+ *
+ * Svelte delegates `input`/`beforeinput` to the app root, so these node-level
+ * listeners run before the component's own handlers: by the time an `oninput`
+ * handler reads `.value`, it has already been cleaned.
+ */
+export function numericInput(node: HTMLInputElement, options: NumericInputOptions = {}) {
+	let opts = options;
+	const negative = () => opts.negative !== false;
+
+	function onBeforeInput(e: InputEvent) {
+		if (!e.inputType.startsWith('insert')) return; // deletions are always fine
+		const data = e.data ?? e.dataTransfer?.getData('text/plain') ?? '';
+		if (!data) return;
+		const start = node.selectionStart ?? node.value.length;
+		const end = node.selectionEnd ?? start;
+		const before = node.value.slice(0, start);
+		const after = node.value.slice(end);
+		if (isPartialDecimal(before + data + after, negative())) return;
+
+		// Not insertable as typed: drop the event and put back whatever was usable.
+		e.preventDefault();
+		const cleaned = filterDecimalInsertion(data, before, after, opts);
+		if (!cleaned) return;
+		node.setRangeText(cleaned, start, end, 'end');
+		node.dispatchEvent(new Event('input', { bubbles: true }));
+	}
+
+	// Safety net for text that arrives without a beforeinput event (autofill,
+	// speech input, a browser that skips it).
+	function onInput() {
+		if (isPartialDecimal(node.value, negative())) return;
+		const caret = node.selectionStart ?? node.value.length;
+		node.value = filterDecimalInsertion(node.value, '', '', opts);
+		const pos = Math.min(caret, node.value.length);
+		node.setSelectionRange(pos, pos);
+	}
+
+	node.addEventListener('beforeinput', onBeforeInput);
+	node.addEventListener('input', onInput);
+
+	return {
+		update(next: NumericInputOptions = {}) {
+			opts = next;
+		},
+		destroy() {
+			node.removeEventListener('beforeinput', onBeforeInput);
+			node.removeEventListener('input', onInput);
+		}
+	};
+}

--- a/client_v2/src/routes/settings/+page.svelte
+++ b/client_v2/src/routes/settings/+page.svelte
@@ -9,6 +9,7 @@
 	import * as m from '$lib/paraglide/messages';
 	import { languages } from '$lib/i18n/languages';
 	import { trackSave } from '$lib/utils/autosave';
+	import { numericInput, parseDecimal } from '$lib/utils/numeric';
 	import { page } from '$app/state';
 	import { entityFromUrl, gotoEntity, EXTRA_FIELDS_ANCHOR } from '$lib/settings/params';
 
@@ -29,6 +30,24 @@
 	}
 	function saveBaseUrl(v: string) {
 		trackSave(settings.setBaseUrl(v.trim()));
+	}
+
+	// The threshold box takes either decimal separator (see $lib/utils/numeric.ts).
+	// What was typed stays on screen for as long as the stored number is still the
+	// one it produced, so storing the canonical 1.5 doesn't rewrite a typed "1,5"
+	// mid-keystroke — and an emptied box doesn't immediately refill itself with the
+	// 0 it stores, which would leave the next digits typed after a stray zero.
+	let thresholdDraft = $state<string | null>(null);
+	let thresholdStored = $state(0);
+	let thresholdText = $derived(
+		thresholdDraft !== null && thresholdStored === settings.lowThreshold
+			? thresholdDraft
+			: String(settings.lowThreshold)
+	);
+	function saveThreshold(v: string) {
+		thresholdDraft = v;
+		thresholdStored = parseDecimal(v) ?? 0;
+		settings.setLowThreshold(thresholdStored);
 	}
 
 	let localeData = locales.map((code) => {
@@ -123,10 +142,12 @@
 			>
 				<input
 					class="num mono"
-					type="number"
+					type="text"
+					inputmode="decimal"
+					use:numericInput={{ negative: false }}
 					aria-label={m['settings.library.lowThreshold.label']()}
-					value={settings.lowThreshold}
-					oninput={(e) => settings.setLowThreshold(Number(e.currentTarget.value) || 0)}
+					value={thresholdText}
+					oninput={(e) => saveThreshold(e.currentTarget.value)}
 				/>
 				<span class="unit">g</span>
 			</SettingRow>

--- a/tests_frontend_v2/tests/change-vendor.spec.ts
+++ b/tests_frontend_v2/tests/change-vendor.spec.ts
@@ -56,8 +56,8 @@ test("change which manufacturer a filament is filed under", async ({ page }) => 
     await expect(page).toHaveURL(/[?&]sel=vendor(:|%3A)\d+/);
 
     const saved = patched(page, "vendor");
-    await inspector.getByRole("spinbutton", { name: "Empty Spool Weight" }).fill("250");
-    await inspector.getByRole("spinbutton", { name: "Empty Spool Weight" }).blur();
+    await inspector.getByRole("textbox", { name: "Empty Spool Weight" }).fill("250");
+    await inspector.getByRole("textbox", { name: "Empty Spool Weight" }).blur();
     await saved;
   });
 

--- a/tests_frontend_v2/tests/numeric-input.spec.ts
+++ b/tests_frontend_v2/tests/numeric-input.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect } from "./fixtures";
+import {
+  expectAppShell,
+  navTab,
+  numberField,
+  openAddSpoolModal,
+  openApp,
+  searchFor,
+  unique,
+} from "./helpers";
+
+/**
+ * Every number in Spoolman — weights, diameters, densities, temperatures, prices —
+ * is typed into the same numeric input. Two things about it are easy to break and
+ * invisible until a user in a comma-decimal locale hits them:
+ *
+ *  - "1,24" has to mean 1.24, not 124 and not "nothing at all",
+ *  - and letters must never make it into a field that will be sent as a number.
+ *
+ * The fields are text inputs (not `type="number"`) precisely so both hold, so the
+ * assertions below type with real key events rather than `fill()`, which would set
+ * the value straight onto the element and skip the keystroke filter entirely.
+ */
+
+test("a decimal comma is accepted everywhere a number is typed", async ({ page }) => {
+  const vendorName = unique("Vendor");
+  const filamentName = unique("Filament");
+  const locationName = unique("Shelf");
+
+  await openApp(page);
+
+  await test.step("describe a filament using comma decimals", async () => {
+    const dialog = await openAddSpoolModal(page);
+    await dialog.getByRole("button", { name: /^Create a new filament/ }).click();
+    await dialog.getByPlaceholder("e.g. Polymaker").fill(vendorName);
+    await dialog.getByPlaceholder("e.g. PolyTerra Matte Sage").fill(filamentName);
+    await dialog.getByPlaceholder("PLA", { exact: true }).fill("PLA");
+
+    await dialog.getByRole("button", { name: /^Advanced specs/ }).click();
+    // Density is pre-filled from the material's SpoolmanDB entry, so clear it first.
+    const density = numberField(dialog, "Density");
+    await density.fill("");
+    await density.pressSequentially("1,24");
+    // The separator the user typed stays on screen; only what's sent is canonical.
+    await expect(density).toHaveValue("1,24");
+
+    const diameter = numberField(dialog, "Diameter");
+    await diameter.fill("");
+    await diameter.pressSequentially("1,75");
+    await expect(diameter).toHaveValue("1,75");
+
+    const weight = numberField(dialog, "Weight");
+    await weight.fill("");
+    await weight.pressSequentially("1000,5");
+
+    await dialog.getByPlaceholder("e.g. Shelf A").fill(locationName);
+
+    // A field that had been read as empty or as 124 would block the submit here:
+    // density is required and must be > 0, and the weight must not exceed it.
+    await dialog.getByRole("button", { name: "Add 1 spool", exact: true }).click();
+    await expect(dialog).toBeHidden();
+  });
+
+  await test.step("the values were stored as decimals, not as whole numbers", async () => {
+    // The group subtitle comes back from the API, so 1,75 mm survived the round trip.
+    await expect(page.getByText(`${vendorName} · 1.75 mm`)).toBeVisible();
+
+    const panel = await searchFor(page, filamentName);
+    await panel.getByRole("link").filter({ hasText: filamentName }).first().click();
+    await expect(page).toHaveURL(/[?&]sel=filament(:|%3A)\d+/);
+
+    // Numeric fields are textboxes now that they are no longer type="number".
+    await expect(page.getByRole("textbox", { name: "Density" })).toHaveValue("1.24");
+    await expect(page.getByRole("textbox", { name: "Diameter" })).toHaveValue("1.75");
+    await expect(page.getByRole("textbox", { name: "Weight", exact: true })).toHaveValue("1000.5");
+  });
+});
+
+test("numeric fields refuse anything that isn't part of a number", async ({ page }) => {
+  await openApp(page);
+  const dialog = await openAddSpoolModal(page);
+  await dialog.getByRole("button", { name: /^Create a new filament/ }).click();
+
+  const weight = numberField(dialog, "Weight");
+
+  await test.step("letters and exponents are dropped as they are typed", async () => {
+    // Filtering happens per keystroke, so the digits around the rejected ones are
+    // still accepted — what matters is that none of "e", "x" or "g" gets in.
+    await weight.fill("");
+    await weight.pressSequentially("1e2x5g");
+    await expect(weight).toHaveValue("125");
+  });
+
+  await test.step("only the first decimal separator is taken", async () => {
+    await weight.fill("");
+    await weight.pressSequentially("1,5.5");
+    await expect(weight).toHaveValue("1,55");
+  });
+
+  await test.step("a minus is refused where negatives make no sense", async () => {
+    await weight.fill("");
+    await weight.pressSequentially("-5");
+    await expect(weight).toHaveValue("5");
+  });
+
+  await test.step("the arrow keys still step the value", async () => {
+    const count = numberField(dialog, "Count");
+    await count.click();
+    await count.press("ArrowUp");
+    await expect(count).toHaveValue("2");
+    await count.press("ArrowDown");
+    await expect(count).toHaveValue("1");
+    // Steps stop at the field's minimum rather than running past it.
+    await count.press("ArrowDown");
+    await expect(count).toHaveValue("1");
+  });
+
+  await dialog.getByRole("button", { name: "Close" }).click();
+});
+
+test("a comma typed into an extra field is stored as a decimal", async ({ page }) => {
+  const fieldKey = `test_num_field_${Date.now().toString(36)}`;
+  const fieldName = unique("Shore");
+  const vendorName = unique("Vendor");
+  const filamentName = unique("Filament");
+  const locationName = unique("Shelf");
+
+  await openApp(page);
+
+  try {
+    await test.step("define a decimal extra field for spools", async () => {
+      await navTab(page, "Settings", "Settings | Spoolman");
+      await page.getByRole("button", { name: "Add Spool field" }).click();
+      await page.getByPlaceholder("lower_snake_case").fill(fieldKey);
+      await page.getByPlaceholder("Display name").fill(fieldName);
+      await page.getByRole("combobox", { name: "Type" }).selectOption("float");
+      await page.getByRole("button", { name: "Save field" }).click();
+      await expect(page.getByText(fieldKey, { exact: true })).toBeVisible();
+    });
+
+    await test.step("type a comma decimal into it on a spool", async () => {
+      await navTab(page, "Library", "Library | Spoolman");
+      const dialog = await openAddSpoolModal(page);
+      await dialog.getByRole("button", { name: /^Create a new filament/ }).click();
+      await dialog.getByPlaceholder("e.g. Polymaker").fill(vendorName);
+      await dialog.getByPlaceholder("e.g. PolyTerra Matte Sage").fill(filamentName);
+      await dialog.getByPlaceholder("PLA", { exact: true }).fill("PLA");
+      await dialog.getByRole("button", { name: /^Advanced specs/ }).click();
+      await numberField(dialog, "Density").fill("1.24");
+      await numberField(dialog, "Weight").fill("1000");
+      await dialog.getByPlaceholder("e.g. Shelf A").fill(locationName);
+
+      const extra = dialog.getByLabel(fieldName, { exact: true });
+      await extra.click();
+      await extra.pressSequentially("2,5");
+      await expect(extra).toHaveValue("2,5");
+
+      await dialog.getByRole("button", { name: "Add 1 spool", exact: true }).click();
+      await expect(dialog).toBeHidden();
+    });
+
+    await test.step("the spool came back from the API holding 2.5", async () => {
+      const spoolRow = page.getByRole("link").filter({ hasText: locationName });
+      await spoolRow.first().click();
+      await expect(page.getByLabel(fieldName, { exact: true })).toHaveValue("2.5");
+    });
+  } finally {
+    // Deleting a field takes its data with it, so the UI asks first.
+    await navTab(page, "Settings", "Settings | Spoolman");
+    page.once("dialog", (dialog) => dialog.accept());
+    await page
+      .locator(".table .row", { hasText: fieldKey })
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+    await expect(page.getByText(fieldKey, { exact: true })).toHaveCount(0);
+  }
+});
+
+/**
+ * The low-stock threshold is the one numeric field outside the add modal and the
+ * inspectors — it lives on the settings page, is stored in localStorage rather
+ * than on the server, and keeps its own draft of what was typed.
+ */
+test("the low-stock threshold takes a comma decimal and keeps it over a reload", async ({ page }) => {
+  await openApp(page);
+  await navTab(page, "Settings", "Settings | Spoolman");
+
+  const threshold = page.getByRole("textbox", { name: "Low-stock threshold" });
+  await threshold.fill("");
+  await threshold.pressSequentially("12abc,5");
+  await expect(threshold).toHaveValue("12,5");
+
+  await page.reload();
+  await expectAppShell(page);
+  // Stored canonically, so it comes back as 12.5 rather than 125 or 0.
+  await expect(page.getByRole("textbox", { name: "Low-stock threshold" })).toHaveValue("12.5");
+});

--- a/tests_frontend_v2/tests/overrides.spec.ts
+++ b/tests_frontend_v2/tests/overrides.spec.ts
@@ -36,7 +36,7 @@ test("a spool keeps a tare weight of its own, and says when it overrides the fil
   await expect(page).toHaveURL(/[?&]sel=spool(:|%3A)\d+/);
 
   const inspector = page.locator(".insp");
-  const spoolTare = inspector.getByRole("spinbutton", { name: "Spool Weight" });
+  const spoolTare = inspector.getByRole("textbox", { name: "Spool Weight" });
 
   await test.step("give this spool a tare weight of its own", async () => {
     const saved = patched(page, "spool");
@@ -50,7 +50,7 @@ test("a spool keeps a tare weight of its own, and says when it overrides the fil
   await test.step("correcting the filament leaves this spool on its own figure", async () => {
     await inspector.getByRole("link", { name: /Open filament/ }).click();
     await expect(page).toHaveURL(/[?&]sel=filament(:|%3A)\d+/);
-    const filamentTare = inspector.getByRole("spinbutton", { name: "Spool Weight" });
+    const filamentTare = inspector.getByRole("textbox", { name: "Spool Weight" });
     const saved = patched(page, "filament");
     await filamentTare.fill("261");
     await filamentTare.blur();


### PR DESCRIPTION
Numeric fields used `<input type="number">`, which only accepts the decimal separator the browser locale dictates and reports everything else as an empty value. Typing `1,75` produced a blank field or, once the separator was dropped, a number a hundred times too large. That input type also accepts `e`, `+` and `-` anywhere in the text and then reads back as empty, so `1e` meant nothing at all.

Numeric fields are now text inputs with `inputmode="decimal"`, filtered per keystroke by a shared `numericInput` action, and read with `parseDecimal`, which takes either separator and returns null rather than NaN for text that is not a number. Pasted text is cleaned instead of refused (`12,5 g` becomes `12,5`). The separator you type stays on screen; what reaches the API is always canonical.

Covers the spool, filament and vendor inspectors, the add spool modal (whose price box was an unfiltered text input accepting anything), extra fields of every numeric type, the extra field editor's order box, and the low stock threshold.

Two notes for review:

* Arrow key stepping is now the component's own, since it was native to the old input type.
* The inputs' ARIA role changes from `spinbutton` to `textbox`. Two specs in `tests_frontend_v2` located fields by that role and are updated here.

Tests: 20 unit tests in `client_v2/src/lib/utils/numeric.test.ts`, 4 browser tests in `tests_frontend_v2/tests/numeric-input.spec.ts`. Full `tests_frontend_v2` suite passes (34), as do lint, format, svelte-check and vitest.
