### PR TITLE
fix(api): preserve extra field JSON types

### DIFF
--- a/spoolman/api/v1/models.py
+++ b/spoolman/api/v1/models.py
@@ -1,5 +1,6 @@
 """Pydantic data models for typing the FastAPI request/responses."""
 
+import json
 from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Annotated, Literal
@@ -154,7 +155,7 @@ class Vendor(BaseModel):
         ),
         examples=["eSun"],
     )
-    extra: dict[str, str] = Field(
+    extra: dict[str, object] = Field(
         description=_extra_fields_description("vendor"),
     )
 
@@ -168,7 +169,7 @@ class Vendor(BaseModel):
             comment=item.comment,
             empty_spool_weight=item.empty_spool_weight,
             external_id=item.external_id,
-            extra={field.key: field.value for field in item.extra},
+            extra={field.key: json.loads(field.value) for field in item.extra},
         )
 
 
@@ -270,7 +271,7 @@ class Filament(BaseModel):
         ),
         examples=["polymaker_pla_polysonicblack_1000_175"],
     )
-    extra: dict[str, str] = Field(
+    extra: dict[str, object] = Field(
         description=_extra_fields_description("filament"),
     )
 
@@ -298,7 +299,7 @@ class Filament(BaseModel):
                 MultiColorDirection(item.multi_color_direction) if item.multi_color_direction is not None else None
             ),
             external_id=item.external_id,
-            extra={field.key: field.value for field in item.extra},
+            extra={field.key: json.loads(field.value) for field in item.extra},
         )
 
 
@@ -405,7 +406,7 @@ class Spool(BaseModel):
         examples=[""],
     )
     archived: bool = Field(description="Whether this spool is archived and should not be used anymore.")
-    extra: dict[str, str] = Field(
+    extra: dict[str, object] = Field(
         description=_extra_fields_description("spool"),
     )
     tags: list[SpoolTag] = Field(
@@ -462,7 +463,7 @@ class Spool(BaseModel):
             lot_nr=item.lot_nr,
             comment=item.comment,
             archived=item.archived if item.archived is not None else False,
-            extra={field.key: field.value for field in item.extra},
+            extra={field.key: json.loads(field.value) for field in item.extra},
             tags=[SpoolTag.from_db(tag) for tag in item.tags],
         )
 

--- a/tests/test_api_models.py
+++ b/tests/test_api_models.py
@@ -1,0 +1,85 @@
+"""Regression tests for API response models."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from spoolman.api.v1.models import Filament, Spool, Vendor
+
+
+@pytest.fixture
+def extra() -> list[SimpleNamespace]:
+    return [
+        SimpleNamespace(key="smooth_time", value="0.035"),
+        SimpleNamespace(key="enabled", value="true"),
+        SimpleNamespace(key="label", value='"PLA"'),
+        SimpleNamespace(key="range", value="[1, null]"),
+    ]
+
+
+@pytest.fixture
+def vendor(extra: list[SimpleNamespace]) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        registered=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        name="Vendor",
+        comment=None,
+        empty_spool_weight=None,
+        external_id=None,
+        extra=extra,
+    )
+
+
+@pytest.fixture
+def filament(extra: list[SimpleNamespace], vendor: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=1,
+        registered=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        name="Filament",
+        vendor=vendor,
+        material=None,
+        price=None,
+        density=1.24,
+        diameter=1.75,
+        weight=None,
+        spool_weight=None,
+        article_number=None,
+        comment=None,
+        settings_extruder_temp=None,
+        settings_bed_temp=None,
+        color_hex=None,
+        multi_color_hexes=None,
+        multi_color_direction=None,
+        external_id=None,
+        extra=extra,
+    )
+
+
+def test_response_models_decode_extra_values(
+    filament: SimpleNamespace,
+    extra: list[SimpleNamespace],
+    vendor: SimpleNamespace,
+):
+    spool = SimpleNamespace(
+        id=1,
+        registered=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        first_used=None,
+        last_used=None,
+        filament=filament,
+        price=None,
+        initial_weight=None,
+        spool_weight=None,
+        used_weight=0,
+        location=None,
+        lot_nr=None,
+        comment=None,
+        archived=False,
+        extra=extra,
+        tags=[],
+    )
+    expected = {"smooth_time": 0.035, "enabled": True, "label": "PLA", "range": [1, None]}
+
+    assert Vendor.from_db(vendor).extra == expected
+    assert Filament.from_db(filament).extra == expected
+    assert Spool.from_db(spool).extra == expected

--- a/tests_integration/tests/fields/test_clear_value.py
+++ b/tests_integration/tests/fields/test_clear_value.py
@@ -98,8 +98,8 @@ async def test_patch_merges_per_key(entity_type: str, random_filament: dict[str,
         )
         assert_httpx_success(result)
         assert result.json()["extra"] == {
-            patched_key: json.dumps("after"),
-            untouched_key: json.dumps("untouched"),
+            patched_key: "after",
+            untouched_key: "untouched",
         }
     finally:
         for key in (patched_key, untouched_key):

--- a/tests_integration/tests/fields/test_clear_value.py
+++ b/tests_integration/tests/fields/test_clear_value.py
@@ -130,7 +130,7 @@ async def test_clear_leaves_other_values_alone(entity_type: str, random_filament
             json={"extra": {cleared_key: None, kept_key: json.dumps("stays")}},
         )
         assert_httpx_success(result)
-        assert result.json()["extra"] == {kept_key: json.dumps("stays")}
+        assert result.json()["extra"] == {kept_key: "stays"}
     finally:
         for key in (cleared_key, kept_key):
             httpx.delete(f"{URL}/api/v1/field/{entity_type}/{key}").raise_for_status()

--- a/tests_integration/tests/fields/test_utilize.py
+++ b/tests_integration/tests/fields/test_utilize.py
@@ -35,7 +35,7 @@ def test_add_vendor_with_extra_field():
     assert_httpx_success(result)
     vendor = result.json()
     assert vendor["name"] == "My Vendor"
-    assert vendor["extra"] == {"mytextfield": '"My Value"'}
+    assert vendor["extra"] == {"mytextfield": "My Value"}
 
     # Clean up
     result = httpx.delete(f"{URL}/api/v1/field/vendor/mytextfield")
@@ -90,7 +90,7 @@ def test_add_vendor_with_extra_field_then_delete():
     assert_httpx_success(result)
     vendor = result.json()
     assert vendor["name"] == "My Vendor"
-    assert vendor["extra"] == {"mytextfield": '"My Value"'}
+    assert vendor["extra"] == {"mytextfield": "My Value"}
 
     # Remove field
     result = httpx.delete(f"{URL}/api/v1/field/vendor/mytextfield")
@@ -143,7 +143,7 @@ def test_update_existing_vendor_with_new_extra_field():
     assert_httpx_success(result)
     vendor = result.json()
     assert vendor["name"] == "My Vendor"
-    assert vendor["extra"] == {"mytextfield": '"My Value"'}
+    assert vendor["extra"] == {"mytextfield": "My Value"}
 
     # Clean up
     result = httpx.delete(f"{URL}/api/v1/field/vendor/mytextfield")

--- a/tests_integration/tests/spool/test_rename_field_value.py
+++ b/tests_integration/tests/spool/test_rename_field_value.py
@@ -82,9 +82,9 @@ def test_rename_extra_field_value(shelf_spools: Fixture):
 
     for spool_id in shelf_spools.spools["Bottom"]:
         # The stored value is JSON-encoded, and readable back as the plain new value.
-        assert _spool(spool_id)["extra"][shelf_spools.field_key] == json.dumps("Lower")
+        assert _spool(spool_id)["extra"][shelf_spools.field_key] == "Lower"
     # The other group is untouched.
-    assert _spool(shelf_spools.spools["Top"][0])["extra"][shelf_spools.field_key] == json.dumps("Top")
+    assert _spool(shelf_spools.spools["Top"][0])["extra"][shelf_spools.field_key] == "Top"
 
 
 def test_renamed_extra_field_value_is_visible_to_grouping(shelf_spools: Fixture):
@@ -124,7 +124,7 @@ def test_rename_value_merges_into_existing(shelf_spools: Fixture):
     assert result.json() == {"spools_updated": 2}
 
     for spool_id in shelf_spools.all_ids:
-        assert _spool(spool_id)["extra"][shelf_spools.field_key] == json.dumps("Top")
+        assert _spool(spool_id)["extra"][shelf_spools.field_key] == "Top"
 
 
 def test_rename_absent_value_is_a_no_op(shelf_spools: Fixture):


### PR DESCRIPTION
## Description

I changed the API response models to decode stored `extra` JSON values before serializing vendor, filament, and spool responses. Numeric, boolean, string, and range values now retain their JSON types.

Fixes #1146

## Why

Extra-field rows store JSON text. Passing that text straight into the response models made values such as `0.035` and `true` appear as JSON strings.

## Verification

- Before on current `main`, the model response emitted `{"smooth_time":"0.035","enabled":"true"}`.
- After, creating and fetching a vendor with those extra values returned `{"smooth_time":0.035,"enabled":true}`.
- `uv run pytest tests/test_api_models.py tests/test_color_hex_validation.py`
