### PR TITLE
fix(database): close the sqlite connections used to write a backup

### DIFF
--- a/spoolman/database/database.py
+++ b/spoolman/database/database.py
@@ -7,6 +7,7 @@ import shutil
 import sqlite3
 import time
 from collections.abc import AsyncGenerator
+from contextlib import closing
 from os import PathLike
 from pathlib import Path
 from typing import NamedTuple
@@ -129,7 +130,14 @@ class Database:
         if Path(target_path).exists():
             raise ValueError("Backup target file already exists.")
 
-        with sqlite3.connect(self.connection_url.database) as src, sqlite3.connect(target_path) as dst:
+        # closing(), not `with sqlite3.connect(...) as conn`: a Connection's context manager is a
+        # transaction manager that commits on exit, it does not close the connection. Leaving the
+        # handles open leaks them on every backup, and on Windows it makes the caller's unlink/move
+        # of the file we just wrote fail with "used by another process" (POSIX unlink hides this).
+        with (
+            closing(sqlite3.connect(self.connection_url.database)) as src,
+            closing(sqlite3.connect(target_path)) as dst,
+        ):
             src.backup(dst, pages=1, progress=progress)
 
         logger.info("Backup complete.")


### PR DESCRIPTION
`Database.backup()` never closes either connection, which breaks database backups entirely on Windows and leaks a connection pair per backup everywhere else.

```python
with sqlite3.connect(self.connection_url.database) as src, sqlite3.connect(target_path) as dst:
    src.backup(dst, pages=1, progress=progress)
```

A `sqlite3.Connection` used as a context manager is a *transaction* manager, not a resource manager: `__exit__` commits or rolls back and leaves the connection open. So both handles are still live when `backup_and_rotate()` immediately does this to the file it just wrote:

```python
pending.unlink(missing_ok=True)
...
shutil.move(pending, newest)
```

On POSIX, unlinking and renaming a file that still has an open descriptor is legal, so nothing visibly breaks and the leak stays invisible. On Windows both calls fail:

```
PermissionError: [WinError 32] The process cannot access the file because it is
being used by another process: '...\backups\spoolman.db.pending'
```

That takes out both the scheduled midnight backup and the manual backup endpoint on every Windows deployment.

`contextlib.closing()` is the fix. Nothing is lost by dropping the old context manager's commit: `Connection.backup()` already commits on the destination internally, so the transaction semantics were doing no work here.

## Testing

No new test needed — `tests/test_backup_rotation.py` already catches this. It has simply never been run on Windows, since CI is `ubuntu-latest` only.

On `master` at 1f2670c, on Windows:

```
$ pytest tests/test_backup_rotation.py
8 failed, 1 passed
```

With this commit:

```
$ pytest tests/test_backup_rotation.py
9 passed

$ pytest tests
210 passed
```

`ruff check .` and `ruff format --check .` are clean. The parenthesized-context-manager form is what `ruff format` produces; it needs `requires-python = ">=3.10"`, which `pyproject.toml` already declares.

This change was prepared with AI assistance; the failure was reproduced and the fix verified locally on Windows against `master`.
