### PR TITLE
fix: dashboard total weight displayes filament weight instead of actual spool weight

### DIFF
--- a/client_v2/src/routes/dashboard/+page.svelte
+++ b/client_v2/src/routes/dashboard/+page.svelte
@@ -771,7 +771,7 @@
 									<div class="chip-subtitle" use:truncTitle>
 										{f.material} -
 										<span class:low={settings.isLow(s.remaining, s.unused)}>{weightAuto(s.remaining)}</span>
-										/ {weightAuto(f.weight)}{s.lastUsedLabel
+										/ {weightAuto(s.initial)}{s.lastUsedLabel
 											? ` - ${m['dashboard.lastUsed']({ time: s.lastUsedLabel })}`
 											: ''}
 									</div>


### PR DESCRIPTION
Today I was looking at the dashboard in the v2 frontend and noticed one of my spools reading `60.7 g / 1 kg` — it's a 250 g roll with a per-spool weight override, and the inspector one click away gets it right.

The chip's total came from the filament's net weight, so every spool with an initial-weight override was measured against a full spool it never was. `Spool.initial` already holds the effective value and falls back to the filament's weight when there is no override.