### PR TITLE
client_v2: quick-pick roll sizes when adding spools

### DIFF
--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -50,6 +50,7 @@
     "add.vendorHint.existing": "Using existing manufacturer “{{name}}”",
     "add.vendorHint.new": "New manufacturer “{{name}}” will be created",
     "add.vendorHint.optional": "Optional — leave blank for no manufacturer",
+    "add.weightPresets": "Common roll sizes",
     "add.yourCatalog": "Your catalog",
     "buttons.apply": "Apply",
     "buttons.archive": "Archive",

--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -37,8 +37,6 @@
     "add.section.spool": "Spool",
     "add.section.spoolNote": "The physical spools going into your inventory.",
     "add.section.spoolSharedNote": "Weight, spool weight and price are also saved as the new filament’s defaults.",
-    "add.spoolDetails": "More details",
-    "add.spoolDetailsNote": "lot number, usage dates, comment",
     "add.spoolWeightPreset.cardboard": "Cardboard {{weight}} g",
     "add.spoolWeightPreset.plastic": "Plastic {{weight}} g",
     "add.spoolWeightPresetsLead": "Start from a typical spool:",

--- a/client_v2/locales/en/common.json
+++ b/client_v2/locales/en/common.json
@@ -37,6 +37,8 @@
     "add.section.spool": "Spool",
     "add.section.spoolNote": "The physical spools going into your inventory.",
     "add.section.spoolSharedNote": "Weight, spool weight and price are also saved as the new filament’s defaults.",
+    "add.spoolDetails": "More details",
+    "add.spoolDetailsNote": "lot number, usage dates, comment",
     "add.spoolWeightPreset.cardboard": "Cardboard {{weight}} g",
     "add.spoolWeightPreset.plastic": "Plastic {{weight}} g",
     "add.spoolWeightPresetsLead": "Start from a typical spool:",

--- a/client_v2/src/lib/components/AddSpoolModal.svelte
+++ b/client_v2/src/lib/components/AddSpoolModal.svelte
@@ -71,10 +71,6 @@
 	// `extraValues` below: the two entities have their own field definitions.
 	let filamentExtra = $state<Extra>({});
 	let showAdvanced = $state(false);
-	// Whether the spool's paperwork (lot number, dates, comment) is folded out. Kept
-	// across an "add and new" on purpose: someone entering lot numbers is entering
-	// them for the whole box of spools, not just the first one.
-	let showSpoolDetails = $state(false);
 	let nameInput = $state<HTMLInputElement | undefined>();
 	// Display-only: an untouched empty name shows the naming guidance rather than
 	// shouting "Required" at a form the user just opened. Submission is unaffected
@@ -942,8 +938,11 @@
 						{/if}
 					</div>
 
-					<div class="form">
-						<label class="wide">
+					<!-- Which spool, and where it lives: the lot number is the one identifier a
+					     spool carries of its own, so it sits with the shelf rather than with the
+					     money. -->
+					<div class="form where">
+						<label>
 							{m['spool.fields.location']()}
 							<Combobox
 								value={location}
@@ -956,6 +955,7 @@
 							     didn't open a popup to find that out. -->
 							<span class="hint">{m['add.locationHint']()}</span>
 						</label>
+						<label>{m['spool.fields.lotNr']()}<input class="mono" bind:value={lot} placeholder="—" /></label>
 					</div>
 
 					<div class="form money">
@@ -1008,44 +1008,27 @@
 						</label>
 					</div>
 
-					<!-- Everything below is either already right or not known yet: a lot number means
-					     squinting at the sticker, and a spool being added the day it arrives has no
-					     usage history and nothing to say about itself. Folded away so the form ends
-					     at the last question most people actually answer, in the same disclosure the
-					     filament half above uses for its specs. -->
-					<button class="adv-toggle" onclick={() => (showSpoolDetails = !showSpoolDetails)}>
-						{#if showSpoolDetails}<ChevronDown size={14} />{:else}<ChevronRight size={14} />{/if}
-						{m['add.spoolDetails']()}
-						{#if !showSpoolDetails}<span class="adv-note">{m['add.spoolDetailsNote']()}</span>{/if}
-					</button>
-					{#if showSpoolDetails}
-						<div class="form">
-							<label>{m['spool.fields.lotNr']()}<input class="mono" bind:value={lot} placeholder="—" /></label
-							>
-						</div>
+					<div class="form dates">
+						<label class="date-label"
+							>{m['spool.fields.firstUsed']()}<DateTimeField
+								value={firstUsed}
+								oninput={(iso) => (firstUsed = iso)}
+							/></label
+						>
+						<label class="date-label"
+							>{m['spool.fields.lastUsed']()}<DateTimeField
+								value={lastUsed}
+								oninput={(iso) => (lastUsed = iso)}
+							/></label
+						>
+					</div>
 
-						<div class="form dates">
-							<label class="date-label"
-								>{m['spool.fields.firstUsed']()}<DateTimeField
-									value={firstUsed}
-									oninput={(iso) => (firstUsed = iso)}
-								/></label
-							>
-							<label class="date-label"
-								>{m['spool.fields.lastUsed']()}<DateTimeField
-									value={lastUsed}
-									oninput={(iso) => (lastUsed = iso)}
-								/></label
-							>
-						</div>
-
-						<div class="form comment-row">
-							<label class="wide"
-								>{m['spool.fields.comment']()}<textarea rows="2" bind:value={comment} placeholder="—"
-								></textarea></label
-							>
-						</div>
-					{/if}
+					<div class="form comment-row">
+						<label class="wide"
+							>{m['spool.fields.comment']()}<textarea rows="2" bind:value={comment} placeholder="—"
+							></textarea></label
+						>
+					</div>
 
 					<ExtraFieldsSection entity="spool" extra={extraValues} onchange={setExtra} />
 
@@ -1393,6 +1376,10 @@
 	/* Count takes only what it needs; the weight and its roll sizes take the rest. */
 	.form.headline {
 		grid-template-columns: auto 1fr;
+	}
+	/* The shelf gets the room; the lot number is a short code. */
+	.form.where {
+		grid-template-columns: 2fr 1fr;
 	}
 	/* The weight field and its roll sizes on one line, so the sizes read as
 	   alternatives to typing in it rather than as a second control stacked

--- a/client_v2/src/lib/components/AddSpoolModal.svelte
+++ b/client_v2/src/lib/components/AddSpoolModal.svelte
@@ -216,6 +216,12 @@
 		{ weight: 140, label: () => m['add.spoolWeightPreset.cardboard']({ weight: 140 }) },
 		{ weight: 200, label: () => m['add.spoolWeightPreset.plastic']({ weight: 200 }) }
 	];
+	// The roll sizes worth a one-click shortcut, taken from the weights actually sold
+	// in the SpoolmanDB catalog: 1 kg is half of it and every brand in it sells one,
+	// with 750 g, 500 g, 250 g and the 2–3 kg bulk rolls making up most of the rest.
+	// Listed by size rather than popularity so the row reads as a scale; anything
+	// else is still typed into the field next to them.
+	const NET_WEIGHT_PRESETS = [250, 500, 750, 1000, 2000, 3000];
 
 	let fillHelp = $derived(
 		fillMode === 'used'
@@ -866,6 +872,22 @@
 								spaced
 								invalid={!!errors.netWeight}
 							/>
+							<!-- Out in the open rather than behind the ⓘ used elsewhere: nearly every
+							     spool is one of these few sizes, so this is the fast path through the
+							     field, not an explanation of it. Buttons nested in the <label> are safe —
+							     a click on interactive content isn't forwarded to the labelled input, so
+							     picking a size doesn't also yank focus into the weight field. -->
+							<span class="presets" role="group" aria-label={m['add.weightPresets']()}>
+								{#each NET_WEIGHT_PRESETS as preset (preset)}
+									<button
+										type="button"
+										class="preset"
+										class:on={Number(netWeight) === preset}
+										aria-pressed={Number(netWeight) === preset}
+										onclick={() => (netWeight = String(preset))}>{weightAuto(preset)}</button
+									>
+								{/each}
+							</span>
 							{#if openHelp === 'weight'}
 								<span class="help-popup" id="weight-help" role="note"
 									>{m['filament.fieldsHelp.weight']()}</span
@@ -1439,6 +1461,13 @@
 		border-color: var(--accent);
 		background: var(--accent-wash-soft);
 	}
+	/* The size the field currently holds, so the row doubles as a readout of which
+	   preset (if any) is in play. */
+	.preset.on {
+		border-color: var(--accent);
+		background: var(--accent-wash);
+		color: var(--text);
+	}
 	.form textarea {
 		width: 100%;
 		border: 1px solid var(--border-strong);
@@ -1525,6 +1554,15 @@
 	@media (max-width: 620px) {
 		.form {
 			grid-template-columns: 1fr 1fr;
+		}
+		/* A 23px-tall pill is a fine mouse target and a poor thumb one. On phones
+		   give them the same 44px height the segmented controls in this modal use —
+		   the roll sizes are the fast path through the weight field, so they have to
+		   be hittable without aiming. */
+		.preset {
+			min-height: 44px;
+			padding: 3px 14px;
+			font-size: 12.5px;
 		}
 	}
 </style>

--- a/client_v2/src/lib/components/AddSpoolModal.svelte
+++ b/client_v2/src/lib/components/AddSpoolModal.svelte
@@ -71,6 +71,10 @@
 	// `extraValues` below: the two entities have their own field definitions.
 	let filamentExtra = $state<Extra>({});
 	let showAdvanced = $state(false);
+	// Whether the spool's paperwork (lot number, dates, comment) is folded out. Kept
+	// across an "add and new" on purpose: someone entering lot numbers is entering
+	// them for the whole box of spools, not just the first one.
+	let showSpoolDetails = $state(false);
 	let nameInput = $state<HTMLInputElement | undefined>();
 	// Display-only: an untouched empty name shows the naming guidance rather than
 	// shouting "Required" at a form the user just opened. Submission is unaffected
@@ -848,10 +852,20 @@
 						     heading imply the filament is unaffected. -->
 						<div class="ent-note shared">{m['add.section.spoolSharedNote']()}</div>
 					{/if}
-					<div class="form">
+					<!-- The spool fields run from what you can answer with the roll in your hand
+					     to what you'd have to go look up: how many, how big, how full, where it
+					     lives — then the numbers off the product page, then paperwork almost
+					     nobody fills in for a fresh spool. Everything down to Location is picked
+					     rather than typed, which is what keeps the common case to a few taps. -->
+					<div class="form headline">
+						<!-- How many and how big, on the line that answers "what am I adding": both
+						     are known at a glance, and the count stays narrow and quiet because it
+						     is 1 nearly every time. Its old neighbour, the empty-spool weight, moved
+						     down to the numbers that come off a product page — sitting between two
+						     weights was what made this row read as three of the same question. -->
 						<label
 							>{m['add.count']()}
-							<NumberInput bind:value={count} min={1} step={1} spaced invalid={!!errors.count} />
+							<NumberInput bind:value={count} min={1} step={1} width="76px" spaced invalid={!!errors.count} />
 							{#if errors.count}<span class="err">{errors.count}</span>{/if}
 						</label>
 						<label
@@ -864,29 +878,33 @@
 								aria-expanded={openHelp === 'weight'}
 								onclick={() => (openHelp = openHelp === 'weight' ? null : 'weight')}>ⓘ</button
 							>
-							<NumberInput
-								bind:value={netWeight}
-								min={0}
-								step={50}
-								unit="g"
-								spaced
-								invalid={!!errors.netWeight}
-							/>
-							<!-- Out in the open rather than behind the ⓘ used elsewhere: nearly every
-							     spool is one of these few sizes, so this is the fast path through the
-							     field, not an explanation of it. Buttons nested in the <label> are safe —
-							     a click on interactive content isn't forwarded to the labelled input, so
-							     picking a size doesn't also yank focus into the weight field. -->
-							<span class="presets" role="group" aria-label={m['add.weightPresets']()}>
-								{#each NET_WEIGHT_PRESETS as preset (preset)}
-									<button
-										type="button"
-										class="preset"
-										class:on={Number(netWeight) === preset}
-										aria-pressed={Number(netWeight) === preset}
-										onclick={() => (netWeight = String(preset))}>{weightAuto(preset)}</button
-									>
-								{/each}
+							<!-- Sizes beside the field, not under it: they're alternatives to typing
+							     in it, and on one line the whole "how big is it" question answers
+							     itself without growing the form. Out in the open rather than behind
+							     the ⓘ used elsewhere, because this is the fast path through the
+							     field, not an explanation of it. Buttons nested in the <label> are
+							     safe — a click on interactive content isn't forwarded to the labelled
+							     input, so picking a size doesn't also yank focus into the field. -->
+							<span class="pick-line">
+								<NumberInput
+									bind:value={netWeight}
+									min={0}
+									step={50}
+									unit="g"
+									width="112px"
+									invalid={!!errors.netWeight}
+								/>
+								<span class="presets" role="group" aria-label={m['add.weightPresets']()}>
+									{#each NET_WEIGHT_PRESETS as preset (preset)}
+										<button
+											type="button"
+											class="preset"
+											class:on={Number(netWeight) === preset}
+											aria-pressed={Number(netWeight) === preset}
+											onclick={() => (netWeight = String(preset))}>{weightAuto(preset)}</button
+										>
+									{/each}
+								</span>
 							</span>
 							{#if openHelp === 'weight'}
 								<span class="help-popup" id="weight-help" role="note"
@@ -895,6 +913,52 @@
 							{/if}
 							{#if errors.netWeight}<span class="err">{errors.netWeight}</span>{/if}
 						</label>
+					</div>
+
+					<div class="fill">
+						<div class="fill-label">{m['add.fillLevel']()}</div>
+						<div class="seg">
+							{#each FILL_MODES as fill_mode (fill_mode.key)}
+								<button
+									class="seg-btn"
+									class:active={fillMode === fill_mode.key}
+									onclick={() => (fillMode = fill_mode.key)}>{fill_mode.labelKey()}</button
+								>
+							{/each}
+						</div>
+						{#if fillMode !== 'full'}
+							<div class="fill-input">
+								<NumberInput
+									bind:value={fillWeight}
+									min={0}
+									step={10}
+									unit="g"
+									placeholder="0"
+									width="130px"
+									invalid={!!errors.fillWeight}
+								/>
+								<span class="fill-help">{errors.fillWeight || fillHelp}</span>
+							</div>
+						{/if}
+					</div>
+
+					<div class="form">
+						<label class="wide">
+							{m['spool.fields.location']()}
+							<Combobox
+								value={location}
+								options={locations}
+								placeholder={m['add.locationPlaceholder']()}
+								oninput={(v) => (location = v)}
+							/>
+							<!-- Always-on rather than behind the ⓘ used elsewhere: "Location" reads as
+							     metadata until you're told it means the physical shelf, and testers
+							     didn't open a popup to find that out. -->
+							<span class="hint">{m['add.locationHint']()}</span>
+						</label>
+					</div>
+
+					<div class="form money">
 						<label
 							>{m['filament.fields.spoolWeight']()}
 							<button
@@ -942,70 +1006,46 @@
 							<NumberInput bind:value={price} min={0} placeholder="—" spaced invalid={!!errors.price} />
 							{#if errors.price}<span class="err">{errors.price}</span>{/if}
 						</label>
-						<label>{m['spool.fields.lotNr']()}<input class="mono" bind:value={lot} placeholder="—" /></label>
-						<label class="wide">
-							{m['spool.fields.location']()}
-							<Combobox
-								value={location}
-								options={locations}
-								placeholder={m['add.locationPlaceholder']()}
-								oninput={(v) => (location = v)}
-							/>
-							<!-- Always-on rather than behind the ⓘ used elsewhere: "Location" reads as
-							     metadata until you're told it means the physical shelf, and testers
-							     didn't open a popup to find that out. -->
-							<span class="hint">{m['add.locationHint']()}</span>
-						</label>
 					</div>
 
-					<div class="fill">
-						<div class="fill-label">{m['add.fillLevel']()}</div>
-						<div class="seg">
-							{#each FILL_MODES as fill_mode (fill_mode.key)}
-								<button
-									class="seg-btn"
-									class:active={fillMode === fill_mode.key}
-									onclick={() => (fillMode = fill_mode.key)}>{fill_mode.labelKey()}</button
-								>
-							{/each}
+					<!-- Everything below is either already right or not known yet: a lot number means
+					     squinting at the sticker, and a spool being added the day it arrives has no
+					     usage history and nothing to say about itself. Folded away so the form ends
+					     at the last question most people actually answer, in the same disclosure the
+					     filament half above uses for its specs. -->
+					<button class="adv-toggle" onclick={() => (showSpoolDetails = !showSpoolDetails)}>
+						{#if showSpoolDetails}<ChevronDown size={14} />{:else}<ChevronRight size={14} />{/if}
+						{m['add.spoolDetails']()}
+						{#if !showSpoolDetails}<span class="adv-note">{m['add.spoolDetailsNote']()}</span>{/if}
+					</button>
+					{#if showSpoolDetails}
+						<div class="form">
+							<label>{m['spool.fields.lotNr']()}<input class="mono" bind:value={lot} placeholder="—" /></label
+							>
 						</div>
-						{#if fillMode !== 'full'}
-							<div class="fill-input">
-								<NumberInput
-									bind:value={fillWeight}
-									min={0}
-									step={10}
-									unit="g"
-									placeholder="0"
-									width="130px"
-									invalid={!!errors.fillWeight}
-								/>
-								<span class="fill-help">{errors.fillWeight || fillHelp}</span>
-							</div>
-						{/if}
-					</div>
 
-					<div class="form dates">
-						<label class="date-label"
-							>{m['spool.fields.firstUsed']()}<DateTimeField
-								value={firstUsed}
-								oninput={(iso) => (firstUsed = iso)}
-							/></label
-						>
-						<label class="date-label"
-							>{m['spool.fields.lastUsed']()}<DateTimeField
-								value={lastUsed}
-								oninput={(iso) => (lastUsed = iso)}
-							/></label
-						>
-					</div>
+						<div class="form dates">
+							<label class="date-label"
+								>{m['spool.fields.firstUsed']()}<DateTimeField
+									value={firstUsed}
+									oninput={(iso) => (firstUsed = iso)}
+								/></label
+							>
+							<label class="date-label"
+								>{m['spool.fields.lastUsed']()}<DateTimeField
+									value={lastUsed}
+									oninput={(iso) => (lastUsed = iso)}
+								/></label
+							>
+						</div>
 
-					<div class="form comment-row">
-						<label class="wide"
-							>{m['spool.fields.comment']()}<textarea rows="2" bind:value={comment} placeholder="—"
-							></textarea></label
-						>
-					</div>
+						<div class="form comment-row">
+							<label class="wide"
+								>{m['spool.fields.comment']()}<textarea rows="2" bind:value={comment} placeholder="—"
+								></textarea></label
+							>
+						</div>
+					{/if}
 
 					<ExtraFieldsSection entity="spool" extra={extraValues} onchange={setExtra} />
 
@@ -1349,6 +1389,23 @@
 		grid-template-columns: 1fr 1fr 1fr;
 		gap: 12px;
 		margin-top: 14px;
+	}
+	/* Count takes only what it needs; the weight and its roll sizes take the rest. */
+	.form.headline {
+		grid-template-columns: auto 1fr;
+	}
+	/* The weight field and its roll sizes on one line, so the sizes read as
+	   alternatives to typing in it rather than as a second control stacked
+	   underneath — and so offering them costs the form no height. */
+	.pick-line {
+		display: flex;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 8px;
+		margin-top: 5px;
+	}
+	.pick-line .presets {
+		margin-top: 0;
 	}
 	.form label {
 		display: block;

--- a/tests_frontend_v2/tests/crud.spec.ts
+++ b/tests_frontend_v2/tests/crud.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from "./fixtures";
-import { createSpoolViaModal, navTab, openApp, searchFor, unique } from "./helpers";
+import {
+  createSpoolViaModal,
+  navTab,
+  numberField,
+  openAddSpoolModal,
+  openApp,
+  searchFor,
+  unique,
+  weightPresets,
+} from "./helpers";
 
 /**
  * The core happy path a real user walks on first use. client_v2 folds what the
@@ -39,6 +48,66 @@ test("create a manufacturer, filament and spool through the add-spool modal", as
     // of its own — this is the page the old Locations one became.
     await navTab(page, "Dashboard", "Dashboard | Spoolman");
     await expect(page.getByText(locationName, { exact: true })).toBeVisible();
+  });
+});
+
+/**
+ * Nearly every spool is one of a handful of roll sizes, so the weight field
+ * offers them as one-click shortcuts rather than making everyone type four
+ * digits (#1051). The picked size has to reach the created spool, and the row
+ * has to keep saying which size is currently in the field.
+ */
+test("a roll size can be picked from the weight field's shortcuts", async ({ page }) => {
+  const vendorName = unique("Vendor");
+  const filamentName = unique("Filament");
+  const locationName = unique("Shelf");
+
+  await openApp(page);
+
+  const dialog = await openAddSpoolModal(page);
+  await dialog.getByRole("button", { name: /^Create a new filament/ }).click();
+  const presets = weightPresets(dialog);
+
+  await test.step("the row reflects the weight the field starts on", async () => {
+    // A new filament starts at the size that dominates the catalog, so that
+    // shortcut — and only it — is marked as the one in play.
+    await expect(numberField(dialog, "Weight")).toHaveValue("1000");
+    await expect(presets.getByRole("button", { name: "1 kg", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(presets.getByRole("button", { name: "500 g", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  await test.step("typing a size of its own leaves no shortcut marked", async () => {
+    await numberField(dialog, "Weight").fill("1234");
+    await expect(presets.getByRole("button", { name: "1 kg", exact: true })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  await test.step("clicking a shortcut creates the spool at that size", async () => {
+    // Start over from a clean modal — the checks above left a made-up weight in
+    // the field — and go through it with the weight set only by the click, so
+    // the library row proves the picked size was what got submitted.
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    await createSpoolViaModal(page, {
+      vendorName,
+      filamentName,
+      locationName,
+      weightG: 500,
+      weightPreset: "500 g",
+    });
+
+    const spoolRow = page.getByRole("link").filter({ hasText: locationName });
+    await expect(spoolRow).toHaveCount(1);
+    await expect(spoolRow).toContainText("500");
   });
 });
 

--- a/tests_frontend_v2/tests/crud.spec.ts
+++ b/tests_frontend_v2/tests/crud.spec.ts
@@ -54,9 +54,8 @@ test("create a manufacturer, filament and spool through the add-spool modal", as
 /**
  * Nearly every spool is one of a handful of roll sizes, so the weight field
  * offers them as shortcuts beside it rather than making everyone type four
- * digits (#1051). The picked size has to reach the created spool, the row has to
- * keep saying which size is in the field, and the paperwork below it stays
- * folded away until someone asks for it.
+ * digits (#1051). The picked size has to reach the created spool, and the row
+ * has to keep saying which size is currently in the field.
  */
 test("a roll size can be picked from the shortcuts beside the weight field", async ({ page }) => {
   const vendorName = unique("Vendor");
@@ -89,15 +88,6 @@ test("a roll size can be picked from the shortcuts beside the weight field", asy
       "aria-pressed",
       "false",
     );
-  });
-
-  await test.step("the paperwork stays folded until asked for", async () => {
-    // Lot number, dates and comment are empty on a spool being added the day it
-    // arrives, so they start collapsed rather than padding out the form.
-    const lotNr = dialog.getByText("Lot Nr", { exact: true });
-    await expect(lotNr).toBeHidden();
-    await dialog.getByRole("button", { name: /More details/ }).click();
-    await expect(lotNr).toBeVisible();
   });
 
   await test.step("clicking a shortcut creates the spool at that size", async () => {

--- a/tests_frontend_v2/tests/crud.spec.ts
+++ b/tests_frontend_v2/tests/crud.spec.ts
@@ -53,11 +53,12 @@ test("create a manufacturer, filament and spool through the add-spool modal", as
 
 /**
  * Nearly every spool is one of a handful of roll sizes, so the weight field
- * offers them as one-click shortcuts rather than making everyone type four
- * digits (#1051). The picked size has to reach the created spool, and the row
- * has to keep saying which size is currently in the field.
+ * offers them as shortcuts beside it rather than making everyone type four
+ * digits (#1051). The picked size has to reach the created spool, the row has to
+ * keep saying which size is in the field, and the paperwork below it stays
+ * folded away until someone asks for it.
  */
-test("a roll size can be picked from the weight field's shortcuts", async ({ page }) => {
+test("a roll size can be picked from the shortcuts beside the weight field", async ({ page }) => {
   const vendorName = unique("Vendor");
   const filamentName = unique("Filament");
   const locationName = unique("Shelf");
@@ -88,6 +89,15 @@ test("a roll size can be picked from the weight field's shortcuts", async ({ pag
       "aria-pressed",
       "false",
     );
+  });
+
+  await test.step("the paperwork stays folded until asked for", async () => {
+    // Lot number, dates and comment are empty on a spool being added the day it
+    // arrives, so they start collapsed rather than padding out the form.
+    const lotNr = dialog.getByText("Lot Nr", { exact: true });
+    await expect(lotNr).toBeHidden();
+    await dialog.getByRole("button", { name: /More details/ }).click();
+    await expect(lotNr).toBeVisible();
   });
 
   await test.step("clicking a shortcut creates the spool at that size", async () => {

--- a/tests_frontend_v2/tests/helpers.ts
+++ b/tests_frontend_v2/tests/helpers.ts
@@ -84,6 +84,16 @@ export function numberField(dialog: Locator, label: string): Locator {
     .first();
 }
 
+/**
+ * The row of roll-size shortcuts under the add-spool modal's Weight field.
+ *
+ * They are plain buttons inside the field's <label>, grouped and named so they
+ * can be reached without depending on the modal's markup.
+ */
+export function weightPresets(dialog: Locator): Locator {
+  return dialog.getByRole("group", { name: "Common roll sizes" });
+}
+
 /** A spool to create through the add-spool modal, together with its filament and vendor. */
 export interface NewSpool {
   vendorName: string;
@@ -93,6 +103,12 @@ export interface NewSpool {
   material?: string;
   /** Net filament weight, in grams. */
   weightG?: number;
+  /**
+   * Set the weight by clicking one of the roll-size shortcuts under the field
+   * (e.g. "500 g", "1 kg") instead of typing it. Must name the same size as
+   * `weightG`, which is still what the result is asserted against.
+   */
+  weightPreset?: string;
   /** How much of it has already been used, in grams. Omit for a full spool. */
   usedG?: number;
   /** Values for the filament's extra fields, keyed by their display name. */
@@ -119,6 +135,7 @@ export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<
     locationName,
     material = "PLA",
     weightG = 1000,
+    weightPreset,
     usedG,
     filamentExtra,
     count = 1,
@@ -155,7 +172,12 @@ export async function createSpoolViaModal(page: Page, spool: NewSpool): Promise<
 
   await expect(numberField(dialog, "Count")).toHaveValue("1");
   if (count !== 1) await numberField(dialog, "Count").fill(String(count));
-  await numberField(dialog, "Weight").fill(String(weightG));
+  if (weightPreset) {
+    await weightPresets(dialog).getByRole("button", { name: weightPreset, exact: true }).click();
+    await expect(numberField(dialog, "Weight")).toHaveValue(String(weightG));
+  } else {
+    await numberField(dialog, "Weight").fill(String(weightG));
+  }
   await dialog.getByPlaceholder("e.g. Shelf A").fill(locationName);
 
   if (usedG !== undefined) {


### PR DESCRIPTION
Adds one-click buttons for the common roll sizes (250 g, 500 g, 750 g, 1 kg, 2 kg, 3 kg) next to the weight field in the add-spool modal, closes #1051. The sizes come from what SpoolmanDB actually lists: 1 kg is about half of the catalog and every brand in it sells one.

The spool half of the form is reorganized to make room for them, and ends up shorter than it was before:

- Count and weight share the top row, with the sizes beside the weight field instead of under it
- Spool weight and price move down to their own row, so the top row is no longer three weights in a line
- Lot number moves next to Location, since it identifies the spool rather than pricing it

Covered by a new test in tests_frontend_v2.