### PR TITLE
client_v2: filter menu colours, materials, checkmarks and multi-select

### DIFF
--- a/client_v2/src/lib/api/spoolSource.ts
+++ b/client_v2/src/lib/api/spoolSource.ts
@@ -23,7 +23,7 @@ import {
 } from './map';
 import { inventory } from '$lib/stores/inventory.svelte';
 import { isDateFilterProp, parseDateFilter, resolveDateFilter } from '$lib/library/dateFilter';
-import { filamentLabel } from '$lib/utils/library';
+import { filamentLabel, type FilterOption } from '$lib/utils/library';
 import type { EntityType } from './fields';
 import { type ExternalFilament } from './external';
 import { searchAll } from './search';
@@ -492,20 +492,30 @@ class HttpSpoolSource {
 		return getJson<string[]>('/material');
 	}
 	/**
-	 * Every filament as a `{ value: id, label }` option for the "filament" filter,
-	 * so a spool listing can be narrowed to one specific filament (e.g. a given
-	 * colour from a given manufacturer). Filaments are cached so the chosen chip
-	 * can render its label from the reactive store.
+	 * Every filament as an option for the "filament" filter, so a spool listing can
+	 * be narrowed to one specific filament (e.g. a given colour from a given
+	 * manufacturer). Each option carries the filament's colours and material as
+	 * well as its label, since the menu shows all three. Filaments are cached so
+	 * the chosen chip can render its label from the reactive store.
 	 */
-	async filamentOptions(): Promise<{ value: string; label: string }[]> {
+	async filamentOptions(): Promise<FilterOption[]> {
 		const items = await getJson<Json[]>('/filament');
 		const filaments = items.map((f) => {
 			if (f.vendor) inventory.upsertVendor(mapVendor(f.vendor));
 			return mapFilament(f);
 		});
 		inventory.upsertFilaments(filaments);
+		// The label already carries the manufacturer, so the material is what's left
+		// to tell two same-named filaments apart; the colors are what the eye goes
+		// to first. Both are free here — this fetches whole filaments anyway.
 		return filaments
-			.map((f) => ({ value: f.id, label: filamentLabel(f, inventory.vendorOf(f)) }))
+			.map((f) => ({
+				value: f.id,
+				label: filamentLabel(f, inventory.vendorOf(f)),
+				meta: f.material,
+				colors: f.colors,
+				direction: f.multiColorDirection
+			}))
 			.sort((a, b) => a.label.localeCompare(b.label));
 	}
 	/** Distinct values currently stored for a scalar extra field (text/single-choice). */

--- a/client_v2/src/lib/components/library/ListToolbar.svelte
+++ b/client_v2/src/lib/components/library/ListToolbar.svelte
@@ -226,6 +226,14 @@
 		return parsed?.kind === 'range' ? parsed : null;
 	});
 
+	// The values this property already filters by. A filter's chip sits in the
+	// toolbar behind the open menu, which is no help when the list is long and the
+	// menu covers it, so the list says so itself (#1090). Values only: a date
+	// filter holds one range at a time, so its presets are a choice, not a set.
+	let activeValues = $derived(
+		new Set(libraryState.filters.filter((f) => f.prop === filterProp).map((f) => f.value))
+	);
+
 	async function openProp(category: FilterCategory) {
 		filterProp = category.key;
 		// The query that found this property says nothing about its values.
@@ -346,7 +354,6 @@
 		const first = visibleOptions[0];
 		if (!first) return;
 		params.toggleFilter(filterProp!, first.value);
-		close();
 	}
 	function chooseFirstSort() {
 		const first = visibleSortSections[0]?.items[0];
@@ -499,14 +506,20 @@
 							onenter={chooseFirstOption}
 						/>
 					{/if}
+					<!-- A value row is a checkbox, not a command: it reads as on or off, and
+					     picking one leaves the menu open so the next one is a click away
+					     (#1090, #1089). Escape and a click outside still close it. -->
 					{#each visibleOptions as opt (opt.value)}
+						{@const checked = activeValues.has(opt.value)}
 						<button
 							class="menu-item"
-							onclick={() => {
-								params.toggleFilter(filterProp!, opt.value);
-								close();
-							}}
+							role="menuitemcheckbox"
+							aria-checked={checked}
+							onclick={() => params.toggleFilter(filterProp!, opt.value)}
 						>
+							<span class="mi-check"
+								>{#if checked}<SquareCheck size={15} />{:else}<Square size={15} />{/if}</span
+							>
 							{#if opt.colors}<Swatch
 									colors={opt.colors}
 									direction={opt.direction}

--- a/client_v2/src/lib/components/library/ListToolbar.svelte
+++ b/client_v2/src/lib/components/library/ListToolbar.svelte
@@ -526,8 +526,11 @@
 									size={16}
 									radius={4}
 								/>{/if}
+							<!-- The gap is a real space, not just margin: it is what separates the
+							     two halves in the row's accessible name, which would otherwise be
+							     read out as one run-together word. -->
 							<span class="mi-label"
-								>{opt.label}{#if opt.meta}<span class="mi-sub">{opt.meta}</span>{/if}</span
+								>{opt.label}{#if opt.meta}&nbsp;<span class="mi-sub">{opt.meta}</span>{/if}</span
 							>
 						</button>
 					{:else}
@@ -797,7 +800,6 @@
 	.mi-sub {
 		color: var(--text-muted);
 		font-size: 11px;
-		margin-left: 6px;
 	}
 	.mi-dir {
 		color: var(--accent-muted);

--- a/client_v2/src/lib/components/library/ListToolbar.svelte
+++ b/client_v2/src/lib/components/library/ListToolbar.svelte
@@ -11,9 +11,10 @@
 		withinLast,
 		type DateFilterProp
 	} from '$lib/library/dateFilter';
-	import { sortDefs, filamentLabel, type SortDef } from '$lib/utils/library';
+	import { sortDefs, filamentLabel, type FilterOption, type SortDef } from '$lib/utils/library';
 	import { filterByQuery, matchesTerms, searchTerms } from '$lib/utils/match';
 	import MenuSearch from '../MenuSearch.svelte';
+	import Swatch from '../Swatch.svelte';
 	import { spoolSource } from '$lib/api/spoolSource';
 	import { inventory } from '$lib/stores/inventory.svelte';
 	import { fields } from '$lib/stores/fields.svelte';
@@ -63,10 +64,6 @@
 		fields.ensure('vendor');
 	});
 
-	interface FilterOption {
-		value: string;
-		label: string;
-	}
 	// Most filters pick from a set of values the API can enumerate; a date filter
 	// picks a range instead, so it gets a panel of its own rather than an option
 	// list (see library/dateFilter for the grammar behind it).
@@ -328,7 +325,11 @@
 
 	let visibleCategories = $derived(filterByQuery(filterCategories, menuQuery, (c) => c.label()));
 	let archivedMatches = $derived(matchesTerms(m['buttons.showArchived'](), searchTerms(menuQuery)));
-	let visibleOptions = $derived(filterByQuery(options, menuQuery, (o) => o.label));
+	// An option's secondary text is on screen, so it has to be searchable: typing
+	// "petg" against a list that visibly says PETG must not come back empty.
+	let visibleOptions = $derived(
+		filterByQuery(options, menuQuery, (o) => (o.meta ? `${o.label} ${o.meta}` : o.label))
+	);
 	let visibleSortSections = $derived(
 		sortSections
 			.map((sec) => ({ ...sec, items: filterByQuery(sec.items, menuQuery, (it) => it.labelKey()) }))
@@ -506,7 +507,15 @@
 								close();
 							}}
 						>
-							<span class="mi-label">{opt.label}</span>
+							{#if opt.colors}<Swatch
+									colors={opt.colors}
+									direction={opt.direction}
+									size={16}
+									radius={4}
+								/>{/if}
+							<span class="mi-label"
+								>{opt.label}{#if opt.meta}<span class="mi-sub">{opt.meta}</span>{/if}</span
+							>
 						</button>
 					{:else}
 						<div class="menu-item"><span class="mi-label mi-meta">{m['search.noResults']()}</span></div>
@@ -768,6 +777,14 @@
 	.mi-meta {
 		color: var(--text-faint);
 		font-size: 11px;
+	}
+	/* Sits with the label rather than off at the row's right edge: it's there to
+	   qualify the name it follows, which is the whole point when two filaments
+	   share one. */
+	.mi-sub {
+		color: var(--text-muted);
+		font-size: 11px;
+		margin-left: 6px;
 	}
 	.mi-dir {
 		color: var(--accent-muted);

--- a/client_v2/src/lib/utils/library.ts
+++ b/client_v2/src/lib/utils/library.ts
@@ -164,6 +164,24 @@ export function filamentLabel(filament: Filament, vendor: Vendor): string {
 	return filament.material?.trim() || `#${filament.id}`;
 }
 
+// --- filter menu metadata -------------------------------------------------
+
+/**
+ * One value on the filter menu's second level. Most properties enumerate bare
+ * strings, where the value is the whole story; a filament is a thing with a look
+ * and a material, and two of them can share a name (#1087, #1088). So an option
+ * carries whatever it has beyond its label and the menu draws what it finds,
+ * which keeps the option list one type however it was built.
+ */
+export interface FilterOption {
+	value: string;
+	label: string;
+	/** Secondary text shown beside the label, and searched along with it. */
+	meta?: string;
+	colors?: string[];
+	direction?: MultiColorDirection;
+}
+
 // --- sort menu metadata ---------------------------------------------------
 
 export interface SortDef {

--- a/tests_frontend_v2/tests/helpers.ts
+++ b/tests_frontend_v2/tests/helpers.ts
@@ -232,6 +232,13 @@ export async function openToolbarMenu(page: Page, name: "Filter" | "Group" | "So
 export async function addFilter(page: Page, property: string, value: string): Promise<void> {
   const menu = await openToolbarMenu(page, "Filter");
   await menu.getByRole("button", { name: property, exact: true }).click();
-  await menu.getByRole("button", { name: value, exact: true }).click();
+  // A value is a checkbox rather than a plain entry: it carries whether it is
+  // already applied, and picking one leaves the menu open so several can be
+  // picked in a row (#1090, #1089).
+  await menu.getByRole("menuitemcheckbox", { name: value, exact: true }).click();
   await expect(page.getByRole("button", { name: `${property}: ${value}` })).toBeVisible();
+  // Which means this has to close it again: every caller expects to be handed a
+  // toolbar with nothing covering it, and two of these calls run back to back.
+  await onlyVisible(page.getByRole("button", { name: /^Filter$/ })).click();
+  await expect(menu).toBeHidden();
 }


### PR DESCRIPTION
Four of the filter-menu items from #1080, all in `ListToolbar.svelte`.

- Filament options now show a colour swatch (#1087) and their material (#1088), so two filaments with the same name are distinguishable. The menu's search box matches the material too. Options for other properties stay single-line.
- Filter values that are already applied are marked with a checkbox (#1090).
- Picking a value no longer closes the menu, so several can be picked in one go (#1089). Escape and clicking outside still close it; picking a property or a date range still closes as before.

One deliberate deviation: the Ctrl-modifier suggested in #1089 is not implemented. Once values carry checkmarks the list reads as a multi-select, so staying open is the expected behaviour and needs no hint text.

No new translatable strings.

Closes #1087
Closes #1088
Closes #1090
Closes #1089
