### PR TITLE
Repair SQLite vendor tables whose id column no longer auto-increments

### DIFF
--- a/migrations/versions/2026_09_02_0900-7b9f3d1c5a24_repair_vendor_id_autoincrement.py
+++ b/migrations/versions/2026_09_02_0900-7b9f3d1c5a24_repair_vendor_id_autoincrement.py
@@ -1,0 +1,65 @@
+"""repair vendor id autoincrement.
+
+Revision ID: 7b9f3d1c5a24
+Revises: fe4970567bb3
+Create Date: 2026-09-02 09:00:00.000000
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7b9f3d1c5a24"
+down_revision = "fe4970567bb3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Rebuild the vendor table on SQLite if its id column cannot auto-increment.
+
+    SQLite only auto-assigns ids to a column declared exactly as a single-column
+    INTEGER PRIMARY KEY (a rowid alias). Databases that have passed through
+    third-party export/conversion tools can come back with e.g. a BIGINT id or a
+    lost primary key; such a table then rejects every INSERT that does not carry
+    an explicit id with "NOT NULL constraint failed: vendor.id" (#1131). Tables
+    created by our own migrations are detected as healthy and left untouched.
+    """
+    conn = op.get_bind()
+    if conn.dialect.name != "sqlite":
+        return
+
+    # PRAGMA table_info rows are (cid, name, type, notnull, dflt_value, pk), where
+    # pk is the 1-based position of the column in the primary key, or 0.
+    info = conn.exec_driver_sql("PRAGMA table_info('vendor')").fetchall()
+    if not info:
+        return
+    pk_columns = [row for row in info if row[5] > 0]
+    id_is_rowid_alias = (
+        len(pk_columns) == 1 and pk_columns[0][1] == "id" and (pk_columns[0][2] or "").upper() == "INTEGER"
+    )
+    if id_is_rowid_alias:
+        return
+
+    vendor = sa.Table(
+        "vendor",
+        sa.MetaData(),
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("registered", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("comment", sa.String(length=1024), nullable=True),
+        sa.Column("empty_spool_weight", sa.Float(), nullable=True),
+        sa.Column("external_id", sa.String(length=256), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    with op.batch_alter_table("vendor", copy_from=vendor, recreate="always"):
+        pass
+    # The old table's indexes went down with it; restore the one the initial
+    # migration created.
+    op.create_index(op.f("ix_vendor_id"), "vendor", ["id"], unique=False)
+
+
+def downgrade() -> None:
+    """Perform the downgrade."""
+    # Nothing to undo: the upgrade only normalizes the table back to the schema
+    # the initial migration always intended.

--- a/tests/test_vendor_id_repair.py
+++ b/tests/test_vendor_id_repair.py
@@ -1,0 +1,108 @@
+"""Tests for the SQLite vendor id auto-increment repair migration (#1131).
+
+SQLite only auto-assigns ids to a column declared exactly as a single-column INTEGER
+PRIMARY KEY. Databases that have passed through third-party export/conversion tools can
+come back with e.g. a BIGINT id or a lost primary key, after which every vendor INSERT
+fails with "NOT NULL constraint failed: vendor.id". The repair migration rebuilds such
+a table in place; these tests drive the real alembic chain against sqlite files.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# The revision just before the repair migration; upgrading to it first lets a test
+# mangle the vendor table the way an external tool would, before the repair has run.
+PRE_REPAIR_REVISION = "fe4970567bb3"
+
+
+def upgrade(data_dir: Path, revision: str) -> None:
+    """Run the real migration chain against the sqlite database in data_dir."""
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", revision],
+        check=True,
+        cwd=REPO_ROOT,
+        env={**os.environ, "SPOOLMAN_DB_TYPE": "sqlite", "SPOOLMAN_DIR_DATA": str(data_dir)},
+    )
+
+
+def mangle_vendor_table(db_path: Path) -> None:
+    """Rebuild the vendor table the way conversion tools do: a BIGINT id is not a rowid alias."""
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE vendor_mangled (
+                id BIGINT NOT NULL,
+                registered DATETIME NOT NULL,
+                name VARCHAR(64) NOT NULL,
+                comment VARCHAR(1024),
+                empty_spool_weight FLOAT,
+                external_id VARCHAR(256),
+                PRIMARY KEY (id)
+            );
+            INSERT INTO vendor_mangled SELECT * FROM vendor;
+            DROP TABLE vendor;
+            ALTER TABLE vendor_mangled RENAME TO vendor;
+            """,
+        )
+        for i in range(1, 7):
+            conn.execute(
+                "INSERT INTO vendor (id, registered, name) VALUES (?, '2023-01-01 00:00:00', ?)",
+                (i, f"Vendor {i}"),
+            )
+        conn.execute(
+            "INSERT INTO filament (id, registered, vendor_id, density, diameter) "
+            "VALUES (1, '2023-01-01 00:00:00', 3, 1.24, 1.75)",
+        )
+        conn.execute("""INSERT INTO vendor_field (vendor_id, key, value) VALUES (2, 'note', '"kept"')""")
+
+
+def insert_vendor(conn: sqlite3.Connection, name: str) -> int:
+    """Insert a vendor the way the ORM does: without an explicit id."""
+    conn.execute("INSERT INTO vendor (registered, name) VALUES ('2026-08-31 16:47:12', ?)", (name,))
+    return conn.execute("SELECT id FROM vendor WHERE name = ?", (name,)).fetchone()[0]
+
+
+def test_repair_restores_autoincrement_and_data(tmp_path: Path):
+    db_path = tmp_path / "spoolman.db"
+    upgrade(tmp_path, PRE_REPAIR_REVISION)
+    mangle_vendor_table(db_path)
+
+    # The mangled table reproduces the reported failure.
+    with sqlite3.connect(db_path) as conn, pytest.raises(sqlite3.IntegrityError, match=r"vendor\.id"):
+        insert_vendor(conn, "Snapmaker")
+
+    upgrade(tmp_path, "head")
+
+    with sqlite3.connect(db_path) as conn:
+        # id auto-increments again, continuing after the existing rows.
+        assert insert_vendor(conn, "Snapmaker") == 7
+        # The existing rows and everything pointing at them survived the rebuild.
+        assert conn.execute("SELECT id, name FROM vendor ORDER BY id").fetchall()[:6] == [
+            (i, f"Vendor {i}") for i in range(1, 7)
+        ]
+        assert conn.execute("SELECT vendor_id FROM filament WHERE id = 1").fetchone() == (3,)
+        assert conn.execute("SELECT value FROM vendor_field WHERE vendor_id = 2").fetchone() == ('"kept"',)
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        index_names = [row[1] for row in conn.execute("PRAGMA index_list('vendor')").fetchall()]
+        assert "ix_vendor_id" in index_names
+
+
+def test_repair_leaves_healthy_databases_alone(tmp_path: Path):
+    db_path = tmp_path / "spoolman.db"
+    upgrade(tmp_path, PRE_REPAIR_REVISION)
+    with sqlite3.connect(db_path) as conn:
+        schema_before = conn.execute("SELECT sql FROM sqlite_master WHERE name = 'vendor'").fetchone()[0]
+
+    upgrade(tmp_path, "head")
+
+    with sqlite3.connect(db_path) as conn:
+        schema_after = conn.execute("SELECT sql FROM sqlite_master WHERE name = 'vendor'").fetchone()[0]
+        assert schema_after == schema_before
+        assert insert_vendor(conn, "Snapmaker") == 1


### PR DESCRIPTION
Fixes #1131

SQLite only hands out ids automatically for a column declared exactly as a single-column `INTEGER PRIMARY KEY` (a rowid alias). Our migrations create `vendor.id` that way, but a database that has been through an export/convert round trip (a `BIGINT` id, or a primary key that got dropped on the way) comes back without the alias, and from then on every `INSERT INTO vendor` that doesn't carry an explicit id fails with `NOT NULL constraint failed: vendor.id`, which is the traceback in the issue. Reads and updates keep working, matching what was reported.

This adds a migration that, on SQLite only, checks `PRAGMA table_info('vendor')` and, if the id isn't a single-column INTEGER primary key, rebuilds the table through alembic's batch mode with the schema the initial migration always intended, keeping every row, the filament/vendor_field references and `ix_vendor_id`. Healthy databases are left untouched (it's a single PRAGMA read), other database types return immediately. I couldn't see the reporter's actual schema, but a non-alias id is the only way SQLite produces this error on an insert without an id, so the check covers the shapes a conversion can leave behind. Only vendor is touched since that's what was reported; if a converted db turns out to have the same problem on filament/spool the same check can be generalised.

How I've tested it: a new unit test upgrades a temp sqlite db to the previous revision, rewrites the vendor table with a `BIGINT` id (which reproduces the exact IntegrityError), then upgrades to head and checks that inserts auto-increment again continuing after the existing ids, that the existing vendors plus a filament and a vendor_field pointing at them survive, that `PRAGMA foreign_key_check` is clean and the index is back. A second test checks a healthy db's `vendor` schema is byte-identical before and after. `pytest tests` passes (275 tests), ruff check and format are clean on the new files.