### PR TITLE
client_v2: make the long toolbar menus searchable

### DIFF
--- a/client_v2/src/lib/components/MenuSearch.svelte
+++ b/client_v2/src/lib/components/MenuSearch.svelte
@@ -1,0 +1,96 @@
+<script lang="ts">
+	import Search from '@lucide/svelte/icons/search';
+	import * as m from '$lib/paraglide/messages';
+
+	interface Props {
+		value: string;
+		oninput: (value: string) => void;
+		/**
+		 * Escape with text in the box, which the caller should treat as "clear";
+		 * with the box already empty the key falls through to `onclose` instead.
+		 */
+		onclear?: () => void;
+		onclose?: () => void;
+		/** Enter: take the first thing still on the list. */
+		onenter?: () => void;
+	}
+
+	let { value, oninput, onclear, onclose, onenter }: Props = $props();
+
+	let el = $state<HTMLInputElement>();
+
+	// Focus as the menu opens, so a menu that was opened to be searched can be
+	// searched without a second click. Only where there is a real pointer: on a
+	// touch device the same focus raises the on-screen keyboard over the very
+	// list it filters, and a thumb is already on the list.
+	$effect(() => {
+		if (el && window.matchMedia('(pointer: fine)').matches) el.focus();
+	});
+
+	function onkeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			// Kept local either way, so that dismissing a query or a menu never also
+			// closes whatever the menu was opened on top of.
+			e.stopPropagation();
+			if (value) onclear?.();
+			else onclose?.();
+		} else if (e.key === 'Enter') {
+			e.preventDefault();
+			onenter?.();
+		}
+	}
+</script>
+
+<div class="menu-search">
+	<span class="icon" aria-hidden="true"><Search size={13} /></span>
+	<input
+		bind:this={el}
+		{value}
+		type="text"
+		autocomplete="off"
+		placeholder={m['common.search']()}
+		aria-label={m['common.search']()}
+		oninput={(e) => oninput(e.currentTarget.value)}
+		{onkeydown}
+	/>
+</div>
+
+<style>
+	/* Sticky so it survives scrolling a list long enough to have needed it. The
+	   background is the menu's own, since rows pass underneath. */
+	.menu-search {
+		position: sticky;
+		top: 0;
+		z-index: 1;
+		display: flex;
+		align-items: center;
+		gap: 7px;
+		/* No vertical padding of its own: the input carries it instead, so the
+		   field's own box covers the full height of the row and a thumb landing
+		   anywhere in the band lands on the input. */
+		padding: 0 10px;
+		background: var(--surface-2);
+		border-bottom: 1px solid var(--border-soft);
+	}
+	.icon {
+		display: flex;
+		flex: none;
+		color: var(--text-dim);
+	}
+	input {
+		flex: 1;
+		min-width: 0;
+		background: none;
+		border: none;
+		color: var(--text);
+		font-family: inherit;
+		font-size: 12.5px;
+		padding: 12px 0;
+	}
+	input:focus {
+		outline: none;
+	}
+	input::placeholder {
+		color: var(--text-faint);
+	}
+</style>

--- a/client_v2/src/lib/components/library/ListToolbar.svelte
+++ b/client_v2/src/lib/components/library/ListToolbar.svelte
@@ -12,6 +12,8 @@
 		type DateFilterProp
 	} from '$lib/library/dateFilter';
 	import { sortDefs, filamentLabel, type SortDef } from '$lib/utils/library';
+	import { filterByQuery, matchesTerms, searchTerms } from '$lib/utils/match';
+	import MenuSearch from '../MenuSearch.svelte';
 	import { spoolSource } from '$lib/api/spoolSource';
 	import { inventory } from '$lib/stores/inventory.svelte';
 	import { fields } from '$lib/stores/fields.svelte';
@@ -33,11 +35,25 @@
 	type Menu = 'filter' | 'group' | 'sort' | null;
 	let open = $state<Menu>(null);
 
+	// A menu's search box narrows whichever list it is sitting on. It belongs to
+	// that list and not to the menu, so it resets on every move between lists —
+	// opening a menu, stepping into a filter property, stepping back out.
+	let menuQuery = $state('');
+
+	/**
+	 * Lists shorter than this fit on screen at a glance, where a search box is one
+	 * more thing to read rather than a way through. The number is the point at
+	 * which scanning stops being instant, not a hard limit on anything.
+	 */
+	const SEARCHABLE_MIN = 8;
+
 	function toggle(m: Menu) {
 		open = open === m ? null : m;
+		menuQuery = '';
 	}
 	function close() {
 		open = null;
+		menuQuery = '';
 	}
 
 	// Extra-field definitions (of all three entities) feed the sort and filter menus.
@@ -215,6 +231,8 @@
 
 	async function openProp(category: FilterCategory) {
 		filterProp = category.key;
+		// The query that found this property says nothing about its values.
+		menuQuery = '';
 		if (category.kind === 'date') {
 			customFrom = '';
 			customTo = '';
@@ -296,6 +314,45 @@
 			(s) => s.items.length
 		)
 	);
+
+	// --- searchable menus (issue #1045) -------------------------------------
+	//
+	// Three of these lists grow without bound: the filter properties and the sort
+	// fields both take on every custom extra field defined, and a filter's values
+	// are whatever the library holds — every filament, every location, every lot
+	// number. Each gets a search box once it is long enough to be worth one; the
+	// group menu has five fixed entries and never does.
+	//
+	// Whether the box shows is decided by the FULL list, never the narrowed one,
+	// so it can't vanish under the cursor the moment a query gets specific.
+
+	let visibleCategories = $derived(filterByQuery(filterCategories, menuQuery, (c) => c.label()));
+	let archivedMatches = $derived(matchesTerms(m['buttons.showArchived'](), searchTerms(menuQuery)));
+	let visibleOptions = $derived(filterByQuery(options, menuQuery, (o) => o.label));
+	let visibleSortSections = $derived(
+		sortSections
+			.map((sec) => ({ ...sec, items: filterByQuery(sec.items, menuQuery, (it) => it.labelKey()) }))
+			.filter((sec) => sec.items.length)
+	);
+
+	// Enter takes the first entry still standing — the one the user has usually
+	// typed enough to be alone on the list.
+	function chooseFirstCategory() {
+		const first = visibleCategories[0];
+		if (first) openProp(first);
+	}
+	function chooseFirstOption() {
+		const first = visibleOptions[0];
+		if (!first) return;
+		params.toggleFilter(filterProp!, first.value);
+		close();
+	}
+	function chooseFirstSort() {
+		const first = visibleSortSections[0]?.items[0];
+		if (!first) return;
+		params.setSortKey(first.key);
+		close();
+	}
 </script>
 
 <svelte:window onclick={close} />
@@ -346,31 +403,50 @@
 		<div class="menu filter-menu">
 			{#if !filterProp}
 				<div class="menu-title">{m['library.filterBy']()}</div>
-				{#each filterCategories as c (c.key)}
+				{#if filterCategories.length >= SEARCHABLE_MIN}
+					<MenuSearch
+						value={menuQuery}
+						oninput={(v) => (menuQuery = v)}
+						onclear={() => (menuQuery = '')}
+						onclose={close}
+						onenter={chooseFirstCategory}
+					/>
+				{/if}
+				{#each visibleCategories as c (c.key)}
 					<button class="menu-item" onclick={() => openProp(c)}>
 						<span class="mi-label">{c.label()}</span>
 						<span class="mi-meta"><ChevronRight size={14} /></span>
 					</button>
 				{/each}
-				<div class="menu-sep"></div>
-				<button
-					class="menu-item"
-					role="menuitemcheckbox"
-					aria-checked={libraryState.showArchived}
-					onclick={() => {
-						params.setShowArchived(!libraryState.showArchived);
-						close();
-					}}
-				>
-					<span class="mi-check"
-						>{#if libraryState.showArchived}<SquareCheck size={15} />{:else}<Square size={15} />{/if}</span
+				<!-- Archived is a filter of sorts, so it answers to the same search box; a
+				     query it doesn't match takes it off the list like any other entry. -->
+				{#if archivedMatches}
+					{#if visibleCategories.length}<div class="menu-sep"></div>{/if}
+					<button
+						class="menu-item"
+						role="menuitemcheckbox"
+						aria-checked={libraryState.showArchived}
+						onclick={() => {
+							params.setShowArchived(!libraryState.showArchived);
+							close();
+						}}
 					>
-					<span class="mi-label">{m['buttons.showArchived']()}</span>
-				</button>
+						<span class="mi-check"
+							>{#if libraryState.showArchived}<SquareCheck size={15} />{:else}<Square size={15} />{/if}</span
+						>
+						<span class="mi-label">{m['buttons.showArchived']()}</span>
+					</button>
+				{:else if !visibleCategories.length}
+					<div class="menu-item"><span class="mi-label mi-meta">{m['search.noResults']()}</span></div>
+				{/if}
 			{:else}
 				{@const c = filterCategories.find((x) => x.key === filterProp)}
-				<button class="menu-title back" onclick={() => (filterProp = null)}
-					><ChevronLeft size={14} /> {c ? c.label() : ''}</button
+				<button
+					class="menu-title back"
+					onclick={() => {
+						filterProp = null;
+						menuQuery = '';
+					}}><ChevronLeft size={14} /> {c ? c.label() : ''}</button
 				>
 				{#if c?.kind === 'date'}
 					{#each DATE_PRESETS as preset (preset)}
@@ -411,7 +487,18 @@
 				{:else if options.length === 0}
 					<div class="menu-item"><span class="mi-label mi-meta">{m['library.noValues']()}</span></div>
 				{:else}
-					{#each options as opt (opt.value)}
+					<!-- The list a filament, location or lot-number filter offers is as long as
+					     the library is big, which is the case this issue was opened for. -->
+					{#if options.length >= SEARCHABLE_MIN}
+						<MenuSearch
+							value={menuQuery}
+							oninput={(v) => (menuQuery = v)}
+							onclear={() => (menuQuery = '')}
+							onclose={close}
+							onenter={chooseFirstOption}
+						/>
+					{/if}
+					{#each visibleOptions as opt (opt.value)}
 						<button
 							class="menu-item"
 							onclick={() => {
@@ -421,6 +508,8 @@
 						>
 							<span class="mi-label">{opt.label}</span>
 						</button>
+					{:else}
+						<div class="menu-item"><span class="mi-label mi-meta">{m['search.noResults']()}</span></div>
 					{/each}
 				{/if}
 			{/if}
@@ -446,7 +535,16 @@
 
 	{#if open === 'sort'}
 		<div class="menu sort-menu">
-			{#each sortSections as sec (sec.key)}
+			{#if sorts.length >= SEARCHABLE_MIN}
+				<MenuSearch
+					value={menuQuery}
+					oninput={(v) => (menuQuery = v)}
+					onclear={() => (menuQuery = '')}
+					onclose={close}
+					onenter={chooseFirstSort}
+				/>
+			{/if}
+			{#each visibleSortSections as sec (sec.key)}
 				<div class="menu-title">{sec.labelKey()}</div>
 				{#each sec.items as it (it.key)}
 					<button
@@ -464,6 +562,8 @@
 						{#if it.unit}<span class="mi-meta">{it.unit}</span>{/if}
 					</button>
 				{/each}
+			{:else}
+				<div class="menu-item"><span class="mi-label mi-meta">{m['search.noResults']()}</span></div>
 			{/each}
 		</div>
 	{/if}

--- a/client_v2/src/lib/utils/match.test.ts
+++ b/client_v2/src/lib/utils/match.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { filterByQuery, matchesTerms, searchTerms } from './match';
+
+// What the in-menu search boxes will and won't find. The rule these guard is that
+// a match is always visible in the label the user is looking at.
+
+describe('searchTerms', () => {
+	it('splits on whitespace and folds case', () => {
+		expect(searchTerms('Black PLA')).toEqual(['black', 'pla']);
+	});
+
+	it('yields nothing for an empty or blank query', () => {
+		expect(searchTerms('')).toEqual([]);
+		expect(searchTerms('   ')).toEqual([]);
+	});
+
+	it('collapses runs of whitespace rather than emitting empty terms', () => {
+		expect(searchTerms('  black   pla  ')).toEqual(['black', 'pla']);
+	});
+});
+
+describe('matchesTerms', () => {
+	it('matches a substring regardless of case', () => {
+		expect(matchesTerms('Polymaker PolyLite', searchTerms('polylite'))).toBe(true);
+	});
+
+	it('matches every term in any order', () => {
+		expect(matchesTerms('Polymaker Black', searchTerms('black poly'))).toBe(true);
+	});
+
+	it('requires all terms, not just one', () => {
+		expect(matchesTerms('Polymaker Black', searchTerms('black prusa'))).toBe(false);
+	});
+
+	it('ignores diacritics on both sides', () => {
+		expect(matchesTerms('Añejo', searchTerms('anejo'))).toBe(true);
+		expect(matchesTerms('Anejo', searchTerms('añejo'))).toBe(true);
+	});
+
+	it('does not match letters that are merely scattered through the label', () => {
+		// The fuzzy match this rules out: "lot" would otherwise hit "Location".
+		expect(matchesTerms('Location', searchTerms('lot'))).toBe(false);
+	});
+
+	it('matches everything when there are no terms', () => {
+		expect(matchesTerms('anything', [])).toBe(true);
+	});
+});
+
+describe('filterByQuery', () => {
+	const items = [
+		{ label: 'Last used' },
+		{ label: 'First used' },
+		{ label: 'Remaining weight' },
+		{ label: 'Lot nr' }
+	];
+
+	it('keeps only the matching items', () => {
+		expect(filterByQuery(items, 'used', (i) => i.label).map((i) => i.label)).toEqual([
+			'Last used',
+			'First used'
+		]);
+	});
+
+	it('returns the list untouched for a blank query', () => {
+		expect(filterByQuery(items, '  ', (i) => i.label)).toBe(items);
+	});
+
+	it('can narrow to nothing', () => {
+		expect(filterByQuery(items, 'colour', (i) => i.label)).toEqual([]);
+	});
+});

--- a/client_v2/src/lib/utils/match.ts
+++ b/client_v2/src/lib/utils/match.ts
@@ -1,0 +1,46 @@
+// Matching for the search boxes that sit at the top of long menus (issue #1045).
+//
+// These lists are already on screen while the user types, so the match has to be
+// one they can see: a plain substring test, never a fuzzy one. A fuzzy match that
+// surfaces "Location" for the query "lot" looks like a bug when both entries are
+// two rows apart.
+//
+// Two liberties are taken, both of which only ever widen what an honest substring
+// finds. Diacritics fold, so "Anejo" reaches "Añejo" from a keyboard that can't
+// type the tilde. And whitespace splits the query into terms that may match in any
+// order, because the labels these lists are built from are compounds — a filament
+// reads "<manufacturer> <name>", and someone hunting Polymaker's black roll types
+// "black poly" as readily as the other way round.
+
+/** Case- and diacritic-insensitive form of a string, for comparison only. */
+function fold(text: string): string {
+	return text
+		.normalize('NFD')
+		.replace(/\p{Diacritic}/gu, '')
+		.toLowerCase();
+}
+
+/**
+ * Split a query into the terms every candidate must contain. An empty or
+ * whitespace-only query yields no terms, which matches everything.
+ */
+export function searchTerms(query: string): string[] {
+	return fold(query).split(/\s+/).filter(Boolean);
+}
+
+/** Whether `text` contains every one of `terms` (as produced by searchTerms). */
+export function matchesTerms(text: string, terms: string[]): boolean {
+	if (terms.length === 0) return true;
+	const haystack = fold(text);
+	return terms.every((t) => haystack.includes(t));
+}
+
+/**
+ * Narrow a list to the items whose label matches `query`. Returns the list
+ * untouched when the query is empty, so callers can filter unconditionally.
+ */
+export function filterByQuery<T>(items: T[], query: string, label: (item: T) => string): T[] {
+	const terms = searchTerms(query);
+	if (terms.length === 0) return items;
+	return items.filter((item) => matchesTerms(label(item), terms));
+}

--- a/tests_frontend_v2/tests/menu-search.spec.ts
+++ b/tests_frontend_v2/tests/menu-search.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "./fixtures";
+import { openApp, openToolbarMenu } from "./helpers";
+
+/**
+ * Searchable toolbar menus (#1045).
+ *
+ * The Library's sort and filter menus grow with the install: every custom extra
+ * field adds a sort field and a filter property, and a filter's values are the
+ * whole library's filaments, locations and lot numbers. Past a point they can
+ * only be scrolled, so each long list carries a search box.
+ *
+ * Everything asserted here holds on an empty database — the sort menu ships 18
+ * fixed fields and the filter menu 9 properties, both already past the length
+ * that earns a box, while the group menu's five fixed entries never do. The
+ * matching rules themselves are unit-tested (client_v2 src/lib/utils/match.test.ts);
+ * what needs a browser is that the box appears on the right lists, narrows them,
+ * and that the keyboard works.
+ */
+
+/** The search box inside an open toolbar menu. */
+const searchBox = (menu: import("@playwright/test").Locator) =>
+  menu.getByRole("textbox", { name: "Search" });
+
+/** The labels of a menu's currently visible entries. */
+async function itemLabels(menu: import("@playwright/test").Locator): Promise<string[]> {
+  return (await menu.locator(".menu-item").allInnerTexts()).map((t) => t.trim());
+}
+
+test("the sort menu is searchable, and Enter takes the first match", async ({ page }) => {
+  await openApp(page);
+  const menu = await openToolbarMenu(page, "Sort");
+
+  // Opened with a pointer, the box takes focus so the menu can be typed at
+  // straight away.
+  await expect(searchBox(menu)).toBeFocused();
+
+  await searchBox(menu).fill("temp");
+  expect(await itemLabels(menu)).toEqual(["Extruder Temp\n°C", "Bed Temp\n°C"]);
+
+  // A section survives only as long as one of its fields does.
+  await expect(menu.getByText("Filament", { exact: true })).toBeVisible();
+  await expect(menu.getByText("Spool", { exact: true })).toBeHidden();
+
+  // Enter applies the first field still listed.
+  await searchBox(menu).press("Enter");
+  await expect(menu).toBeHidden();
+  await expect(page.locator(".chip.sort")).toContainText("Extruder Temp");
+});
+
+test("a query that matches nothing says so rather than emptying the menu", async ({ page }) => {
+  await openApp(page);
+  const menu = await openToolbarMenu(page, "Sort");
+
+  await searchBox(menu).fill("nothingmatchesthis");
+  expect(await itemLabels(menu)).toEqual(["No matches found"]);
+
+  // Escape clears the query first, and only closes the menu once it is empty —
+  // so a mistyped query costs one key, not the whole menu.
+  await searchBox(menu).press("Escape");
+  await expect(searchBox(menu)).toHaveValue("");
+  await expect(menu).toBeVisible();
+
+  await searchBox(menu).press("Escape");
+  await expect(menu).toBeHidden();
+});
+
+test("the filter menu searches its properties, archived included", async ({ page }) => {
+  await openApp(page);
+  const menu = await openToolbarMenu(page, "Filter");
+
+  await searchBox(menu).fill("lot");
+  // A substring match, not a fuzzy one: "Location" contains those letters in
+  // order but not together, and must not be offered here.
+  expect(await itemLabels(menu)).toEqual(["Lot Nr"]);
+
+  // "Show Archived" is a filter like any other and answers to the same box.
+  await searchBox(menu).fill("arch");
+  expect(await itemLabels(menu)).toEqual(["Show Archived"]);
+
+  // Every move between lists starts a fresh query, because the one that found a
+  // property says nothing about its values. Stepping into Material and back out
+  // must therefore leave the property list unnarrowed. (On an empty database
+  // Material itself has no values to offer, and so no box of its own — which is
+  // the same rule seen from the other side: a list too short to scroll gets no
+  // search box.)
+  await searchBox(menu).fill("material");
+  await menu.locator(".menu-item").first().click();
+  const back = menu.getByRole("button", { name: "Material" });
+  await expect(back).toBeVisible();
+  await expect(searchBox(menu)).toHaveCount(0);
+
+  await back.click();
+  await expect(searchBox(menu)).toHaveValue("");
+  expect(await itemLabels(menu)).toContain("Location");
+});
+
+test("the group menu is short enough to need no search box", async ({ page }) => {
+  await openApp(page);
+  const menu = await openToolbarMenu(page, "Group");
+
+  await expect(menu.getByRole("button", { name: "None (flat)" })).toBeVisible();
+  await expect(searchBox(menu)).toHaveCount(0);
+});


### PR DESCRIPTION
The Library's sort and filter menus grow with the install: every custom extra field adds a sort field and a filter property, and a filter's values are the whole library (every filament, location, lot number). Past a point the only way through them was scrolling.

Each of those lists now gets a search box once it passes 8 entries, so the group menu's five fixed entries are left alone. Matching is a plain substring test, widened only by folding diacritics and by letting whitespace-separated terms match in any order, so "black poly" finds "Polymaker Black". Deliberately not fuzzy: typing "lot" must not surface "Location".

Escape clears the query then closes the menu, Enter takes the first entry still listed. The box takes focus as the menu opens, except on touch where that would raise the keyboard over the list it filters. No new locale strings.

Closes #1045