### PR TITLE
Add OpenSpool QR to spool and filament details

### DIFF
--- a/client_v2/src/lib/components/library/FilamentInspector.svelte
+++ b/client_v2/src/lib/components/library/FilamentInspector.svelte
@@ -8,6 +8,7 @@
 	import ConfirmDialog from '../ConfirmDialog.svelte';
 	import Plus from '@lucide/svelte/icons/plus';
 	import Copy from '@lucide/svelte/icons/copy';
+	import QrCode from '@lucide/svelte/icons/qr-code';
 	import Trash2 from '@lucide/svelte/icons/trash-2';
 	import Square from '@lucide/svelte/icons/square';
 	import SquareCheck from '@lucide/svelte/icons/square-check';
@@ -22,6 +23,7 @@
 	import Field from '../Field.svelte';
 	import VendorSection from './VendorSection.svelte';
 	import ChangeVendorModal from './ChangeVendorModal.svelte';
+	import OpenSpoolQrModal from './OpenSpoolQrModal.svelte';
 	import OverrideMark from './OverrideMark.svelte';
 	import type { Filament, Spool } from '$lib/types';
 	import { inventory } from '$lib/stores/inventory.svelte';
@@ -164,6 +166,7 @@
 	// first), and it carries the empty-spool weight this filament may be inheriting,
 	// so it gets a dialog that says what will happen instead of a debounced autosave.
 	let changeVendorOpen = $state(false);
+	let openSpoolQrOpen = $state(false);
 
 	let confirmLines = $derived(
 		plan.allowed
@@ -235,6 +238,9 @@
 			<Button onclick={() => ui.openAddModal(filament.id)}
 				><Plus size={15} /> {m['inspector.addSpoolsOfThis']()}</Button
 			>
+			<Button variant="outline" onclick={() => (openSpoolQrOpen = true)} title="OpenSpool QR"
+				><QrCode size={15} /> OpenSpool QR</Button
+			>
 			<!-- Duplicating and deleting are occasional, so they sit apart as quiet icons
 			     and leave the end of the row to the one action this panel is really for.
 			     Buying the same filament in another colour is common enough to stay a
@@ -276,6 +282,8 @@
 		current={vendor}
 		onclose={() => (changeVendorOpen = false)}
 	/>
+
+	<OpenSpoolQrModal open={openSpoolQrOpen} {filament} {vendor} onclose={() => (openSpoolQrOpen = false)} />
 
 	<SectionLabel>
 		<span style="padding-left:20px"

--- a/client_v2/src/lib/components/library/OpenSpoolQrModal.svelte
+++ b/client_v2/src/lib/components/library/OpenSpoolQrModal.svelte
@@ -1,0 +1,272 @@
+<script lang="ts">
+	import { untrack } from 'svelte';
+	import QRCode from 'qrcode';
+	import X from '@lucide/svelte/icons/x';
+	import type { Filament, Spool, Vendor } from '$lib/types';
+	import { buildOpenSpoolProfile, encodeOpenSpoolQr, type OpenSpoolProfile } from '$lib/openspool/qr';
+	import * as m from '$lib/paraglide/messages';
+
+	interface Props {
+		open: boolean;
+		spool?: Spool;
+		filament: Filament;
+		vendor?: Vendor;
+		onclose: () => void;
+	}
+
+	let { open, spool, filament, vendor, onclose }: Props = $props();
+	let dialog = $state<HTMLDivElement | null>(null);
+	let opener: HTMLElement | null = null;
+	let image = $state('');
+	let error = $state('');
+	let profile = $state<OpenSpoolProfile | null>(null);
+
+	$effect(() => {
+		if (!open) {
+			image = '';
+			error = '';
+			profile = null;
+			return;
+		}
+
+		let cancelled = false;
+		image = '';
+		error = '';
+		try {
+			// Keep the QR stable while the modal is open. Live inventory updates replace
+			// the spool/filament objects frequently; tracking them here would clear and
+			// regenerate the image on every update, making it visibly blink. Reopening
+			// the modal still takes a fresh snapshot of the current values.
+			const nextProfile = untrack(() => buildOpenSpoolProfile({ spool, filament, vendor }));
+			profile = nextProfile;
+			const payload = encodeOpenSpoolQr(nextProfile);
+			QRCode.toDataURL(payload, {
+				errorCorrectionLevel: 'H',
+				margin: 4,
+				width: 760,
+				color: { dark: '#000000', light: '#FFFFFF' }
+			})
+				.then((dataUrl) => {
+					if (!cancelled) image = dataUrl;
+				})
+				.catch((cause: unknown) => {
+					if (!cancelled) error = cause instanceof Error ? cause.message : String(cause);
+				});
+		} catch (cause) {
+			error = cause instanceof Error ? cause.message : String(cause);
+		}
+
+		return () => {
+			cancelled = true;
+		};
+	});
+
+	$effect(() => {
+		if (open) {
+			opener ??= document.activeElement as HTMLElement | null;
+			dialog?.focus();
+		} else if (opener) {
+			opener.focus();
+			opener = null;
+		}
+	});
+
+	function close() {
+		onclose();
+	}
+</script>
+
+<svelte:window
+	onkeydown={(event) => {
+		if (open && event.key === 'Escape') close();
+	}}
+/>
+
+{#if open}
+	<div class="overlay">
+		<button class="backdrop" tabindex="-1" aria-hidden="true" onclick={close}></button>
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="openspool-qr-title"
+			tabindex="-1"
+			bind:this={dialog}
+		>
+			<div class="head">
+				<span class="title" id="openspool-qr-title">OpenSpool QR</span>
+				<button class="x" onclick={close} aria-label={m['buttons.close']()}><X size={18} /></button>
+			</div>
+
+			<div class="body" aria-live="polite">
+				{#if error}
+					<div class="error">{error}</div>
+				{:else if profile}
+					<div class="profile">
+						<strong>{profile.brand} · {profile.name}</strong>
+						<span>{profile.type}{profile.subtype ? ` / ${profile.subtype}` : ''}</span>
+						<div class="colors" aria-label={profile.color_name ?? profile.color_hex}>
+							{#each [profile.color_hex, ...(profile.additional_color_hexes ?? [])] as color (color)}
+								<span class="color" style:background={color} title={color}></span>
+							{/each}
+							<span class="hexes">
+								{[profile.color_hex, ...(profile.additional_color_hexes ?? [])].join(', ')}
+							</span>
+						</div>
+					</div>
+
+					{#if image}
+						<img src={image} alt="OpenSpool QR" />
+						<button class="confirm" type="button" onclick={close}>OK</button>
+					{:else}
+						<div class="loading">{m['loading']()}…</div>
+					{/if}
+				{/if}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	.overlay {
+		position: fixed;
+		inset: 0;
+		z-index: 60;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 16px;
+		background: rgba(0, 0, 0, 0.64);
+		backdrop-filter: blur(5px);
+	}
+	.backdrop {
+		position: fixed;
+		inset: 0;
+		margin: 0;
+		padding: 0;
+		border: none;
+		background: transparent;
+		cursor: default;
+	}
+	.modal {
+		position: relative;
+		z-index: 1;
+		width: 720px;
+		max-width: 100%;
+		max-height: calc(100vh - 32px);
+		overflow: hidden;
+		background: var(--bg);
+		border: 1px solid var(--border-strong);
+		border-radius: var(--radius-xl);
+		box-shadow: 0 24px 80px rgba(0, 0, 0, 0.55);
+	}
+	.head {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		padding: 16px 18px 12px 20px;
+		border-bottom: 1px solid var(--border);
+	}
+	.title {
+		font-size: 17px;
+		font-weight: 700;
+	}
+	.x {
+		display: inline-flex;
+		margin-left: auto;
+		padding: 7px;
+		color: var(--text-dim);
+		background: var(--surface-raised);
+		border: none;
+		border-radius: 50%;
+		cursor: pointer;
+	}
+	.x:hover {
+		color: var(--text);
+	}
+	.body {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		max-height: calc(100vh - 96px);
+		overflow: auto;
+		padding: 18px 20px 20px;
+	}
+	.profile {
+		display: flex;
+		align-self: stretch;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 14px;
+		font-size: 13px;
+		color: var(--text-2);
+	}
+	.profile strong {
+		font-size: 15px;
+		color: var(--text);
+	}
+	.colors {
+		display: flex;
+		align-items: center;
+		gap: 5px;
+		margin-top: 4px;
+	}
+	.color {
+		width: 15px;
+		height: 15px;
+		border: 1px solid var(--border-strong);
+		border-radius: 50%;
+	}
+	.hexes {
+		margin-left: 3px;
+		font-family: var(--font-mono);
+		font-size: 12px;
+		color: var(--text-dim);
+	}
+	img {
+		display: block;
+		width: min(100%, 590px);
+		height: auto;
+		background: #fff;
+		border-radius: var(--radius);
+	}
+	.confirm {
+		display: inline-flex;
+		align-items: center;
+		margin-top: 14px;
+		padding: 8px 13px;
+		color: #fff;
+		background: var(--accent-fill);
+		border: none;
+		border-radius: var(--radius);
+		font-size: 12.5px;
+		font-weight: 600;
+		cursor: pointer;
+	}
+	.confirm:hover {
+		background: var(--accent-fill-hover);
+	}
+	.loading,
+	.error {
+		padding: 56px 16px;
+		font-size: 13px;
+		color: var(--text-dim);
+	}
+	.error {
+		color: var(--danger);
+	}
+	@media (max-width: 640px) {
+		.overlay {
+			align-items: flex-end;
+			padding: 0;
+		}
+		.modal {
+			max-height: 94vh;
+			border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+		}
+		.body {
+			max-height: calc(94vh - 60px);
+			padding: 14px;
+		}
+	}
+</style>

--- a/client_v2/src/lib/components/library/SpoolInspector.svelte
+++ b/client_v2/src/lib/components/library/SpoolInspector.svelte
@@ -10,6 +10,7 @@
 	import Combobox from '../Combobox.svelte';
 	import Scale from '@lucide/svelte/icons/scale';
 	import Printer from '@lucide/svelte/icons/printer';
+	import QrCode from '@lucide/svelte/icons/qr-code';
 	import Archive from '@lucide/svelte/icons/archive';
 	import ArchiveRestore from '@lucide/svelte/icons/archive-restore';
 	import ArrowRight from '@lucide/svelte/icons/arrow-right';
@@ -25,6 +26,7 @@
 	import LinkedText from '../LinkedText.svelte';
 	import VendorSection from './VendorSection.svelte';
 	import ChangeFilamentModal from './ChangeFilamentModal.svelte';
+	import OpenSpoolQrModal from './OpenSpoolQrModal.svelte';
 	import OverrideMark from './OverrideMark.svelte';
 	import type { Filament, Spool } from '$lib/types';
 	import { inventory } from '$lib/stores/inventory.svelte';
@@ -279,6 +281,7 @@
 	// full weight with it, so it gets a dialog that says what will happen instead
 	// of a debounced autosave (#1010).
 	let changeFilamentOpen = $state(false);
+	let openSpoolQrOpen = $state(false);
 
 	let confirmLines = $derived(
 		spool.remaining > 0
@@ -351,6 +354,9 @@
 				title={m['printing.qrcode.button']()}
 				><Printer size={15} /> <span class="btn-label">{m['printing.qrcode.button']()}</span></Button
 			>
+			<Button variant="outline" onclick={() => (openSpoolQrOpen = true)} title="OpenSpool QR"
+				><QrCode size={15} /> <span class="btn-label">OpenSpool QR</span></Button
+			>
 			<Button
 				variant="outline"
 				onclick={toggleArchived}
@@ -387,6 +393,14 @@
 		{spool}
 		current={filament}
 		onclose={() => (changeFilamentOpen = false)}
+	/>
+
+	<OpenSpoolQrModal
+		open={openSpoolQrOpen}
+		{spool}
+		{filament}
+		{vendor}
+		onclose={() => (openSpoolQrOpen = false)}
 	/>
 
 	<div class="gauge">

--- a/client_v2/src/lib/openspool/qr.test.ts
+++ b/client_v2/src/lib/openspool/qr.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import type { Filament, Spool, Vendor } from '$lib/types';
+import { buildOpenSpoolProfile, encodeOpenSpoolQr } from './qr';
+
+const spool: Spool = {
+	id: 9,
+	filamentId: '9',
+	unused: false,
+	remaining: 657.6884,
+	initial: 1000,
+	usedWeight: 342.3116,
+	location: 'Conjure',
+	lot: '',
+	firstUsedLabel: '',
+	lastUsedLabel: '',
+	registeredLabel: '',
+	archived: false,
+	comment: '',
+	tags: [],
+	extra: {}
+};
+
+const filament: Filament = {
+	id: '9',
+	vendorId: '3',
+	name: 'Silk PLA (Red Blue Green)',
+	material: 'PLA',
+	colors: ['#ff0000', '#0000ff', '#00ff00'],
+	diameter: 1.75,
+	density: 1.24,
+	nozzleTemp: 230,
+	bedTemp: 60,
+	weight: 1000,
+	price: 0,
+	comment: '',
+	registeredLabel: '',
+	extra: { variant: '"Silk"' }
+};
+
+const vendor: Vendor = {
+	id: '3',
+	name: 'Conjure',
+	emptyWeight: 0,
+	comment: '',
+	registeredLabel: '',
+	extra: {}
+};
+
+describe('OpenSpool QR', () => {
+	it('maps only values available in Spoolman and does not invent minimum temperatures', () => {
+		const profile = buildOpenSpoolProfile({ spool, filament, vendor });
+		expect(profile).toEqual({
+			schema_version: '1',
+			brand: 'Conjure',
+			name: 'Silk PLA (Red Blue Green)',
+			type: 'PLA',
+			subtype: 'Silk',
+			color_hex: '#FF0000',
+			additional_color_hexes: ['#0000FF', '#00FF00'],
+			diameter_mm: 1.75,
+			nozzle_temp_max_c: 230,
+			bed_temp_max_c: 60,
+			weight_g: 1000
+		});
+		expect(profile.nozzle_temp_min_c).toBeUndefined();
+		expect(profile.bed_temp_min_c).toBeUndefined();
+	});
+
+	it('builds a profile directly from a filament when there is no spool yet', () => {
+		const profile = buildOpenSpoolProfile({ filament, vendor });
+		expect(profile.weight_g).toBe(1000);
+		expect(profile.brand).toBe('Conjure');
+		expect(profile.name).toBe('Silk PLA (Red Blue Green)');
+	});
+
+	it('uses a verified profile stored in the filament extra field', () => {
+		const verified = {
+			schema_version: '1',
+			brand: 'Conjure',
+			name: 'Silk PLA (Red Blue Green)',
+			type: 'PLA',
+			subtype: 'Silk',
+			color_name: 'Red Blue Green',
+			color_hex: '#FF0000',
+			additional_color_hexes: ['#0000FF', '#00FF00'],
+			diameter_mm: 1.75,
+			nozzle_temp_min_c: 200,
+			nozzle_temp_max_c: 230,
+			bed_temp_min_c: 40,
+			bed_temp_max_c: 60,
+			weight_g: 1000,
+			source_url: 'https://example.com/profile'
+		};
+		const withOverride = {
+			...filament,
+			extra: { ...filament.extra, openspool_profile: JSON.stringify(JSON.stringify(verified)) }
+		};
+		expect(buildOpenSpoolProfile({ spool, filament: withOverride, vendor })).toEqual(verified);
+	});
+
+	it('encodes compact OpenSpool JSON ready for the NFC record', () => {
+		const profile = buildOpenSpoolProfile({ spool, filament, vendor });
+		const payload = encodeOpenSpoolQr(profile);
+		expect(payload).toBe(JSON.stringify(JSON.parse(payload)));
+		expect(JSON.parse(payload)).toEqual({
+			protocol: 'openspool',
+			version: '1.0',
+			brand: 'Conjure',
+			type: 'PLA',
+			subtype: 'Silk',
+			color_hex: '#FF0000',
+			additional_color_hexes: ['#0000FF', '#00FF00'],
+			max_temp: 230,
+			bed_max_temp: 60,
+			diameter: 1.75,
+			weight: 1000
+		});
+		expect(payload).not.toContain('schema_version');
+		expect(payload).not.toContain('name');
+	});
+
+	it('refuses to silently truncate unsupported colors', () => {
+		expect(() =>
+			buildOpenSpoolProfile({
+				spool,
+				vendor,
+				filament: {
+					...filament,
+					colors: ['#000001', '#000002', '#000003', '#000004', '#000005', '#000006']
+				}
+			})
+		).toThrow('at most four additional colors');
+	});
+});

--- a/client_v2/src/lib/openspool/qr.ts
+++ b/client_v2/src/lib/openspool/qr.ts
@@ -1,0 +1,206 @@
+import type { Filament, Spool, Vendor } from '$lib/types';
+
+export const OPEN_SPOOL_PROFILE_EXTRA_KEY = 'openspool_profile';
+
+const COLOR_PATTERN = /^#[0-9A-F]{6}$/;
+
+export interface OpenSpoolProfile {
+	schema_version: '1';
+	brand: string;
+	name: string;
+	type: string;
+	subtype?: string;
+	color_name?: string;
+	color_hex: string;
+	additional_color_hexes?: string[];
+	diameter_mm?: number;
+	nozzle_temp_min_c?: number;
+	nozzle_temp_max_c?: number;
+	bed_temp_min_c?: number;
+	bed_temp_max_c?: number;
+	weight_g?: number;
+	source_url?: string;
+}
+
+export interface OpenSpoolProfileContext {
+	spool?: Spool;
+	filament: Filament;
+	vendor?: Vendor;
+}
+
+export interface OpenSpoolPayload {
+	protocol: 'openspool';
+	version: '1.0';
+	brand: string;
+	type: string;
+	subtype?: string;
+	color_hex: string;
+	additional_color_hexes?: string[];
+	min_temp?: number;
+	max_temp?: number;
+	bed_min_temp?: number;
+	bed_max_temp?: number;
+	diameter?: number;
+	weight?: number;
+}
+
+function decodeExtraValue(value: string | undefined): unknown {
+	let decoded: unknown = value;
+	for (let attempt = 0; attempt < 2 && typeof decoded === 'string'; attempt += 1) {
+		try {
+			decoded = JSON.parse(decoded);
+		} catch {
+			break;
+		}
+	}
+	return decoded;
+}
+
+function extraText(extra: Record<string, string>, key: string): string | undefined {
+	const decoded = decodeExtraValue(extra[key]);
+	if (typeof decoded !== 'string') return undefined;
+	const text = decoded.trim();
+	return text || undefined;
+}
+
+function profileOverride(filament: Filament): Partial<OpenSpoolProfile> | undefined {
+	const decoded = decodeExtraValue(filament.extra[OPEN_SPOOL_PROFILE_EXTRA_KEY]);
+	if (decoded == null) return undefined;
+	if (typeof decoded !== 'object' || Array.isArray(decoded)) {
+		throw new Error(`${OPEN_SPOOL_PROFILE_EXTRA_KEY} must contain a JSON object`);
+	}
+	return decoded as Partial<OpenSpoolProfile>;
+}
+
+function color(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const hex = value.trim().replace(/^#/, '').toUpperCase();
+	return /^[0-9A-F]{6}$/.test(hex) ? `#${hex}` : undefined;
+}
+
+function text(value: unknown): string | undefined {
+	if (typeof value !== 'string') return undefined;
+	const trimmed = value.trim();
+	return trimmed || undefined;
+}
+
+function positiveNumber(value: unknown): number | undefined {
+	const number = typeof value === 'number' ? value : Number(value);
+	return Number.isFinite(number) && number > 0 ? number : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+	const number = positiveNumber(value);
+	return number == null ? undefined : Math.round(number);
+}
+
+function overrideColors(value: unknown): string[] | undefined {
+	if (value == null) return undefined;
+	if (!Array.isArray(value)) throw new Error('additional_color_hexes must be an array');
+	return value.map((entry) => color(entry) ?? String(entry));
+}
+
+/**
+ * Build the self-contained profile transported to the NFC writer.
+ *
+ * Spoolman only has one nozzle and bed temperature, so those map to maximums;
+ * missing minimums are deliberately omitted. Installations that need the full
+ * manufacturer profile can store it as JSON in the filament text extra field
+ * `openspool_profile`. Values in that object override the mapped fields.
+ */
+export function buildOpenSpoolProfile({
+	spool,
+	filament,
+	vendor
+}: OpenSpoolProfileContext): OpenSpoolProfile {
+	const override = profileOverride(filament);
+	const mappedColors = filament.colors.map(color).filter((entry): entry is string => entry != null);
+	const additionalOverride = overrideColors(override?.additional_color_hexes);
+
+	const profileWithEmptyValues: OpenSpoolProfile = {
+		schema_version: '1',
+		brand: text(override?.brand) ?? vendor?.name.trim() ?? '',
+		name: text(override?.name) ?? filament.name.trim(),
+		type: text(override?.type) ?? filament.material.trim(),
+		subtype: text(override?.subtype) ?? extraText(filament.extra, 'variant'),
+		color_name: text(override?.color_name),
+		color_hex: color(override?.color_hex) ?? mappedColors[0] ?? '',
+		additional_color_hexes:
+			additionalOverride ?? (mappedColors.length > 1 ? mappedColors.slice(1) : undefined),
+		diameter_mm: positiveNumber(override?.diameter_mm) ?? positiveNumber(filament.diameter),
+		nozzle_temp_min_c: positiveInteger(override?.nozzle_temp_min_c),
+		nozzle_temp_max_c: positiveInteger(override?.nozzle_temp_max_c) ?? positiveInteger(filament.nozzleTemp),
+		bed_temp_min_c: positiveInteger(override?.bed_temp_min_c),
+		bed_temp_max_c: positiveInteger(override?.bed_temp_max_c) ?? positiveInteger(filament.bedTemp),
+		weight_g:
+			positiveInteger(override?.weight_g) ??
+			positiveInteger(spool?.initial) ??
+			positiveInteger(filament.weight),
+		source_url: text(override?.source_url)
+	};
+
+	// Optional fields that Spoolman does not know must stay absent from the QR,
+	// instead of being serialized as nulls or made-up defaults.
+	const profile = Object.fromEntries(
+		Object.entries(profileWithEmptyValues).filter(([, value]) => value != null && value !== '')
+	) as unknown as OpenSpoolProfile;
+	validateOpenSpoolProfile(profile);
+	return profile;
+}
+
+export function validateOpenSpoolProfile(profile: OpenSpoolProfile): void {
+	if (!profile.brand) throw new Error('OpenSpool profile has no brand');
+	if (!profile.name) throw new Error('OpenSpool profile has no name');
+	if (!profile.type) throw new Error('OpenSpool profile has no material type');
+	if (!COLOR_PATTERN.test(profile.color_hex)) throw new Error('OpenSpool profile has no valid color');
+
+	const additional = profile.additional_color_hexes ?? [];
+	if (additional.length > 4) throw new Error('OpenSpool supports at most four additional colors');
+	if (additional.some((entry) => !COLOR_PATTERN.test(entry))) {
+		throw new Error('OpenSpool profile has an invalid additional color');
+	}
+
+	if (
+		profile.nozzle_temp_min_c != null &&
+		profile.nozzle_temp_max_c != null &&
+		profile.nozzle_temp_min_c > profile.nozzle_temp_max_c
+	) {
+		throw new Error('OpenSpool nozzle temperature range is invalid');
+	}
+	if (
+		profile.bed_temp_min_c != null &&
+		profile.bed_temp_max_c != null &&
+		profile.bed_temp_min_c > profile.bed_temp_max_c
+	) {
+		throw new Error('OpenSpool bed temperature range is invalid');
+	}
+}
+
+export function toOpenSpoolPayload(profile: OpenSpoolProfile): OpenSpoolPayload {
+	validateOpenSpoolProfile(profile);
+	const payloadWithEmptyValues: OpenSpoolPayload = {
+		protocol: 'openspool',
+		version: '1.0',
+		brand: profile.brand.trim(),
+		type: profile.type.trim().toUpperCase(),
+		subtype: profile.subtype?.trim() || undefined,
+		color_hex: profile.color_hex.toUpperCase(),
+		additional_color_hexes: profile.additional_color_hexes?.length
+			? profile.additional_color_hexes.map((entry) => entry.toUpperCase())
+			: undefined,
+		min_temp: profile.nozzle_temp_min_c,
+		max_temp: profile.nozzle_temp_max_c,
+		bed_min_temp: profile.bed_temp_min_c,
+		bed_max_temp: profile.bed_temp_max_c,
+		diameter: profile.diameter_mm,
+		weight: profile.weight_g
+	};
+
+	return Object.fromEntries(
+		Object.entries(payloadWithEmptyValues).filter(([, value]) => value != null && value !== '')
+	) as unknown as OpenSpoolPayload;
+}
+
+export function encodeOpenSpoolQr(profile: OpenSpoolProfile): string {
+	return JSON.stringify(toOpenSpoolPayload(profile));
+}


### PR DESCRIPTION
## Summary

- add an `OpenSpool QR` action next to label printing in both the spool and filament inspectors
- encode a self-contained compact OpenSpool 1.0 JSON payload directly in the QR, ready for an NFC `application/json` record
- show a stable QR in an accessible modal with close, backdrop, Escape, and OK controls
- derive only known Spoolman values and omit unavailable temperature minima instead of inventing defaults
- support an optional `openspool_profile` filament text extra field for verified full profiles

## Validation

- `npm test` (298 tests passed)
- `npm run check`
- `npm run lint`
- `npm run build`
- production container smoke test and Chromium interaction test

The QR writer uses the OpenSpool fields consumed by paxx/Snapmaker U1 (`protocol`, `version`, `type`, `color_hex`, temperatures, diameter, and weight) without a project-specific transport envelope.