### PR TITLE
chore(client): let prettier respect the working tree's line endings

### DIFF
--- a/client/.prettierrc
+++ b/client/.prettierrc
@@ -1,5 +1,6 @@
 {
   "printWidth": 120,
+  "endOfLine": "auto",
   "overrides": [
     {
       "files": ["public/locales/**/*.json"],

--- a/client_v2/.prettierrc
+++ b/client_v2/.prettierrc
@@ -3,6 +3,7 @@
 	"singleQuote": true,
 	"trailingComma": "none",
 	"printWidth": 110,
+	"endOfLine": "auto",
 	"plugins": ["prettier-plugin-svelte"],
 	"overrides": [{ "files": "*.svelte", "options": { "parser": "svelte" } }]
 }


### PR DESCRIPTION
Prettier reports every file in both clients as mis-formatted on a Windows checkout, which makes the local lint gate unusable and makes the pre-commit hook restage the whole client tree.

`.gitattributes` sets `* text=auto`, so every text file is checked out CRLF on Windows. Prettier defaults to `endOfLine: "lf"` and flags the lot:

```
$ cd client_v2 && npx prettier --check .
[warn] Code style issues found in 163 files.
```

CI never sees it, because it runs on `ubuntu-latest` where the checkout is LF. Locally on Windows the consequences are worse than noise: `lefthook run ci` can never pass, and the `pre-commit` hook runs `prettier --write .` with `stage_fixed: true`, so any commit from a Windows machine rewrites and stages every file under `client/` and `client_v2/`.

`endOfLine: "auto"` tells Prettier to respect what is already in the working tree. This gives up nothing: `* text=auto` already normalizes everything to LF in the index and in the repository, so LF in version control stays guaranteed by git regardless of this setting. It is the fix Prettier documents for exactly this situation.

## Testing

`client_v2`, on Windows, before: `Code style issues found in 163 files`. After: `All matched files use Prettier code style!`. Same in `client/` (97 files -> 0).

`eslint .`, `npm run check` and `vitest run` are unaffected and still clean.

No source file changes, so there is no effect on Linux or on CI, where prettier already passed.

This change was prepared with AI assistance; verified locally on Windows.
