### PR TITLE
Key the tag scan debounce on the resolved match

### DIFF
--- a/spoolman/api/v1/tag.py
+++ b/spoolman/api/v1/tag.py
@@ -90,7 +90,9 @@ class TagScanParameters(BaseModel):
         "Scans are ephemeral -- broadcast only, never stored. Repeated identical scans from the "
         "same reader within a few seconds are broadcast once, because readers re-detect a tag that "
         "is sitting still; the response is unaffected, so a de-duplicated scan never looks to the "
-        "device like a failed lookup."
+        "device like a failed lookup. A scan that resolves to a different spool than the last one "
+        "-- because the tag has just been linked, unlinked, or moved -- is never de-duplicated, so "
+        "an agent that links a tag can re-report the scan and have the correction go out at once."
     ),
     responses={
         200: {"model": TagScan},
@@ -129,7 +131,7 @@ async def scan(
         spool=Spool.from_db(db_spool) if db_spool is not None else None,
     )
 
-    if scan_relay.should_broadcast(uid, reader_id):
+    if scan_relay.should_broadcast(uid, reader_id, result.matched_spool_id):
         await _broadcast(result)
 
     content = jsonable_encoder(result, exclude_none=True)

--- a/spoolman/scanrelay.py
+++ b/spoolman/scanrelay.py
@@ -19,7 +19,7 @@ from datetime import datetime, timedelta, timezone
 # Readers poll continuously -- nfc2klipper re-reads a tag for as long as it sits on the
 # reader -- so the same UID fires over and over. Suppressing repeats server-side, before the
 # broadcast, means every subscriber benefits and no device has to be well-behaved for the UI
-# to be.
+# to be. Only a scan that resolves the same way is a repeat; see should_broadcast.
 DEBOUNCE_WINDOW = timedelta(seconds=3)
 
 # How long a reader stays listed after its last scan. Long, because the list exists to fill a
@@ -77,8 +77,10 @@ class ScanRelay:
         """Initialize an empty relay."""
         self.debounce_window = debounce_window
         self.reader_ttl = reader_ttl
-        # (uid, reader_id) -> when it was last broadcast.
-        self._last_broadcast: dict[tuple[str, str], datetime] = {}
+        # (uid, reader_id, matched_spool_id) -> when it was last broadcast. The match is part
+        # of the key because it is part of the answer: a repeat is only a repeat while the scan
+        # still resolves to the same thing.
+        self._last_broadcast: dict[tuple[str, str, int | None], datetime] = {}
         self._readers: dict[str, Reader] = {}
         # Scans arrive on the event loop, but the loop is not the only thing that can touch
         # this: pruning walks the dicts while a scan may be inserting into them. A plain lock
@@ -106,14 +108,25 @@ class ScanRelay:
             while len(self._readers) > MAX_READERS:
                 self._readers.pop(next(iter(self._readers)))
 
-    def should_broadcast(self, uid: str, reader_id: str, now: datetime | None = None) -> bool:
+    def should_broadcast(
+        self,
+        uid: str,
+        reader_id: str,
+        matched_spool_id: int | None,
+        now: datetime | None = None,
+    ) -> bool:
         """Whether this scan is new enough to broadcast, recording it if so.
 
         Only the fan-out is debounced. The caller still answers the device on every POST: a
         de-duplicated scan must not look to the device like a failed lookup.
+
+        `matched_spool_id` is required rather than optional so that a future call site cannot
+        quietly reintroduce the bug this argument exists to fix (#1115): a tag scanned before it
+        was linked, then linked and scanned again, used to be suppressed as a duplicate, leaving
+        every subscriber that trusts the broadcast still showing "unknown tag".
         """
         now = now or datetime.now(tz=timezone.utc)
-        key = (uid, reader_id)
+        key = (uid, reader_id, matched_spool_id)
         with self._lock:
             self._prune_debounce(now)
             last = self._last_broadcast.get(key)

--- a/tests/test_scan_relay.py
+++ b/tests/test_scan_relay.py
@@ -24,35 +24,70 @@ def relay() -> ScanRelay:
 
 
 def test_first_scan_broadcasts(relay: ScanRelay):
-    assert relay.should_broadcast("04A2", "desk", now=T0) is True
+    assert relay.should_broadcast("04A2", "desk", None, now=T0) is True
 
 
 def test_repeat_within_the_window_is_suppressed(relay: ScanRelay):
     """A reader re-reads a tag that is sitting still; subscribers should see one event."""
-    relay.should_broadcast("04A2", "desk", now=T0)
-    assert relay.should_broadcast("04A2", "desk", now=T0 + timedelta(seconds=1)) is False
-    assert relay.should_broadcast("04A2", "desk", now=T0 + timedelta(seconds=2.9)) is False
+    relay.should_broadcast("04A2", "desk", 7, now=T0)
+    assert relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=1)) is False
+    assert relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=2.9)) is False
 
 
 def test_repeat_after_the_window_broadcasts_again(relay: ScanRelay):
     """Tapping the same tag again later is a new scan, not a duplicate."""
-    relay.should_broadcast("04A2", "desk", now=T0)
-    assert relay.should_broadcast("04A2", "desk", now=T0 + timedelta(seconds=4)) is True
+    relay.should_broadcast("04A2", "desk", 7, now=T0)
+    assert relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=4)) is True
 
 
 def test_debounce_is_per_uid_and_per_reader(relay: ScanRelay):
     """Two readers tapping at once, or one reader seeing two tags, are distinct scans."""
-    relay.should_broadcast("04A2", "desk", now=T0)
-    assert relay.should_broadcast("04A2", "printer", now=T0) is True
-    assert relay.should_broadcast("B1C2", "desk", now=T0) is True
+    relay.should_broadcast("04A2", "desk", None, now=T0)
+    assert relay.should_broadcast("04A2", "printer", None, now=T0) is True
+    assert relay.should_broadcast("B1C2", "desk", None, now=T0) is True
+
+
+def test_a_changed_match_is_not_a_repeat(relay: ScanRelay):
+    """The correction after a tag is linked must go out, not wait for the window (#1115).
+
+    An agent taps an unlinked tag, links it in its own UI, then re-reports the scan so the
+    paired browser learns the tag is known. Keyed on `(uid, reader)` alone, that second scan
+    looked like a duplicate of the first and the browser kept showing "unknown tag".
+    """
+    assert relay.should_broadcast("04A2", "desk", None, now=T0) is True
+    assert relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=1)) is True
+
+
+def test_a_repeat_of_an_unlinked_tag_is_still_suppressed(relay: ScanRelay):
+    """The reason the debounce exists survives the fix: the key stays `(uid, reader, None)`."""
+    relay.should_broadcast("04A2", "desk", None, now=T0)
+    assert relay.should_broadcast("04A2", "desk", None, now=T0 + timedelta(seconds=1)) is False
+
+
+def test_repeats_of_the_corrected_match_are_suppressed(relay: ScanRelay):
+    """A tag left sitting on the reader after being linked is still one event, not a stream."""
+    relay.should_broadcast("04A2", "desk", None, now=T0)
+    relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=1))
+    assert relay.should_broadcast("04A2", "desk", 7, now=T0 + timedelta(seconds=1.5)) is False
+
+
+def test_losing_a_match_is_also_a_change(relay: ScanRelay):
+    """Unlinking is the same event in reverse: the browser has to hear it lost its spool."""
+    relay.should_broadcast("04A2", "desk", 7, now=T0)
+    assert relay.should_broadcast("04A2", "desk", None, now=T0 + timedelta(seconds=1)) is True
+
+
+def test_a_tag_moved_to_another_spool_is_a_change(relay: ScanRelay):
+    relay.should_broadcast("04A2", "desk", 7, now=T0)
+    assert relay.should_broadcast("04A2", "desk", 8, now=T0 + timedelta(seconds=1)) is True
 
 
 def test_debounce_entries_are_pruned(relay: ScanRelay):
     """The cache does not grow without bound as tags come and go."""
     for i in range(50):
-        relay.should_broadcast(f"UID{i:04X}", "desk", now=T0)
+        relay.should_broadcast(f"UID{i:04X}", "desk", None, now=T0)
     assert len(relay._last_broadcast) == 50  # noqa: SLF001
-    relay.should_broadcast("LATER", "desk", now=T0 + timedelta(seconds=30))
+    relay.should_broadcast("LATER", "desk", None, now=T0 + timedelta(seconds=30))
     assert len(relay._last_broadcast) == 1  # noqa: SLF001
 
 
@@ -115,8 +150,8 @@ def test_the_relays_own_clock_is_internally_consistent():
     """
     relay = ScanRelay()
     relay.register("desk", "Desk reader")
-    assert relay.should_broadcast("04A2", "desk") is True
-    assert relay.should_broadcast("04A2", "desk") is False
+    assert relay.should_broadcast("04A2", "desk", None) is True
+    assert relay.should_broadcast("04A2", "desk", None) is False
 
     listed = relay.readers()
     assert [r.reader_id for r in listed] == ["desk"]

--- a/tests_integration/tests/tag/test_relay_ws.py
+++ b/tests_integration/tests/tag/test_relay_ws.py
@@ -172,6 +172,42 @@ async def test_debounce_suppresses_the_broadcast_not_the_response(random_filamen
 
 
 @pytest.mark.asyncio
+async def test_a_scan_corrected_by_a_link_is_not_debounced(random_filament: dict[str, Any]):
+    """The end-to-end shape of #1115.
+
+    An agent taps an unlinked tag, links it in its own UI, and re-reports the same scan so the
+    paired browser hears the correction. That second scan lands well inside the debounce window
+    and used to be dropped, leaving every subscriber that trusts the broadcast still showing an
+    unknown tag until the window elapsed.
+    """
+    uid, reader_id = _uid(), _reader_id()
+
+    result = httpx.post(f"{URL}/api/v1/spool", json={"filament_id": random_filament["id"]})
+    result.raise_for_status()
+    spool = result.json()
+    try:
+        async with connect(f"{WS_URL}/api/v1/tag/scan/{reader_id}") as ws:
+            await asyncio.sleep(0.2)
+
+            _scan(uid, reader_id).raise_for_status()
+            unknown = json.loads(await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT_S))
+            # Omitted rather than null: broadcasts are serialized with exclude_none, the same
+            # shape the REST endpoints use. Either way the browser has been told "no match".
+            assert unknown["payload"].get("matched_spool_id") is None
+
+            httpx.post(f"{URL}/api/v1/spool/{spool['id']}/tag", json={"uid": uid}).raise_for_status()
+
+            # No sleep: the point is that the correction goes out inside the debounce window.
+            _scan(uid, reader_id).raise_for_status()
+            corrected = json.loads(await asyncio.wait_for(ws.recv(), timeout=RECV_TIMEOUT_S))
+
+        assert corrected["payload"]["matched_spool_id"] == spool["id"]
+        assert corrected["payload"]["spool"]["id"] == spool["id"]
+    finally:
+        httpx.delete(f"{URL}/api/v1/spool/{spool['id']}")
+
+
+@pytest.mark.asyncio
 async def test_distinct_tags_from_one_reader_are_not_debounced():
     """Debouncing is per (uid, reader): moving from one spool to the next is two scans."""
     reader_id = _reader_id()


### PR DESCRIPTION
The scan relay debounced on `(uid, reader_id)` and time alone, so a scan whose match had changed looked like a duplicate of one that resolved to nothing. An agent that taps an unlinked tag, links it, then re-reports the scan had its correction swallowed for the whole 3 second window, leaving subscribers that trust the broadcast still showing an unknown tag.

The debounce key now includes the resolved `matched_spool_id`, so a repeat is only a repeat while the scan still resolves to the same thing. Repeats of a still-unlinked tag keep collapsing on `(uid, reader, None)`, which is the reason the debounce exists in the first place.

Fixes #1115